### PR TITLE
feat(groups): implement group creation and retrieval endpoints with validation

### DIFF
--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -1,0 +1,184 @@
+const Group = require('../models/Group');
+const User = require('../models/User');
+const { createAuditLog } = require('../services/auditService');
+const { forwardToMemberRequestPipeline } = require('../services/groupService');
+
+/**
+ * POST /groups
+ * Process 2.1 + 2.2: Create group, validate data, persist to D2, forward to 2.5.
+ *
+ * DFD flows:
+ *   f02 — 2.1 sends groupName + leaderId to 2.2 for validation
+ *   f18 — 2.2 writes validated group record to D2
+ *   f03 — 2.2 forwards valid group data to Process 2.5
+ */
+const createGroup = async (req, res) => {
+  try {
+    const { groupName, leaderId } = req.body;
+
+    // --- Input validation ---
+    if (!groupName || typeof groupName !== 'string' || !groupName.trim()) {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'groupName is required and must be a non-empty string.',
+      });
+    }
+
+    if (!leaderId || typeof leaderId !== 'string' || !leaderId.trim()) {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'leaderId is required.',
+      });
+    }
+
+    // The authenticated user must be the declared leader.
+    if (req.user.userId !== leaderId.trim()) {
+      return res.status(403).json({
+        code: 'FORBIDDEN',
+        message: 'leaderId must match the authenticated user.',
+      });
+    }
+
+    const normalizedName = groupName.trim();
+
+    // --- Process 2.2: Validate group name uniqueness against D2 ---
+    const existingGroup = await Group.findOne({
+      groupName: { $regex: new RegExp(`^${normalizedName}$`, 'i') },
+    });
+
+    if (existingGroup) {
+      return res.status(409).json({
+        code: 'GROUP_NAME_TAKEN',
+        message: `A group named "${normalizedName}" already exists. Please choose a different name.`,
+      });
+    }
+
+    // --- Process 2.2: Verify leaderId exists in D1 (User Accounts) ---
+    const leader = await User.findOne({ userId: leaderId.trim() });
+
+    if (!leader) {
+      return res.status(400).json({
+        code: 'LEADER_NOT_FOUND',
+        message: 'The specified leader does not exist in user accounts (D1).',
+      });
+    }
+
+    if (leader.accountStatus !== 'active') {
+      return res.status(400).json({
+        code: 'LEADER_ACCOUNT_INACTIVE',
+        message: 'The leader account must be active before creating a group.',
+      });
+    }
+
+    // --- f18: Write validated group record to D2 with status pending_validation ---
+    const group = new Group({
+      groupName: normalizedName,
+      leaderId: leader.userId,
+      status: 'pending_validation',
+    });
+
+    await group.save();
+
+    // --- f03: Forward valid group data to Process 2.5 (member request pipeline) ---
+    await forwardToMemberRequestPipeline(group);
+
+    // Audit log (non-fatal)
+    try {
+      await createAuditLog({
+        action: 'GROUP_CREATED',
+        actorId: leader.userId,
+        targetId: group.groupId,
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed (non-fatal):', auditError.message);
+    }
+
+    return res.status(201).json(formatGroupResponse(group));
+  } catch (error) {
+    console.error('createGroup error:', error);
+
+    // Mongoose duplicate-key error (race condition on groupName unique index)
+    if (error.code === 11000) {
+      return res.status(409).json({
+        code: 'GROUP_NAME_TAKEN',
+        message: 'A group with that name already exists.',
+      });
+    }
+
+    return res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'An unexpected error occurred while creating the group.',
+    });
+  }
+};
+
+/**
+ * GET /groups/:groupId
+ * Process 2.2: Return validated group record from D2.
+ *
+ * Returns: group_id, group_name, leader, advisor, status, members,
+ *          github_org, jira_project
+ */
+const getGroup = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+
+    const group = await Group.findOne({ groupId });
+
+    if (!group) {
+      return res.status(404).json({
+        code: 'GROUP_NOT_FOUND',
+        message: `No group found with id "${groupId}".`,
+      });
+    }
+
+    // Audit log (non-fatal)
+    try {
+      await createAuditLog({
+        action: 'GROUP_RETRIEVED',
+        actorId: req.user.userId,
+        targetId: group.groupId,
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed (non-fatal):', auditError.message);
+    }
+
+    return res.status(200).json(formatGroupResponse(group));
+  } catch (error) {
+    console.error('getGroup error:', error);
+    return res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'An unexpected error occurred while retrieving the group.',
+    });
+  }
+};
+
+/**
+ * Formats a Group document into the API response shape.
+ * Field names follow the acceptance criteria:
+ *   group_id, group_name, leader, advisor, status, members,
+ *   github_org, jira_project
+ */
+const formatGroupResponse = (group) => ({
+  group_id: group.groupId,
+  group_name: group.groupName,
+  leader: group.leaderId,
+  advisor: group.advisor,
+  status: group.status,
+  members: group.members.map((m) => ({
+    user_id: m.userId,
+    role: m.role,
+    status: m.status,
+    joined_at: m.joinedAt,
+  })),
+  github_org: group.githubOrg,
+  jira_project: group.jiraProject,
+  created_at: group.createdAt,
+  updated_at: group.updatedAt,
+});
+
+module.exports = { createGroup, getGroup };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const mongoose = require('mongoose');
 const authRoutes = require('./routes/auth');
 const onboardingRoutes = require('./routes/onboarding');
