### PR TITLE
feat: implement password reset & management endpoints (#18)

### DIFF
--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -4,6 +4,7 @@ const StudentIdRegistry = require('../models/StudentIdRegistry');
 const { hashPassword, comparePassword, validatePasswordStrength } = require('../utils/password');
 const { generateTokenPair, verifyRefreshToken } = require('../utils/jwt');
 const { createAuditLog } = require('../services/auditService');
+const { sendPasswordResetEmail } = require('../services/emailService');
 const axios = require('axios');
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
@@ -519,6 +520,223 @@ const changePassword = async (req, res) => {
   }
 };
 
+/**
+ * Request a password reset link (non-revealing: always returns 200)
+ * Rate limited to 5 requests per hour per account
+ */
+const requestPasswordReset = async (req, res) => {
+  try {
+    const { email } = req.body;
+
+    if (!email) {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'Email is required',
+      });
+    }
+
+    const user = await User.findOne({ email: email.toLowerCase() });
+
+    if (user) {
+      const now = new Date();
+      const oneHourAgo = new Date(now - 60 * 60 * 1000);
+
+      // Rate limiting: max 5 requests per hour
+      if (user.passwordResetWindowStart && user.passwordResetWindowStart > oneHourAgo) {
+        if (user.passwordResetSentCount >= 5) {
+          // Non-revealing: still return 200, just don't send email
+          return res.status(200).json({
+            message: 'If an account with that email exists, a password reset link has been sent.',
+          });
+        }
+        user.passwordResetSentCount += 1;
+      } else {
+        user.passwordResetWindowStart = now;
+        user.passwordResetSentCount = 1;
+      }
+
+      // Generate plain token, store SHA-256 hash
+      const plainToken = crypto.randomBytes(32).toString('hex');
+      const hashedToken = crypto.createHash('sha256').update(plainToken).digest('hex');
+
+      user.passwordResetToken = hashedToken;
+      user.passwordResetTokenExpiry = new Date(now.getTime() + 15 * 60 * 1000); // 15 minutes
+      await user.save();
+
+      try {
+        await sendPasswordResetEmail(user.email, plainToken);
+      } catch (emailError) {
+        console.error('Password reset email failed (non-fatal):', emailError.message);
+      }
+
+      try {
+        await createAuditLog({
+          action: 'PASSWORD_RESET_REQUESTED',
+          actorId: user.userId,
+          targetId: user.userId,
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('Audit log failed for PASSWORD_RESET_REQUESTED (non-fatal):', auditError.message);
+      }
+    }
+
+    return res.status(200).json({
+      message: 'If an account with that email exists, a password reset link has been sent.',
+    });
+  } catch (error) {
+    console.error('Password reset request error:', error);
+    res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'Password reset request failed',
+    });
+  }
+};
+
+/**
+ * Confirm password reset using token from email
+ */
+const confirmPasswordReset = async (req, res) => {
+  try {
+    const { token, newPassword } = req.body;
+
+    if (!token || !newPassword) {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'Token and newPassword are required',
+      });
+    }
+
+    const hashedToken = crypto.createHash('sha256').update(token).digest('hex');
+
+    const user = await User.findOne({
+      passwordResetToken: hashedToken,
+      passwordResetTokenExpiry: { $gt: new Date() },
+    });
+
+    if (!user) {
+      return res.status(400).json({
+        code: 'INVALID_TOKEN',
+        message: 'Password reset token is invalid or has expired',
+      });
+    }
+
+    const { isValid, errors: passwordErrors } = validatePasswordStrength(newPassword);
+    if (!isValid) {
+      return res.status(400).json({
+        code: 'WEAK_PASSWORD',
+        message: 'New password does not meet requirements',
+        details: passwordErrors,
+      });
+    }
+
+    // Update password and invalidate token (single-use enforcement)
+    user.hashedPassword = await hashPassword(newPassword);
+    user.passwordResetToken = null;
+    user.passwordResetTokenExpiry = null;
+    user.passwordResetSentCount = 0;
+    user.passwordResetWindowStart = null;
+    await user.save();
+
+    // Revoke all refresh tokens (log out all sessions)
+    await RefreshToken.updateMany({ userId: user.userId }, { isRevoked: true });
+
+    try {
+      await createAuditLog({
+        action: 'PASSWORD_RESET_CONFIRMED',
+        actorId: user.userId,
+        targetId: user.userId,
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed for PASSWORD_RESET_CONFIRMED (non-fatal):', auditError.message);
+    }
+
+    return res.status(200).json({
+      message: 'Password has been reset successfully. All sessions have been invalidated.',
+    });
+  } catch (error) {
+    console.error('Password reset confirm error:', error);
+    res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'Password reset failed',
+    });
+  }
+};
+
+/**
+ * Admin-initiated password reset for any user
+ * Requires admin role
+ */
+const adminInitiatePasswordReset = async (req, res) => {
+  try {
+    const { userId: targetUserId, email: targetEmail } = req.body;
+    const { userId: actorId } = req.user;
+
+    if (!targetUserId && !targetEmail) {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'Either userId or email is required',
+      });
+    }
+
+    const query = targetUserId
+      ? { userId: targetUserId }
+      : { email: targetEmail.toLowerCase() };
+
+    const user = await User.findOne(query);
+
+    if (!user) {
+      return res.status(404).json({
+        code: 'USER_NOT_FOUND',
+        message: 'User not found',
+      });
+    }
+
+    const plainToken = crypto.randomBytes(32).toString('hex');
+    const hashedToken = crypto.createHash('sha256').update(plainToken).digest('hex');
+
+    user.passwordResetToken = hashedToken;
+    user.passwordResetTokenExpiry = new Date(Date.now() + 15 * 60 * 1000); // 15 minutes
+    // Admin override clears the rate limit window
+    user.passwordResetSentCount = 0;
+    user.passwordResetWindowStart = null;
+    await user.save();
+
+    try {
+      await sendPasswordResetEmail(user.email, plainToken);
+    } catch (emailError) {
+      console.error('Password reset email failed (non-fatal):', emailError.message);
+    }
+
+    try {
+      await createAuditLog({
+        action: 'PASSWORD_RESET_ADMIN_INITIATED',
+        actorId,
+        targetId: user.userId,
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed for PASSWORD_RESET_ADMIN_INITIATED (non-fatal):', auditError.message);
+    }
+
+    return res.status(200).json({
+      message: 'Password reset initiated. The user will receive an email with reset instructions.',
+      userId: user.userId,
+      email: user.email,
+    });
+  } catch (error) {
+    console.error('Admin password reset error:', error);
+    res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'Admin password reset failed',
+    });
+  }
+};
+
 module.exports = {
   loginWithPassword,
   registerStudent,
@@ -527,4 +745,7 @@ module.exports = {
   changePassword,
   initiateGithubOAuth,
   githubOAuthCallback,
+  requestPasswordReset,
+  confirmPasswordReset,
+  adminInitiatePasswordReset,
 };

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -12,7 +12,14 @@ const auditLogSchema = new mongoose.Schema(
     action: {
       type: String,
       required: true,
-      enum: ['ACCOUNT_CREATED', 'ACCOUNT_RETRIEVED', 'ACCOUNT_UPDATED'],
+      enum: [
+        'ACCOUNT_CREATED',
+        'ACCOUNT_RETRIEVED',
+        'ACCOUNT_UPDATED',
+        'PASSWORD_RESET_REQUESTED',
+        'PASSWORD_RESET_CONFIRMED',
+        'PASSWORD_RESET_ADMIN_INITIATED',
+      ],
     },
     actorId: {
       type: String,

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -90,6 +90,14 @@ const userSchema = new mongoose.Schema(
       type: Date,
       default: null,
     },
+    passwordResetSentCount: {
+      type: Number,
+      default: 0,
+    },
+    passwordResetWindowStart: {
+      type: Date,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -9,6 +9,9 @@ const {
   changePassword,
   initiateGithubOAuth,
   githubOAuthCallback,
+  requestPasswordReset,
+  confirmPasswordReset,
+  adminInitiatePasswordReset,
 } = require('../controllers/auth');
 
 // Public routes
@@ -16,10 +19,13 @@ router.post('/login', loginWithPassword);
 router.post('/register', registerStudent);
 router.post('/refresh', refreshAccessToken);
 router.get('/github/oauth/callback', githubOAuthCallback);
+router.post('/password-reset/request', requestPasswordReset);
+router.post('/password-reset/confirm', confirmPasswordReset);
 
 // Protected routes
 router.post('/logout', authMiddleware, logout);
 router.post('/change-password', authMiddleware, changePassword);
 router.post('/github/oauth/initiate', authMiddleware, initiateGithubOAuth);
+router.post('/password-reset/admin-initiate', authMiddleware, roleMiddleware(['admin']), adminInitiatePasswordReset);
 
 module.exports = router;

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -115,4 +115,38 @@ const sendAccountReadyEmail = async (email, role) => {
   }
 };
 
-module.exports = { sendVerificationEmail, sendAccountReadyEmail };
+/**
+ * Send password reset link to user.
+ * In dev mode: logs the token to the console.
+ */
+const sendPasswordResetEmail = async (email, token) => {
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const resetUrl = `${frontendUrl}/reset-password?token=${token}`;
+
+  console.log('\n[EMAIL] ── Password Reset Email ─────────────────');
+  console.log(`[EMAIL] To:    ${email}`);
+  console.log(`[EMAIL] Token: ${token}`);
+  console.log(`[EMAIL] URL:   ${resetUrl}`);
+  console.log('[EMAIL] ────────────────────────────────────────\n');
+
+  const transporter = getTransporter();
+  if (!transporter) {
+    return { messageId: 'dev-mode', recipient: email, status: 'sent' };
+  }
+
+  try {
+    const info = await transporter.sendMail({
+      from: process.env.EMAIL_USER,
+      to: email,
+      subject: 'Reset your password',
+      text: `Reset your password: ${resetUrl}\n\nThis link expires in 15 minutes. If you did not request this, ignore this email.`,
+      html: `<p>Click to reset your password: <a href="${resetUrl}">Reset Password</a></p><p>This link expires in <strong>15 minutes</strong>. If you did not request a password reset, please ignore this email.</p>`,
+    });
+    return { messageId: info.messageId, recipient: email, status: 'sent' };
+  } catch (err) {
+    console.error('[EMAIL] Send failed:', err.message);
+    return { messageId: null, recipient: email, status: 'failed' };
+  }
+};
+
+module.exports = { sendVerificationEmail, sendAccountReadyEmail, sendPasswordResetEmail };

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -121,7 +121,7 @@ const sendAccountReadyEmail = async (email, role) => {
  */
 const sendPasswordResetEmail = async (email, token) => {
   const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
-  const resetUrl = `${frontendUrl}/reset-password?token=${token}`;
+  const resetUrl = `${frontendUrl}/auth/reset-password?token=${token}`;
 
   console.log('\n[EMAIL] ── Password Reset Email ─────────────────');
   console.log(`[EMAIL] To:    ${email}`);

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -1,4 +1,393 @@
 /**
+ * Password Reset & Management Endpoint Tests
+ *
+ * Covers:
+ *  - POST /auth/password-reset/request (non-revealing, rate limiting)
+ *  - POST /auth/password-reset/confirm (token validation, single-use, password strength)
+ *  - POST /auth/password-reset/admin-initiate (admin-only, user lookup)
+ *  - Token generation: SHA-256 hashed storage, 15-min expiry
+ *  - All refresh tokens revoked after successful reset
+ *  - Audit logging for all reset events
+ *
+ * Run: npm test
+ */
+
+const crypto = require('crypto');
+
+describe('Password Reset Flow (integration)', () => {
+  const mongoUri = process.env.MONGODB_TEST_URI || 'mongodb://localhost:27017/senior-app-test-auth';
+  const mongoose = require('mongoose');
+
+  let User;
+  let RefreshToken;
+  let AuditLog;
+  let hashPassword;
+  let generateRefreshToken;
+  let requestPasswordReset;
+  let confirmPasswordReset;
+  let adminInitiatePasswordReset;
+
+  const hashToken = (plain) => crypto.createHash('sha256').update(plain).digest('hex');
+
+  const makeReq = (body = {}, user = null, headers = {}) => ({
+    body,
+    user,
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent', ...headers },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+    // Load all modules after connection is established so they share the same mongoose instance
+    User = require('../src/models/User');
+    RefreshToken = require('../src/models/RefreshToken');
+    AuditLog = require('../src/models/AuditLog');
+    ({ hashPassword } = require('../src/utils/password'));
+    ({ generateRefreshToken } = require('../src/utils/jwt'));
+    ({ requestPasswordReset, confirmPasswordReset, adminInitiatePasswordReset } = require('../src/controllers/auth'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await User.deleteMany({});
+    await RefreshToken.deleteMany({});
+    await AuditLog.deleteMany({});
+  });
+
+  // ─── requestPasswordReset ──────────────────────────────────────────────────
+
+  describe('requestPasswordReset', () => {
+    it('returns 200 with generic message for unknown email (non-revealing)', async () => {
+      const req = makeReq({ email: 'nobody@example.com' });
+      const res = makeRes();
+      await requestPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('If an account') })
+      );
+    });
+
+    it('returns 200 with generic message for known email', async () => {
+      await new User({
+        email: 'known@example.com',
+        hashedPassword: await hashPassword('T3st_Secure#99'),
+        role: 'student',
+        accountStatus: 'active',
+      }).save();
+
+      const req = makeReq({ email: 'known@example.com' });
+      const res = makeRes();
+      await requestPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('stores hashed reset token and 15-min expiry for existing user', async () => {
+      await new User({
+        email: 'tokentest@example.com',
+        hashedPassword: await hashPassword('T3st_Secure#99'),
+        role: 'student',
+        accountStatus: 'active',
+      }).save();
+
+      const req = makeReq({ email: 'tokentest@example.com' });
+      const res = makeRes();
+      await requestPasswordReset(req, res);
+
+      const user = await User.findOne({ email: 'tokentest@example.com' });
+      expect(user.passwordResetToken).toBeTruthy();
+      expect(user.passwordResetTokenExpiry).toBeTruthy();
+
+      const msUntilExpiry = user.passwordResetTokenExpiry - new Date();
+      expect(msUntilExpiry).toBeGreaterThan(14 * 60 * 1000); // > 14 min
+      expect(msUntilExpiry).toBeLessThanOrEqual(15 * 60 * 1000); // ≤ 15 min
+    });
+
+    it('returns 400 when email is missing', async () => {
+      const req = makeReq({});
+      const res = makeRes();
+      await requestPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('enforces rate limit: silently suppresses after 5 requests per hour', async () => {
+      await new User({
+        email: 'ratelimit@example.com',
+        hashedPassword: await hashPassword('T3st_Secure#99'),
+        role: 'student',
+        accountStatus: 'active',
+      }).save();
+
+      // Send 5 requests (all succeed)
+      for (let i = 0; i < 5; i++) {
+        const req = makeReq({ email: 'ratelimit@example.com' });
+        const res = makeRes();
+        await requestPasswordReset(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+      }
+
+      // 6th request still returns 200 (non-revealing) but token is unchanged (rate limited)
+      const tokenBefore = (await User.findOne({ email: 'ratelimit@example.com' })).passwordResetToken;
+      const req = makeReq({ email: 'ratelimit@example.com' });
+      const res = makeRes();
+      await requestPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      const tokenAfter = (await User.findOne({ email: 'ratelimit@example.com' })).passwordResetToken;
+      expect(tokenAfter).toBe(tokenBefore); // token unchanged — rate limited
+    });
+
+    it('creates PASSWORD_RESET_REQUESTED audit log for existing user', async () => {
+      await new User({
+        email: 'auditreq@example.com',
+        hashedPassword: await hashPassword('T3st_Secure#99'),
+        role: 'student',
+        accountStatus: 'active',
+      }).save();
+
+      const req = makeReq({ email: 'auditreq@example.com' });
+      const res = makeRes();
+      await requestPasswordReset(req, res);
+
+      const log = await AuditLog.findOne({ action: 'PASSWORD_RESET_REQUESTED' });
+      expect(log).toBeTruthy();
+    });
+  });
+
+  // ─── confirmPasswordReset ──────────────────────────────────────────────────
+
+  describe('confirmPasswordReset', () => {
+    const setupUserWithToken = async (overrides = {}) => {
+      const plainToken = crypto.randomBytes(32).toString('hex');
+      const hashedToken = hashToken(plainToken);
+      const user = await new User({
+        email: 'reset@example.com',
+        hashedPassword: await hashPassword('T3st_Secure#99'),
+        role: 'student',
+        accountStatus: 'active',
+        passwordResetToken: hashedToken,
+        passwordResetTokenExpiry: new Date(Date.now() + 15 * 60 * 1000),
+        ...overrides,
+      }).save();
+      return { user, plainToken };
+    };
+
+    it('returns 400 when token and newPassword are missing', async () => {
+      const req = makeReq({});
+      const res = makeRes();
+      await confirmPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 400 for invalid token', async () => {
+      const req = makeReq({ token: 'invalidtoken', newPassword: 'NewSecure@123' });
+      const res = makeRes();
+      await confirmPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_TOKEN' }));
+    });
+
+    it('returns 400 for expired token', async () => {
+      const { plainToken } = await setupUserWithToken({
+        passwordResetTokenExpiry: new Date(Date.now() - 1000), // already expired
+      });
+      const req = makeReq({ token: plainToken, newPassword: 'NewSecure@123' });
+      const res = makeRes();
+      await confirmPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_TOKEN' }));
+    });
+
+    it('returns 400 for weak new password', async () => {
+      const { plainToken } = await setupUserWithToken();
+      const req = makeReq({ token: plainToken, newPassword: 'weak' });
+      const res = makeRes();
+      await confirmPasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'WEAK_PASSWORD' }));
+    });
+
+    it('resets password and clears token on valid request', async () => {
+      const { plainToken, user } = await setupUserWithToken();
+
+      for (let i = 0; i < 2; i++) {
+        await new RefreshToken({
+          userId: user.userId,
+          token: generateRefreshToken(user.userId),
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        }).save();
+      }
+
+      const req = makeReq({ token: plainToken, newPassword: 'NewSecure@123' });
+      const res = makeRes();
+      await confirmPasswordReset(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      const updated = await User.findOne({ email: 'reset@example.com' });
+      expect(updated.passwordResetToken).toBeNull();
+      expect(updated.passwordResetTokenExpiry).toBeNull();
+    });
+
+    it('enforces single-use: second confirm with same token returns 400', async () => {
+      const { plainToken } = await setupUserWithToken();
+
+      const req1 = makeReq({ token: plainToken, newPassword: 'NewSecure@123' });
+      await confirmPasswordReset(req1, makeRes());
+
+      const req2 = makeReq({ token: plainToken, newPassword: 'AnotherPass@456' });
+      const res2 = makeRes();
+      await confirmPasswordReset(req2, res2);
+      expect(res2.status).toHaveBeenCalledWith(400);
+      expect(res2.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_TOKEN' }));
+    });
+
+    it('revokes all refresh tokens on successful reset', async () => {
+      const { plainToken, user } = await setupUserWithToken();
+
+      for (let i = 0; i < 3; i++) {
+        await new RefreshToken({
+          userId: user.userId,
+          token: generateRefreshToken(user.userId),
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        }).save();
+      }
+
+      const req = makeReq({ token: plainToken, newPassword: 'NewSecure@123' });
+      await confirmPasswordReset(req, makeRes());
+
+      const active = await RefreshToken.find({ userId: user.userId, isRevoked: false });
+      expect(active).toHaveLength(0);
+    });
+
+    it('creates PASSWORD_RESET_CONFIRMED audit log', async () => {
+      const { plainToken } = await setupUserWithToken();
+      const req = makeReq({ token: plainToken, newPassword: 'NewSecure@123' });
+      await confirmPasswordReset(req, makeRes());
+
+      const log = await AuditLog.findOne({ action: 'PASSWORD_RESET_CONFIRMED' });
+      expect(log).toBeTruthy();
+    });
+  });
+
+  // ─── adminInitiatePasswordReset ────────────────────────────────────────────
+
+  describe('adminInitiatePasswordReset', () => {
+    const setupAdmin = async () =>
+      new User({
+        email: 'admin@example.com',
+        hashedPassword: await hashPassword('Admin#Secure99'),
+        role: 'admin',
+        accountStatus: 'active',
+      }).save();
+
+    const setupTarget = async () =>
+      new User({
+        email: 'target@example.com',
+        hashedPassword: await hashPassword('T3st_Secure#99'),
+        role: 'student',
+        accountStatus: 'active',
+      }).save();
+
+    it('returns 400 when neither userId nor email provided', async () => {
+      const admin = await setupAdmin();
+      const req = makeReq({}, { userId: admin.userId, role: 'admin' });
+      const res = makeRes();
+      await adminInitiatePasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it('returns 404 for unknown userId', async () => {
+      const admin = await setupAdmin();
+      const req = makeReq({ userId: 'usr_nonexistent' }, { userId: admin.userId, role: 'admin' });
+      const res = makeRes();
+      await adminInitiatePasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'USER_NOT_FOUND' }));
+    });
+
+    it('returns 404 for unknown email', async () => {
+      const admin = await setupAdmin();
+      const req = makeReq({ email: 'ghost@example.com' }, { userId: admin.userId, role: 'admin' });
+      const res = makeRes();
+      await adminInitiatePasswordReset(req, res);
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('generates reset token and returns 200 when targeting by userId', async () => {
+      const admin = await setupAdmin();
+      const target = await setupTarget();
+
+      const req = makeReq({ userId: target.userId }, { userId: admin.userId, role: 'admin' });
+      const res = makeRes();
+      await adminInitiatePasswordReset(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: target.userId, email: target.email })
+      );
+
+      const updated = await User.findOne({ userId: target.userId });
+      expect(updated.passwordResetToken).toBeTruthy();
+      expect(updated.passwordResetTokenExpiry).toBeTruthy();
+    });
+
+    it('generates reset token and returns 200 when targeting by email', async () => {
+      const admin = await setupAdmin();
+      const target = await setupTarget();
+
+      const req = makeReq({ email: target.email }, { userId: admin.userId, role: 'admin' });
+      const res = makeRes();
+      await adminInitiatePasswordReset(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const updated = await User.findOne({ email: target.email });
+      expect(updated.passwordResetToken).toBeTruthy();
+    });
+
+    it('creates PASSWORD_RESET_ADMIN_INITIATED audit log', async () => {
+      const admin = await setupAdmin();
+      const target = await setupTarget();
+
+      const req = makeReq({ userId: target.userId }, { userId: admin.userId, role: 'admin' });
+      await adminInitiatePasswordReset(req, makeRes());
+
+      const log = await AuditLog.findOne({ action: 'PASSWORD_RESET_ADMIN_INITIATED' });
+      expect(log).toBeTruthy();
+      expect(log.actorId).toBe(admin.userId);
+      expect(log.targetId).toBe(target.userId);
+    });
+
+    it('generated token expires in 15 minutes', async () => {
+      const admin = await setupAdmin();
+      const target = await setupTarget();
+
+      const req = makeReq({ userId: target.userId }, { userId: admin.userId, role: 'admin' });
+      await adminInitiatePasswordReset(req, makeRes());
+
+      const updated = await User.findOne({ userId: target.userId });
+      const msUntilExpiry = updated.passwordResetTokenExpiry - new Date();
+      expect(msUntilExpiry).toBeGreaterThan(14 * 60 * 1000);
+      expect(msUntilExpiry).toBeLessThanOrEqual(15 * 60 * 1000);
+    });
+  });
+});
+
+/**
  * JWT & Session Token Management Tests
  *
  * Covers:


### PR DESCRIPTION
- Add POST /auth/password-reset/request (non-revealing, rate limited 5/hr)
- Add POST /auth/password-reset/confirm (token validation, single-use, 15-min expiry)
- Add POST /auth/password-reset/admin-initiate (admin-only, by userId or email)
- Store reset tokens as SHA-256 hashes; send plain token via email
- Revoke all refresh tokens on successful reset
- Audit log all reset events (REQUESTED, CONFIRMED, ADMIN_INITIATED)
- Add 21 integration tests covering all acceptance criteria