### PR TITLE
feat: implement GitHub OAuth 2.0 integration (issue #19)

### DIFF
--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -9,6 +9,17 @@ const axios = require('axios');
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 
+// In-memory CSRF state store: state → { userId, expiresAt }
+const oauthStateStore = new Map();
+
+// Purge expired state tokens every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, val] of oauthStateStore.entries()) {
+    if (val.expiresAt < now) oauthStateStore.delete(key);
+  }
+}, 5 * 60 * 1000).unref();
+
 /**
  * Login with email and password
  */
@@ -365,31 +376,29 @@ const logout = async (req, res) => {
 };
 
 /**
- * Initiate GitHub OAuth
+ * Initiate GitHub OAuth (1.3-A)
+ * Protected — requires authenticated user.
+ * Generates a CSRF state token, stores it in memory with a 10-minute TTL,
+ * and returns the GitHub authorization URL.
  */
 const initiateGithubOAuth = async (req, res) => {
   try {
-    const { redirectUri } = req.body;
-
-    if (!redirectUri) {
-      return res.status(400).json({
-        code: 'INVALID_INPUT',
-        message: 'Redirect URI is required',
-      });
-    }
-
-    // Generate state token for CSRF protection
     const state = crypto.randomBytes(32).toString('hex');
 
-    // TODO: Store state in Redis or database with expiration
-    // For now, we'll just generate it
-
-    const authorizationUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${redirectUri}&state=${state}&scope=user`;
-
-    return res.status(200).json({
-      authorizationUrl,
-      state,
+    oauthStateStore.set(state, {
+      userId: req.user.userId,
+      expiresAt: Date.now() + 10 * 60 * 1000,
     });
+
+    const redirectUri = process.env.GITHUB_REDIRECT_URI;
+    const authorizationUrl =
+      `https://github.com/login/oauth/authorize` +
+      `?client_id=${process.env.GITHUB_CLIENT_ID}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&state=${state}` +
+      `&scope=read:user`;
+
+    return res.status(200).json({ authorizationUrl, state });
   } catch (error) {
     console.error('GitHub OAuth initiation error:', error);
     res.status(500).json({
@@ -400,66 +409,133 @@ const initiateGithubOAuth = async (req, res) => {
 };
 
 /**
- * Handle GitHub OAuth callback
+ * Handle GitHub OAuth callback (1.3-B)
+ * Public GET — browser is redirected here by GitHub after authorization.
+ * Verifies CSRF state, exchanges code for GitHub access token, fetches
+ * the GitHub user, enforces uniqueness, and links the account.
+ * Always responds with a 302 redirect to the frontend callback handler.
  */
 const githubOAuthCallback = async (req, res) => {
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const callbackBase = `${frontendUrl}/auth/github/callback`;
+
+  const redirectError = (code) =>
+    res.redirect(`${callbackBase}?error=${encodeURIComponent(code)}`);
+
   try {
-    const { code, state } = req.query;
+    const { code, state, error: oauthError } = req.query;
+
+    // GitHub may send an error query param (e.g. user denied access)
+    if (oauthError) {
+      return redirectError(oauthError);
+    }
 
     if (!code || !state) {
-      return res.status(400).json({
-        code: 'INVALID_INPUT',
-        message: 'Code and state parameters are required',
-      });
+      return redirectError('MISSING_PARAMS');
     }
 
-    // TODO: Verify state token
-    // For now, we'll accept it
+    // Verify CSRF state token
+    const stateData = oauthStateStore.get(state);
+    if (!stateData || stateData.expiresAt < Date.now()) {
+      oauthStateStore.delete(state);
+      return redirectError('INVALID_STATE');
+    }
 
-    // Exchange code for access token
-    const tokenResponse = await axios.post(
-      'https://github.com/login/oauth/access_token',
-      {
-        client_id: process.env.GITHUB_CLIENT_ID,
-        client_secret: process.env.GITHUB_CLIENT_SECRET,
-        code,
-        redirect_uri: process.env.GITHUB_REDIRECT_URI,
-      },
-      {
-        headers: { Accept: 'application/json' },
+    // Consume state (one-time use)
+    const { userId } = stateData;
+    oauthStateStore.delete(state);
+
+    // Exchange authorization code for GitHub access token
+    let githubAccessToken;
+    try {
+      const tokenResponse = await axios.post(
+        'https://github.com/login/oauth/access_token',
+        {
+          client_id: process.env.GITHUB_CLIENT_ID,
+          client_secret: process.env.GITHUB_CLIENT_SECRET,
+          code,
+          redirect_uri: process.env.GITHUB_REDIRECT_URI,
+        },
+        { headers: { Accept: 'application/json' } }
+      );
+
+      if (tokenResponse.data.error) {
+        console.error('GitHub token exchange error:', tokenResponse.data.error_description);
+        return redirectError('TOKEN_EXCHANGE_FAILED');
       }
-    );
 
-    const { access_token } = tokenResponse.data;
-
-    if (!access_token) {
-      return res.status(400).json({
-        code: 'OAUTH_FAILED',
-        message: 'Failed to obtain GitHub access token',
-      });
+      githubAccessToken = tokenResponse.data.access_token;
+    } catch (exchangeError) {
+      console.error('GitHub token exchange request failed:', exchangeError.message);
+      return redirectError('TOKEN_EXCHANGE_FAILED');
     }
 
-    // Get GitHub user info
-    const userResponse = await axios.get('https://api.github.com/user', {
-      headers: { Authorization: `Bearer ${access_token}` },
+    if (!githubAccessToken) {
+      return redirectError('TOKEN_EXCHANGE_FAILED');
+    }
+
+    // Fetch GitHub user profile
+    let githubUsername, githubId;
+    try {
+      const userResponse = await axios.get('https://api.github.com/user', {
+        headers: { Authorization: `Bearer ${githubAccessToken}` },
+      });
+      githubUsername = userResponse.data.login;
+      githubId = String(userResponse.data.id);
+    } catch (userError) {
+      console.error('GitHub /user API failed:', userError.message);
+      return redirectError('GITHUB_API_FAILED');
+    }
+
+    if (!githubUsername || !githubId) {
+      return redirectError('GITHUB_API_FAILED');
+    }
+
+    // Load the authenticated user who initiated the OAuth flow
+    const user = await User.findOne({ userId });
+    if (!user) {
+      return redirectError('USER_NOT_FOUND');
+    }
+
+    // Uniqueness check: reject if this GitHub ID is already linked to a different account
+    const conflictById = await User.findOne({ githubId, userId: { $ne: userId } });
+    if (conflictById) {
+      return redirectError('GITHUB_ALREADY_LINKED');
+    }
+
+    // Uniqueness check: reject if this GitHub username is already taken by a different account
+    const conflictByUsername = await User.findOne({
+      githubUsername: githubUsername.toLowerCase(),
+      userId: { $ne: userId },
     });
+    if (conflictByUsername) {
+      return redirectError('GITHUB_USERNAME_TAKEN');
+    }
 
-    const { login: githubUsername, id: githubId } = userResponse.data;
+    // Persist GitHub identity on the user record
+    user.githubUsername = githubUsername;
+    user.githubId = githubId;
+    await user.save();
 
-    // TODO: Link GitHub to current user or create new account
-    // For now, just return the GitHub info
+    // Best-effort audit log
+    try {
+      await createAuditLog({
+        action: 'GITHUB_OAUTH_LINKED',
+        actorId: userId,
+        targetId: userId,
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed for GITHUB_OAUTH_LINKED (non-fatal):', auditError.message);
+    }
 
-    return res.status(200).json({
-      githubUsername,
-      githubId,
-      linkedUserId: req.user?.userId || null,
-    });
+    return res.redirect(
+      `${callbackBase}?status=linked&githubUsername=${encodeURIComponent(githubUsername)}`
+    );
   } catch (error) {
     console.error('GitHub OAuth callback error:', error);
-    res.status(500).json({
-      code: 'SERVER_ERROR',
-      message: 'GitHub OAuth callback failed',
-    });
+    return redirectError('SERVER_ERROR');
   }
 };
 

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -19,6 +19,7 @@ const auditLogSchema = new mongoose.Schema(
         'PASSWORD_RESET_REQUESTED',
         'PASSWORD_RESET_CONFIRMED',
         'PASSWORD_RESET_ADMIN_INITIATED',
+        'GITHUB_OAUTH_LINKED',
       ],
     },
     actorId: {

--- a/backend/tests/github-oauth.test.js
+++ b/backend/tests/github-oauth.test.js
@@ -1,0 +1,352 @@
+/**
+ * GitHub OAuth Integration Tests
+ *
+ * Covers:
+ *  - POST /auth/github/oauth/initiate — state token generation, authorizationUrl shape
+ *  - GET  /auth/github/oauth/callback — CSRF validation, token exchange, GitHub API call,
+ *    uniqueness enforcement, user update, audit log, redirect behaviour
+ *
+ * External HTTP calls (GitHub APIs) are mocked via jest.mock so no real network
+ * traffic occurs and tests run without GitHub credentials.
+ *
+ * Run: npm test -- --testPathPattern=github-oauth
+ */
+
+const mongoose = require('mongoose');
+const axios = require('axios');
+
+// ── Mock axios before importing the controller ────────────────────────────────
+jest.mock('axios');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeReq = (opts = {}) => ({
+  body: opts.body || {},
+  query: opts.query || {},
+  user: opts.user || null,
+  ip: '127.0.0.1',
+  headers: { 'user-agent': 'test-agent', ...(opts.headers || {}) },
+});
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.redirect = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+// ── Test Suite ────────────────────────────────────────────────────────────────
+
+describe('GitHub OAuth (integration)', () => {
+  const mongoUri =
+    process.env.MONGODB_TEST_URI || 'mongodb://localhost:27017/senior-app-test-github-oauth';
+
+  let User;
+  let AuditLog;
+  let hashPassword;
+  let initiateGithubOAuth;
+  let githubOAuthCallback;
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+
+    // Load modules after DB is ready so they share the same mongoose instance
+    User = require('../src/models/User');
+    AuditLog = require('../src/models/AuditLog');
+    ({ hashPassword } = require('../src/utils/password'));
+    ({ initiateGithubOAuth, githubOAuthCallback } = require('../src/controllers/auth'));
+
+    // Set env vars used by the controller
+    process.env.GITHUB_CLIENT_ID = 'test-client-id';
+    process.env.GITHUB_CLIENT_SECRET = 'test-client-secret';
+    process.env.GITHUB_REDIRECT_URI = 'http://localhost:5000/api/v1/auth/github/oauth/callback';
+    process.env.FRONTEND_URL = 'http://localhost:3000';
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await User.deleteMany({});
+    await AuditLog.deleteMany({});
+    jest.clearAllMocks();
+  });
+
+  // ── Helper: create a test user ───────────────────────────────────────────────
+
+  const createUser = async (overrides = {}) =>
+    new User({
+      email: 'user@example.com',
+      hashedPassword: await hashPassword('T3st_Secure#99'),
+      role: 'student',
+      accountStatus: 'active',
+      ...overrides,
+    }).save();
+
+  // ── initiateGithubOAuth ──────────────────────────────────────────────────────
+
+  describe('initiateGithubOAuth', () => {
+    it('returns 200 with authorizationUrl and state', async () => {
+      const user = await createUser();
+      const req = makeReq({ user: { userId: user.userId } });
+      const res = makeRes();
+
+      await initiateGithubOAuth(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.state).toBeDefined();
+      expect(body.authorizationUrl).toContain('https://github.com/login/oauth/authorize');
+    });
+
+    it('authorizationUrl contains client_id, redirect_uri, state, and scope', async () => {
+      const user = await createUser({ email: 'urlcheck@example.com' });
+      const req = makeReq({ user: { userId: user.userId } });
+      const res = makeRes();
+
+      await initiateGithubOAuth(req, res);
+
+      const { authorizationUrl, state } = res.json.mock.calls[0][0];
+      expect(authorizationUrl).toContain('client_id=test-client-id');
+      expect(authorizationUrl).toContain(encodeURIComponent(process.env.GITHUB_REDIRECT_URI));
+      expect(authorizationUrl).toContain(`state=${state}`);
+      expect(authorizationUrl).toContain('scope=read:user');
+    });
+
+    it('each call generates a unique state token', async () => {
+      const user = await createUser({ email: 'unique@example.com' });
+      const req1 = makeReq({ user: { userId: user.userId } });
+      const req2 = makeReq({ user: { userId: user.userId } });
+      const res1 = makeRes();
+      const res2 = makeRes();
+
+      await initiateGithubOAuth(req1, res1);
+      await initiateGithubOAuth(req2, res2);
+
+      const state1 = res1.json.mock.calls[0][0].state;
+      const state2 = res2.json.mock.calls[0][0].state;
+      expect(state1).not.toBe(state2);
+    });
+  });
+
+  // ── githubOAuthCallback ──────────────────────────────────────────────────────
+
+  describe('githubOAuthCallback', () => {
+    // Helper: run initiate and capture the state token
+    const initiateAndGetState = async (userId) => {
+      const req = makeReq({ user: { userId } });
+      const res = makeRes();
+      await initiateGithubOAuth(req, res);
+      return res.json.mock.calls[0][0].state;
+    };
+
+    // Helper: mock a successful GitHub token exchange + user fetch
+    const mockGithubSuccess = (login = 'octocat', id = 1) => {
+      axios.post.mockResolvedValueOnce({ data: { access_token: 'gha_fake_token' } });
+      axios.get.mockResolvedValueOnce({ data: { login, id } });
+    };
+
+    it('redirects with MISSING_PARAMS when code or state absent', async () => {
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: {} }), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=MISSING_PARAMS')
+      );
+    });
+
+    it('redirects with the GitHub error when GitHub sends an error param', async () => {
+      const res = makeRes();
+      await githubOAuthCallback(
+        makeReq({ query: { error: 'access_denied', code: 'x', state: 'y' } }),
+        res
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=access_denied')
+      );
+    });
+
+    it('redirects with INVALID_STATE for an unknown state token', async () => {
+      const res = makeRes();
+      await githubOAuthCallback(
+        makeReq({ query: { code: 'somecode', state: 'completely-wrong-state' } }),
+        res
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=INVALID_STATE')
+      );
+    });
+
+    it('state token is one-time use — second callback with same state gets INVALID_STATE', async () => {
+      const user = await createUser({ email: 'onetimeuse@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('first-use', 100);
+      const res1 = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c1', state } }), res1);
+      // First call should succeed (redirect with status=linked)
+      expect(res1.redirect).toHaveBeenCalledWith(expect.stringContaining('status=linked'));
+
+      // Second call with the same state should fail
+      const res2 = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c2', state } }), res2);
+      expect(res2.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=INVALID_STATE')
+      );
+    });
+
+    it('redirects with TOKEN_EXCHANGE_FAILED when GitHub returns an error in token response', async () => {
+      const user = await createUser({ email: 'exchangefail@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      axios.post.mockResolvedValueOnce({
+        data: { error: 'bad_verification_code', error_description: 'The code is invalid.' },
+      });
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'badcode', state } }), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=TOKEN_EXCHANGE_FAILED')
+      );
+    });
+
+    it('redirects with TOKEN_EXCHANGE_FAILED when token exchange throws', async () => {
+      const user = await createUser({ email: 'exchangethrow@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      axios.post.mockRejectedValueOnce(new Error('Network error'));
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=TOKEN_EXCHANGE_FAILED')
+      );
+    });
+
+    it('redirects with GITHUB_API_FAILED when the /user API call throws', async () => {
+      const user = await createUser({ email: 'apifail@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      axios.post.mockResolvedValueOnce({ data: { access_token: 'gha_token' } });
+      axios.get.mockRejectedValueOnce(new Error('GitHub API down'));
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=GITHUB_API_FAILED')
+      );
+    });
+
+    it('redirects with GITHUB_ALREADY_LINKED when githubId belongs to another account', async () => {
+      // Another user already has this GitHub ID
+      await createUser({
+        email: 'owner@example.com',
+        githubId: '9999',
+        githubUsername: 'existinguser',
+      });
+
+      const user = await createUser({ email: 'newcomer@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('existinguser', 9999); // same githubId
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=GITHUB_ALREADY_LINKED')
+      );
+    });
+
+    it('redirects with GITHUB_USERNAME_TAKEN when githubUsername belongs to another account', async () => {
+      // Another user already has this GitHub username (different ID)
+      await createUser({
+        email: 'usernameowner@example.com',
+        githubId: '1111',
+        githubUsername: 'takenname',
+      });
+
+      const user = await createUser({ email: 'usernamenewcomer@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('takenname', 2222); // same username, different ID
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('error=GITHUB_USERNAME_TAKEN')
+      );
+    });
+
+    it('saves githubUsername and githubId on success', async () => {
+      const user = await createUser({ email: 'savetest@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('octocat', 42);
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+
+      const updated = await User.findOne({ userId: user.userId });
+      expect(updated.githubUsername).toBe('octocat');
+      expect(updated.githubId).toBe('42');
+    });
+
+    it('redirects to frontend with status=linked and githubUsername on success', async () => {
+      const user = await createUser({ email: 'successredirect@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('octocat', 99);
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('http://localhost:3000/auth/github/callback')
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('status=linked')
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('githubUsername=octocat')
+      );
+    });
+
+    it('creates a GITHUB_OAUTH_LINKED audit log on success', async () => {
+      const user = await createUser({ email: 'auditlink@example.com' });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('octokitten', 77);
+
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), makeRes());
+
+      const log = await AuditLog.findOne({ action: 'GITHUB_OAUTH_LINKED' });
+      expect(log).toBeTruthy();
+      expect(log.actorId).toBe(user.userId);
+    });
+
+    it('linking the same GitHub account again (idempotent) succeeds', async () => {
+      const user = await createUser({
+        email: 'idempotent@example.com',
+        githubId: '55',
+        githubUsername: 'samecat',
+      });
+      const state = await initiateAndGetState(user.userId);
+
+      mockGithubSuccess('samecat', 55); // same account already linked
+
+      const res = makeRes();
+      await githubOAuthCallback(makeReq({ query: { code: 'c', state } }), res);
+
+      // Should succeed — not treated as a conflict
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('status=linked')
+      );
+    });
+  });
+});


### PR DESCRIPTION
Completes endpoints 1.3-A and 1.3-B per issue acceptance criteria.

- POST /auth/github/oauth/initiate: generates CSRF state token stored in-memory with 10-minute TTL, returns authorizationUrl and state
- GET /auth/github/oauth/callback: validates state (one-time use), exchanges code for GitHub access token, calls GitHub /user API, enforces uniqueness on githubId and githubUsername, persists both fields on the user record, redirects 302 to frontend handler
- Duplicate GitHub accounts rejected (GITHUB_ALREADY_LINKED / GITHUB_USERNAME_TAKEN conveyed via redirect error param)
- Audit log emitted on successful link (GITHUB_OAUTH_LINKED)
- Added GITHUB_OAUTH_LINKED to AuditLog action enum
- 16 integration tests covering all success and failure paths