### PR TITLE
feat: implement user account CRUD operations (#16)

### DIFF
--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -1,8 +1,9 @@
 const User = require('../models/User');
 const RefreshToken = require('../models/RefreshToken');
 const StudentIdRegistry = require('../models/StudentIdRegistry');
-const { hashPassword, comparePassword } = require('../utils/password');
+const { hashPassword, comparePassword, validatePasswordStrength } = require('../utils/password');
 const { generateTokenPair, verifyRefreshToken } = require('../utils/jwt');
+const { createAuditLog } = require('../services/auditService');
 const axios = require('axios');
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
@@ -119,6 +120,16 @@ const registerStudent = async (req, res) => {
       });
     }
 
+    // Validate password strength
+    const { isValid, errors: passwordErrors } = validatePasswordStrength(password);
+    if (!isValid) {
+      return res.status(400).json({
+        code: 'WEAK_PASSWORD',
+        message: 'Password does not meet requirements',
+        details: passwordErrors,
+      });
+    }
+
     // Verify and decode validation token
     let tokenPayload;
     try {
@@ -183,6 +194,19 @@ const registerStudent = async (req, res) => {
     });
 
     await user.save();
+
+    // Best-effort audit log: failure here must not fail the registration response
+    try {
+      await createAuditLog({
+        action: 'ACCOUNT_CREATED',
+        actorId: user.userId,
+        targetId: user.userId,
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed for ACCOUNT_CREATED (non-fatal):', auditError.message);
+    }
 
     // Generate tokens
     const tokens = generateTokenPair(user.userId, user.role);

--- a/backend/src/controllers/onboarding.js
+++ b/backend/src/controllers/onboarding.js
@@ -5,6 +5,7 @@ const User = require('../models/User');
 const { parseCSV } = require('../utils/csvParser');
 const { validateBatch } = require('../utils/studentIdValidator');
 const { sendVerificationEmail, sendAccountReadyEmail } = require('../services/emailService');
+const { createAuditLog } = require('../services/auditService');
 
 /**
  * Upload and process student ID CSV file
@@ -329,15 +330,19 @@ const completeOnboarding = async (req, res) => {
 };
 
 /**
- * Get user account record from D1
+ * Get user account record
  * GET /onboarding/accounts/:userId
+ * Access: owner or admin
  */
 const getAccount = async (req, res) => {
   try {
     const { userId } = req.params;
     const requestingUser = req.user;
 
-    if (requestingUser.userId !== userId && requestingUser.role !== 'admin') {
+    const isOwner = requestingUser.userId === userId;
+    const isAdmin = requestingUser.role === 'admin';
+
+    if (!isOwner && !isAdmin) {
       return res.status(403).json({ code: 'FORBIDDEN', message: 'Access denied' });
     }
 
@@ -345,6 +350,15 @@ const getAccount = async (req, res) => {
     if (!user) {
       return res.status(404).json({ code: 'NOT_FOUND', message: 'User not found' });
     }
+
+    // Audit: account record accessed
+    await createAuditLog({
+      action: 'ACCOUNT_RETRIEVED',
+      actorId: requestingUser.userId,
+      targetId: userId,
+      ipAddress: req.ip,
+      userAgent: req.headers['user-agent'],
+    });
 
     return res.status(200).json({
       userId: user.userId,
@@ -364,17 +378,50 @@ const getAccount = async (req, res) => {
 /**
  * Update user account record
  * PATCH /onboarding/accounts/:userId
+ *
+ * Access / field rules:
+ *   - Owner (self):  may update githubUsername only
+ *   - Admin:         may update githubUsername, emailVerified, accountStatus
+ *   - Neither role can update `role` through this endpoint
  */
 const updateAccount = async (req, res) => {
   try {
     const { userId } = req.params;
     const requestingUser = req.user;
 
-    if (requestingUser.userId !== userId && requestingUser.role !== 'admin') {
+    const isOwner = requestingUser.userId === userId;
+    const isAdmin = requestingUser.role === 'admin';
+
+    if (!isOwner && !isAdmin) {
       return res.status(403).json({ code: 'FORBIDDEN', message: 'Access denied' });
     }
 
-    const allowedFields = ['githubUsername', 'emailVerified', 'accountStatus'];
+    // Block role updates for everyone through this endpoint
+    if (req.body.role !== undefined) {
+      return res.status(403).json({
+        code: 'FORBIDDEN',
+        message: 'Role cannot be updated through this endpoint',
+      });
+    }
+
+    // Determine permitted fields by requester's privilege level
+    const allowedFields = isAdmin
+      ? ['githubUsername', 'emailVerified', 'accountStatus']
+      : ['githubUsername'];
+
+    // Non-admin trying to touch a privileged field
+    if (!isAdmin) {
+      const privilegedFields = ['emailVerified', 'accountStatus'];
+      for (const field of privilegedFields) {
+        if (req.body[field] !== undefined) {
+          return res.status(403).json({
+            code: 'FORBIDDEN',
+            message: `Only admins may update '${field}'`,
+          });
+        }
+      }
+    }
+
     const updates = {};
     for (const field of allowedFields) {
       if (req.body[field] !== undefined) {
@@ -382,9 +429,38 @@ const updateAccount = async (req, res) => {
       }
     }
 
-    const user = await User.findOneAndUpdate({ userId }, updates, { new: true });
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ code: 'NO_CHANGES', message: 'No valid fields to update' });
+    }
+
+    const user = await User.findOne({ userId });
     if (!user) {
       return res.status(404).json({ code: 'NOT_FOUND', message: 'User not found' });
+    }
+
+    // Capture previous values before applying changes
+    const previousValues = {};
+    const newValues = {};
+    for (const field of Object.keys(updates)) {
+      previousValues[field] = user[field];
+      newValues[field] = updates[field];
+      user[field] = updates[field];
+    }
+
+    await user.save();
+
+    // Best-effort audit log: failure here must not fail the update response
+    try {
+      await createAuditLog({
+        action: 'ACCOUNT_UPDATED',
+        actorId: requestingUser.userId,
+        targetId: userId,
+        changes: { previous: previousValues, updated: newValues },
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed for ACCOUNT_UPDATED (non-fatal):', auditError.message);
     }
 
     return res.status(200).json({

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -1,0 +1,47 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const auditLogSchema = new mongoose.Schema(
+  {
+    auditId: {
+      type: String,
+      default: () => `aud_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+    },
+    action: {
+      type: String,
+      required: true,
+      enum: ['ACCOUNT_CREATED', 'ACCOUNT_RETRIEVED', 'ACCOUNT_UPDATED'],
+    },
+    actorId: {
+      type: String,
+      required: true,
+    },
+    targetId: {
+      type: String,
+      required: true,
+    },
+    // Captured for ACCOUNT_UPDATED: { previous: {}, updated: {} }
+    changes: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
+    },
+    ipAddress: {
+      type: String,
+      default: null,
+    },
+    userAgent: {
+      type: String,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+auditLogSchema.index({ targetId: 1, createdAt: -1 });
+auditLogSchema.index({ actorId: 1, createdAt: -1 });
+
+const AuditLog = mongoose.model('AuditLog', auditLogSchema);
+
+module.exports = AuditLog;

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -1,0 +1,24 @@
+const AuditLog = require('../models/AuditLog');
+
+/**
+ * Record an audit event.
+ *
+ * @param {object} params
+ * @param {string} params.action      - One of ACCOUNT_CREATED | ACCOUNT_RETRIEVED | ACCOUNT_UPDATED
+ * @param {string} params.actorId     - userId of the requester performing the action
+ * @param {string} params.targetId    - userId of the account being acted upon
+ * @param {object} [params.changes]   - For ACCOUNT_UPDATED: { previous, updated }
+ * @param {string} [params.ipAddress]
+ * @param {string} [params.userAgent]
+ * @param {object} [session]          - Mongoose session for transactional writes
+ */
+const createAuditLog = async (
+  { action, actorId, targetId, changes = null, ipAddress = null, userAgent = null },
+  session = null
+) => {
+  const log = new AuditLog({ action, actorId, targetId, changes, ipAddress, userAgent });
+  await log.save(session ? { session } : undefined);
+  return log;
+};
+
+module.exports = { createAuditLog };

--- a/backend/src/utils/password.js
+++ b/backend/src/utils/password.js
@@ -1,6 +1,6 @@
 const bcrypt = require('bcryptjs');
 
-const SALT_ROUNDS = 10;
+const SALT_ROUNDS = 12;
 
 /**
  * Hash password using bcryptjs


### PR DESCRIPTION
- Add POST /auth/register with password strength validation and bcrypt cost 12
- Add GET /onboarding/accounts/:userId with owner/admin access control
- Add PATCH /onboarding/accounts/:userId with role-based field restrictions
- Block role updates via PATCH for all users
- Add AuditLog model and audit service (ACCOUNT_CREATED, ACCOUNT_RETRIEVED, ACCOUNT_UPDATED)
- Use best-effort audit logging to maintain local MongoDB compatibility