+const groupRoutes = require('./routes/groups');
 const { errorHandler } = require('./middleware/auth');
 
 const app = express();
@@ -49,6 +50,7 @@ connectDB();
 // Routes
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/onboarding', onboardingRoutes);
+app.use('/api/v1/groups', groupRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -25,6 +25,8 @@ const auditLogSchema = new mongoose.Schema(
         'EMAIL_PASSWORD_RESET_SENT',
         'EMAIL_ACCOUNT_READY_SENT',
         'EMAIL_DELIVERY_FAILED',
+        'GROUP_CREATED',
+        'GROUP_RETRIEVED',
       ],
     },
     actorId: {

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -1,0 +1,62 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const memberSchema = new mongoose.Schema(
+  {
+    userId: { type: String, required: true },
+    role: { type: String, enum: ['leader', 'member'], default: 'member' },
+    status: {
+      type: String,
+      enum: ['pending', 'accepted', 'rejected'],
+      default: 'pending',
+    },
+    joinedAt: { type: Date, default: null },
+  },
+  { _id: false }
+);
+
+const groupSchema = new mongoose.Schema(
+  {
+    groupId: {
+      type: String,
+      default: () => `grp_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+    },
+    groupName: {
+      type: String,
+      required: true,
+      trim: true,
+      unique: true,
+    },
+    leaderId: {
+      type: String,
+      required: true,
+    },
+    advisor: {
+      type: String,
+      default: null,
+    },
+    status: {
+      type: String,
+      enum: ['pending_validation', 'active', 'inactive', 'archived'],
+      default: 'pending_validation',
+    },
+    members: [memberSchema],
+    githubOrg: {
+      type: String,
+      default: null,
+    },
+    jiraProject: {
+      type: String,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+groupSchema.index({ leaderId: 1 });
+
+const Group = mongoose.model('Group', groupSchema);
+
+module.exports = Group;

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const { authMiddleware } = require('../middleware/auth');
+const { createGroup, getGroup } = require('../controllers/groups');
+
+// POST /api/v1/groups — Process 2.1 + 2.2: create, validate, persist, forward to 2.5
+router.post('/', authMiddleware, createGroup);
+
+// GET /api/v1/groups/:groupId — Process 2.2: retrieve validated group record from D2
+router.get('/:groupId', authMiddleware, getGroup);
+
+module.exports = router;

--- a/backend/src/services/groupService.js
+++ b/backend/src/services/groupService.js
@@ -1,0 +1,34 @@
+/**
+ * Group Service — Process 2.5 forwarding (DFD flow f03: 2.2 → 2.5)
+ *
+ * After Process 2.2 validates and writes the group record to D2,
+ * the validated group data is forwarded to Process 2.5 (member request
+ * processing pipeline). This service initialises the member list by
+ * adding the leader as the first confirmed member, making the group
+ * ready to receive further membership requests.
+ */
+
+/**
+ * Forward validated group data to the member request processing pipeline.
+ * Adds the leader as an accepted member (initial state for Process 2.5).
+ *
+ * @param {object} group - Mongoose Group document (already saved to D2)
+ * @returns {object} Updated group document
+ */
+const forwardToMemberRequestPipeline = async (group) => {
+  const leaderAlreadyAdded = group.members.some((m) => m.userId === group.leaderId);
+
+  if (!leaderAlreadyAdded) {
+    group.members.push({
+      userId: group.leaderId,
+      role: 'leader',
+      status: 'accepted',
+      joinedAt: new Date(),
+    });
+    await group.save();
+  }
+
+  return group;
+};
+
+module.exports = { forwardToMemberRequestPipeline };


### PR DESCRIPTION
## Overview

Implements the group validation and persistence layer (Process 2.2 in the Level 2 DFD). When a user submits a group creation request, the system validates the data, writes the group record to D2, and forwards it to the member request pipeline (Process 2.5).

## DFD Flows Implemented

- f02 (2.1 → 2.2): Group name and leader ID are received from the creation request and passed to the validation layer.

- f18 (2.2 → D2): After successful validation, the group record is written to the D2 store (groups MongoDB collection) with status: pending_validation.

- f03 (2.2 → 2.5): The validated group data is forwarded to the member request processing pipeline — concretely, the leader is seeded as the first accepted member, initialising the group for future membership requests.