### PR TITLE
feat(onboarding): implement account finalization and activation flow

### DIFF
--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -833,7 +833,6 @@ const professorOnboard = async (req, res) => {
     }
 
     user.hashedPassword = await hashPassword(newPassword);
-    user.accountStatus = 'active';
     user.requiresPasswordChange = false;
     await user.save();
 
@@ -1015,9 +1014,9 @@ const adminCreateProfessor = async (req, res) => {
       role: 'professor',
       firstName: firstName || '',
       lastName: lastName || '',
-      accountStatus: 'active',
+      accountStatus: 'pending',
       emailVerified: false,
-      requiresPasswordChange: true, 
+      requiresPasswordChange: true,
     });
 
     await professor.save();

--- a/backend/src/controllers/onboarding.js
+++ b/backend/src/controllers/onboarding.js
@@ -374,6 +374,10 @@ const verifyEmail = async (req, res) => {
 /**
  * Finalise onboarding — mark account active and send account-ready email
  * POST /onboarding/complete
+ *
+ * Triggered after:
+ *   - Email verification (student flow f16): emailVerified === true
+ *   - Password set (professor flow f21):     requiresPasswordChange === false
  */
 const completeOnboarding = async (req, res) => {
   try {
@@ -388,17 +392,54 @@ const completeOnboarding = async (req, res) => {
       return res.status(404).json({ code: 'NOT_FOUND', message: 'User not found' });
     }
 
-    if (!user.emailVerified) {
-      return res.status(400).json({
-        code: 'EMAIL_NOT_VERIFIED',
-        message: 'Email must be verified before completing onboarding',
+    // Idempotency: account already active — return current state without resending email (f22)
+    if (user.accountStatus === 'active') {
+      return res.status(200).json({
+        userId: user.userId,
+        email: user.email,
+        role: user.role,
+        githubUsername: user.githubUsername || null,
+        emailVerified: user.emailVerified,
+        accountStatus: user.accountStatus,
+        createdAt: user.createdAt,
       });
     }
 
+    // Verify prerequisites for finalization
+    const emailVerifiedFlow = user.emailVerified; // student: verified email (f16)
+    const passwordSetFlow = user.role === 'professor' && user.requiresPasswordChange === false; // professor: set password (f21)
+
+    if (!emailVerifiedFlow && !passwordSetFlow) {
+      return res.status(400).json({
+        code: 'PREREQUISITES_NOT_MET',
+        message: 'Account cannot be finalized: email must be verified or initial password must be set',
+      });
+    }
+
+    // Persist: mark account active in D1 (flow f22)
     user.accountStatus = 'active';
     await user.save();
 
-    await sendAccountReadyEmail(user.email, user.role, user.userId);
+    // Audit: log onboarding completion (best-effort)
+    try {
+      await createAuditLog({
+        action: 'ONBOARDING_COMPLETED',
+        actorId: user.userId,
+        targetId: user.userId,
+        changes: { newStatus: 'active', role: user.role },
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed for ONBOARDING_COMPLETED (non-fatal):', auditError.message);
+    }
+
+    // Notify: role-specific account-ready email (best-effort, f23/f24)
+    try {
+      await sendAccountReadyEmail(user.email, user.role, user.userId);
+    } catch (emailError) {
+      console.error('Account-ready email failed (non-fatal):', emailError.message);
+    }
 
     return res.status(200).json({
       userId: user.userId,

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -20,6 +20,7 @@ const auditLogSchema = new mongoose.Schema(
         'PASSWORD_RESET_CONFIRMED',
         'PASSWORD_RESET_ADMIN_INITIATED',
         'GITHUB_OAUTH_LINKED',
+        'ONBOARDING_COMPLETED',
         'EMAIL_VERIFICATION_SENT',
         'EMAIL_PASSWORD_RESET_SENT',
         'EMAIL_ACCOUNT_READY_SENT',

--- a/backend/tests/onboarding.complete.test.js
+++ b/backend/tests/onboarding.complete.test.js
@@ -1,0 +1,203 @@
+/**
+ * Onboarding Completion Integration Tests
+ *
+ * Tests for POST /onboarding/complete (flows f16, f21, f22, f23, f24).
+ * Covers: student email-verified flow, professor password-set flow,
+ *         idempotency, prerequisites not met, 404, auth guard, audit logging.
+ *
+ * Run: npm test -- onboarding.complete.test.js
+ */
+
+const mongoose = require('mongoose');
+const request = require('supertest');
+const app = require('../src/index');
+const User = require('../src/models/User');
+const AuditLog = require('../src/models/AuditLog');
+const { generateTokenPair } = require('../src/utils/jwt');
+
+jest.mock('../src/services/emailService', () => ({
+  sendVerificationEmail: jest.fn().mockResolvedValue({ messageId: 'mock-id', status: 'sent' }),
+  sendAccountReadyEmail: jest.fn().mockResolvedValue({ messageId: 'mock-id', status: 'sent' }),
+  sendProfessorCredentialsEmail: jest.fn().mockResolvedValue({ messageId: 'mock-id', status: 'sent' }),
+  sendPasswordResetEmail: jest.fn().mockResolvedValue({ messageId: 'mock-id', status: 'sent' }),
+  _internal: { sendWithRetry: jest.fn(), isTransientError: jest.fn(), isDevMode: jest.fn(), createTransporter: jest.fn() },
+}));
+
+const { sendAccountReadyEmail } = require('../src/services/emailService');
+
+const MONGO_URI = process.env.MONGODB_TEST_URI || 'mongodb://localhost:27017/senior-app-test';
+
+const createStudent = (overrides = {}) =>
+  User.create({
+    email: `student-${Date.now()}-${Math.random()}@example.com`,
+    hashedPassword: 'hashed',
+    role: 'student',
+    accountStatus: 'pending_verification',
+    emailVerified: false,
+    ...overrides,
+  });
+
+const createProfessor = (overrides = {}) =>
+  User.create({
+    email: `prof-${Date.now()}-${Math.random()}@example.com`,
+    hashedPassword: 'hashed',
+    role: 'professor',
+    accountStatus: 'pending',
+    emailVerified: false,
+    requiresPasswordChange: true,
+    ...overrides,
+  });
+
+const authHeader = (user) => {
+  const { accessToken } = generateTokenPair(user.userId, user.role);
+  return `Bearer ${accessToken}`;
+};
+
+beforeAll(async () => {
+  await mongoose.connect(MONGO_URI);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  await AuditLog.deleteMany({});
+  jest.clearAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Student email-verified flow (f16 → f22 → f23)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('student email-verified flow (f16)', () => {
+  it('activates account, audits completion, and sends student account-ready email', async () => {
+    const user = await createStudent({ emailVerified: true });
+
+    const res = await request(app)
+      .post('/api/v1/onboarding/complete')
+      .set('Authorization', authHeader(user))
+      .send({ userId: user.userId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.accountStatus).toBe('active');
+    expect(res.body.userId).toBe(user.userId);
+    expect(res.body.role).toBe('student');
+
+    expect(sendAccountReadyEmail).toHaveBeenCalledTimes(1);
+    expect(sendAccountReadyEmail).toHaveBeenCalledWith(user.email, 'student', user.userId);
+
+    const audit = await AuditLog.findOne({ targetId: user.userId, action: 'ONBOARDING_COMPLETED' });
+    expect(audit).not.toBeNull();
+    expect(audit.changes.role).toBe('student');
+    expect(audit.changes.newStatus).toBe('active');
+  });
+
+  it('returns 400 PREREQUISITES_NOT_MET when student email is not verified', async () => {
+    const user = await createStudent({ emailVerified: false });
+
+    const res = await request(app)
+      .post('/api/v1/onboarding/complete')
+      .set('Authorization', authHeader(user))
+      .send({ userId: user.userId });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('PREREQUISITES_NOT_MET');
+    expect(sendAccountReadyEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Professor password-set flow (f21 → f22 → f24)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('professor password-set flow (f21)', () => {
+  it('activates account, audits completion, and sends professor account-ready email', async () => {
+    const prof = await createProfessor({ requiresPasswordChange: false });
+
+    const res = await request(app)
+      .post('/api/v1/onboarding/complete')
+      .set('Authorization', authHeader(prof))
+      .send({ userId: prof.userId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.accountStatus).toBe('active');
+    expect(res.body.role).toBe('professor');
+
+    expect(sendAccountReadyEmail).toHaveBeenCalledTimes(1);
+    expect(sendAccountReadyEmail).toHaveBeenCalledWith(prof.email, 'professor', prof.userId);
+
+    const audit = await AuditLog.findOne({ targetId: prof.userId, action: 'ONBOARDING_COMPLETED' });
+    expect(audit).not.toBeNull();
+    expect(audit.changes.role).toBe('professor');
+  });
+
+  it('returns 400 PREREQUISITES_NOT_MET when professor has not set their password yet', async () => {
+    const prof = await createProfessor({ requiresPasswordChange: true });
+
+    const res = await request(app)
+      .post('/api/v1/onboarding/complete')
+      .set('Authorization', authHeader(prof))
+      .send({ userId: prof.userId });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('PREREQUISITES_NOT_MET');
+    expect(sendAccountReadyEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Idempotency — notification sent only once per account
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('idempotency', () => {
+  it('returns current state without resending email when account is already active', async () => {
+    const user = await createStudent({ emailVerified: true, accountStatus: 'active' });
+
+    const res = await request(app)
+      .post('/api/v1/onboarding/complete')
+      .set('Authorization', authHeader(user))
+      .send({ userId: user.userId });
+
+    expect(res.status).toBe(200);
+    expect(res.body.accountStatus).toBe('active');
+    expect(sendAccountReadyEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+it('returns 400 MISSING_FIELDS when userId is omitted', async () => {
+  const user = await createStudent();
+
+  const res = await request(app)
+    .post('/api/v1/onboarding/complete')
+    .set('Authorization', authHeader(user))
+    .send({});
+
+  expect(res.status).toBe(400);
+  expect(res.body.code).toBe('MISSING_FIELDS');
+});
+
+it('returns 404 NOT_FOUND for an unknown userId', async () => {
+  const user = await createStudent({ emailVerified: true });
+
+  const res = await request(app)
+    .post('/api/v1/onboarding/complete')
+    .set('Authorization', authHeader(user))
+    .send({ userId: 'usr_doesnotexist' });
+
+  expect(res.status).toBe(404);
+  expect(res.body.code).toBe('NOT_FOUND');
+});
+
+it('returns 401 when no auth token is provided', async () => {
+  const res = await request(app)
+    .post('/api/v1/onboarding/complete')
+    .send({ userId: 'usr_whatever' });
+
+  expect(res.status).toBe(401);
+});


### PR DESCRIPTION
- Add POST /onboarding/complete with idempotency guard (no duplicate emails)
- Support student flow (emailVerified) and professor flow (requiresPasswordChange)
- Persist account status to active on finalization (flow f22)
- Send role-specific account-ready email for student (f23) and professor (f24)
- Add ONBOARDING_COMPLETED audit event with best-effort logging
- Create professors with accountStatus pending so they go through finalization
- Remove premature accountStatus activation from professorOnboard
- Add integration tests covering both flows, idempotency, and error cases