### PR TITLE
feat: implement group creation request and leader auto-assignment (#31)

### DIFF
--- a/backend/.env 2
+++ b/backend/.env 2
@@ -1,0 +1,27 @@
+# Server Configuration
+PORT=5001
+NODE_ENV=development
+
+# Database Configuration
+MONGODB_URI=mongodb://localhost:27017/senior-app
+DB_HOST=localhost
+DB_PORT=27017
+DB_NAME=senior-app
+
+# JWT Configuration
+JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
+JWT_REFRESH_SECRET=your-super-secret-refresh-key-change-this-in-production
+JWT_EXPIRATION=15m
+JWT_REFRESH_EXPIRATION=7d
+
+# GitHub OAuth Configuration
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+GITHUB_REDIRECT_URI=http://localhost:5001/api/v1/auth/github/oauth/callback
+
+# Email Configuration
+EMAIL_SERVICE=gmail
+EMAIL_USER=your-email@gmail.com
+EMAIL_PASSWORD=your-app-password
+FRONTEND_URL=http://localhost:3000
+

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -21,6 +21,10 @@ const TEST_ADMINS = [
   { email: 'admin@university.edu', name: 'Test Admin', password: 'AdminPass1!' },
 ];
 
+const TEST_COORDINATORS = [
+  { email: 'coordinator@university.edu', name: 'Test Coordinator', password: 'CoordPass1!' },
+];
+
 const TEST_STUDENTS = [
   { studentId: 'STU-2025-001', name: 'Alice Smith', email: 'alice@university.edu' },
   { studentId: 'STU-2025-002', name: 'Bob Johnson', email: 'bob@university.edu' },
@@ -131,6 +135,33 @@ async function seed() {
   }
 
   console.log(`Done (admins): ${adminInserted} inserted, ${adminSkipped} skipped.`);
+
+  // ── Coordinators ──────────────────────────────────────────────────────────
+  console.log('\nSeeding coordinators...');
+  let coordInserted = 0;
+  let coordSkipped = 0;
+
+  for (const coord of TEST_COORDINATORS) {
+    const exists = await User.findOne({ email: coord.email });
+    if (exists) {
+      console.log(`  skip  ${coord.email} (already exists)`);
+      coordSkipped++;
+    } else {
+      const hashedPassword = await hashPassword(coord.password);
+      await User.create({
+        email: coord.email,
+        hashedPassword,
+        role: 'coordinator',
+        accountStatus: 'active',
+        emailVerified: true,
+        requiresPasswordChange: false,
+      });
+      console.log(`  added ${coord.email} — password: ${coord.password}`);
+      coordInserted++;
+    }
+  }
+
+  console.log(`Done (coordinators): ${coordInserted} inserted, ${coordSkipped} skipped.`);
 
   // ── Student Users ─────────────────────────────────────────────────────────
   console.log('\nSeeding student users...');

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -2,6 +2,7 @@ const Group = require('../models/Group');
 const ApprovalQueue = require('../models/ApprovalQueue');
 const GroupMembership = require('../models/GroupMembership');
 const User = require('../models/User');
+const ScheduleWindow = require('../models/ScheduleWindow');
 const { createAuditLog } = require('../services/auditService');
 const { forwardToMemberRequestPipeline } = require('../services/groupService');
 
@@ -150,7 +151,31 @@ const forwardApprovalResults = async (req, res) => {
  */
 const createGroup = async (req, res) => {
   try {
-    const { groupName, leaderId } = req.body;
+    const {
+      groupName,
+      leaderId,
+      githubPat,
+      githubOrg,
+      jiraUrl,
+      jiraUsername,
+      jiraToken,
+      projectKey,
+    } = req.body;
+
+    // --- Schedule boundary check (f01: Student → 2.1) ---
+    const now = new Date();
+    const activeWindow = await ScheduleWindow.findOne({
+      isActive: true,
+      startsAt: { $lte: now },
+      endsAt: { $gte: now },
+    });
+
+    if (!activeWindow) {
+      return res.status(403).json({
+        code: 'OUTSIDE_SCHEDULE_WINDOW',
+        message: 'Group creation is currently closed. Please check the coordinator-defined schedule.',
+      });
+    }
 
     // --- Input validation ---
     if (!groupName || typeof groupName !== 'string' || !groupName.trim()) {
@@ -211,6 +236,12 @@ const createGroup = async (req, res) => {
       groupName: normalizedName,
       leaderId: leader.userId,
       status: 'pending_validation',
+      githubPat: githubPat || null,
+      githubOrg: githubOrg || null,
+      jiraUrl: jiraUrl || null,
+      jiraUsername: jiraUsername || null,
+      jiraToken: jiraToken || null,
+      projectKey: projectKey || null,
     });
 
     await group.save();
@@ -310,6 +341,7 @@ const formatGroupResponse = (group) => ({
   })),
   githubOrg: group.githubOrg,
   jiraProject: group.jiraProject,
+  projectKey: group.projectKey,
   createdAt: group.createdAt,
   updatedAt: group.updatedAt,
 });

--- a/backend/src/controllers/scheduleWindow.js
+++ b/backend/src/controllers/scheduleWindow.js
@@ -1,0 +1,117 @@
+const ScheduleWindow = require('../models/ScheduleWindow');
+
+/**
+ * GET /schedule-window/active
+ * Returns the currently active schedule window (if any).
+ * Used by the frontend to show open/closed status on the group creation page.
+ */
+const getActiveWindow = async (req, res) => {
+  try {
+    const now = new Date();
+    const window = await ScheduleWindow.findOne({
+      isActive: true,
+      startsAt: { $lte: now },
+      endsAt: { $gte: now },
+    });
+
+    if (!window) {
+      return res.status(200).json({ open: false, window: null });
+    }
+
+    return res.status(200).json({
+      open: true,
+      window: {
+        windowId: window.windowId,
+        label: window.label,
+        startsAt: window.startsAt,
+        endsAt: window.endsAt,
+      },
+    });
+  } catch (err) {
+    console.error('getActiveWindow error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' });
+  }
+};
+
+/**
+ * POST /schedule-window
+ * Coordinator/admin creates a new schedule window.
+ * Body: { startsAt, endsAt, label? }
+ *
+ * Deactivates any existing windows that overlap with the new one.
+ */
+const createWindow = async (req, res) => {
+  try {
+    const { startsAt, endsAt, label } = req.body;
+
+    if (!startsAt || isNaN(new Date(startsAt).getTime())) {
+      return res.status(400).json({ code: 'INVALID_INPUT', message: 'startsAt must be a valid date.' });
+    }
+
+    if (!endsAt || isNaN(new Date(endsAt).getTime())) {
+      return res.status(400).json({ code: 'INVALID_INPUT', message: 'endsAt must be a valid date.' });
+    }
+
+    const start = new Date(startsAt);
+    const end = new Date(endsAt);
+
+    if (end <= start) {
+      return res.status(400).json({ code: 'INVALID_INPUT', message: 'endsAt must be after startsAt.' });
+    }
+
+    // Deactivate overlapping windows so only one is active at a time
+    await ScheduleWindow.updateMany(
+      {
+        isActive: true,
+        startsAt: { $lt: end },
+        endsAt: { $gt: start },
+      },
+      { $set: { isActive: false } }
+    );
+
+    const window = await ScheduleWindow.create({
+      startsAt: start,
+      endsAt: end,
+      isActive: true,
+      createdBy: req.user.userId,
+      label: label || '',
+    });
+
+    return res.status(201).json({
+      windowId: window.windowId,
+      label: window.label,
+      startsAt: window.startsAt,
+      endsAt: window.endsAt,
+      createdBy: window.createdBy,
+      createdAt: window.createdAt,
+    });
+  } catch (err) {
+    console.error('createWindow error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' });
+  }
+};
+
+/**
+ * DELETE /schedule-window/:windowId
+ * Coordinator/admin deactivates a schedule window.
+ */
+const deactivateWindow = async (req, res) => {
+  try {
+    const { windowId } = req.params;
+
+    const window = await ScheduleWindow.findOne({ windowId });
+    if (!window) {
+      return res.status(404).json({ code: 'NOT_FOUND', message: 'Schedule window not found.' });
+    }
+
+    window.isActive = false;
+    await window.save();
+
+    return res.status(200).json({ windowId: window.windowId, isActive: false });
+  } catch (err) {
+    console.error('deactivateWindow error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred.' });
+  }
+};
+
+module.exports = { getActiveWindow, createWindow, deactivateWindow };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 const authRoutes = require('./routes/auth');
 const onboardingRoutes = require('./routes/onboarding');
 const groupRoutes = require('./routes/groups');
+const scheduleWindowRoutes = require('./routes/scheduleWindow');
 const { errorHandler } = require('./middleware/auth');
 
 const app = express();
@@ -51,6 +52,7 @@ connectDB();
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/onboarding', onboardingRoutes);
 app.use('/api/v1/groups', groupRoutes);
+app.use('/api/v1/schedule-window', scheduleWindowRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -47,7 +47,27 @@ const groupSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    githubPat: {
+      type: String,
+      default: null,
+    },
     jiraProject: {
+      type: String,
+      default: null,
+    },
+    jiraUrl: {
+      type: String,
+      default: null,
+    },
+    jiraUsername: {
+      type: String,
+      default: null,
+    },
+    jiraToken: {
+      type: String,
+      default: null,
+    },
+    projectKey: {
       type: String,
       default: null,
     },

--- a/backend/src/models/ScheduleWindow.js
+++ b/backend/src/models/ScheduleWindow.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * ScheduleWindow — stores coordinator-defined group creation windows.
+ *
+ * Only one window can be active at a given point in time.
+ * createGroup checks this collection and rejects requests outside
+ * any active window (AC: schedule boundary enforcement).
+ */
+const scheduleWindowSchema = new mongoose.Schema(
+  {
+    windowId: {
+      type: String,
+      default: () => `sw_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+    },
+    startsAt: { type: Date, required: true },
+    endsAt: { type: Date, required: true },
+    isActive: { type: Boolean, default: true },
+    createdBy: { type: String, required: true }, // coordinatorId / adminId
+    label: { type: String, default: '' },        // e.g. "Spring 2026 – Group Creation"
+  },
+  { timestamps: true }
+);
+
+// Index used by the createGroup boundary check
+scheduleWindowSchema.index({ isActive: 1, startsAt: 1, endsAt: 1 });
+
+const ScheduleWindow = mongoose.model('ScheduleWindow', scheduleWindowSchema);
+
+module.exports = ScheduleWindow;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -22,7 +22,7 @@ const userSchema = new mongoose.Schema(
     },
     role: {
       type: String,
-      enum: ['student', 'professor', 'admin', 'committee_member'],
+      enum: ['student', 'professor', 'admin', 'committee_member', 'coordinator'],
       default: 'student',
     },
     githubUsername: {

--- a/backend/src/routes/scheduleWindow.js
+++ b/backend/src/routes/scheduleWindow.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+const { authMiddleware, roleMiddleware } = require('../middleware/auth');
+const { getActiveWindow, createWindow, deactivateWindow } = require('../controllers/scheduleWindow');
+
+// GET /api/v1/schedule-window/active — anyone authenticated can check if creation is open
+router.get('/active', authMiddleware, getActiveWindow);
+
+// POST /api/v1/schedule-window — coordinator/admin defines a new window
+router.post('/', authMiddleware, roleMiddleware(['coordinator', 'admin']), createWindow);
+
+// DELETE /api/v1/schedule-window/:windowId — coordinator/admin deactivates a window
+router.delete('/:windowId', authMiddleware, roleMiddleware(['coordinator', 'admin']), deactivateWindow);
+
+module.exports = router;

--- a/backend/tests/groupCreation.test.js
+++ b/backend/tests/groupCreation.test.js
@@ -1,0 +1,389 @@
+/**
+ * Group Creation Integration Tests
+ *
+ * Tests for createGroup controller (DFD flows f01, f02, f18, f03).
+ * Covers: happy path, schedule window enforcement, duplicate name,
+ *         leader validation, missing fields, github/jira fields.
+ *
+ * Run: npm test -- groupCreation.test.js
+ */
+
+const mongoose = require('mongoose');
+
+describe('POST /groups — createGroup', () => {
+  const mongoUri =
+    process.env.MONGODB_TEST_URI ||
+    'mongodb://localhost:27017/senior-app-test-group-creation';
+
+  let Group;
+  let User;
+  let ScheduleWindow;
+  let createGroup;
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  const makeReq = (body = {}, userId = 'usr_leader') => ({
+    body,
+    user: { userId, role: 'student' },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent' },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  const createActiveUser = (overrides = {}) =>
+    User.create({
+      email: `user_${Date.now()}_${Math.random()}@test.com`,
+      hashedPassword: 'hashed',
+      userId: overrides.userId || `usr_${Date.now()}`,
+      accountStatus: 'active',
+      role: 'student',
+      ...overrides,
+    });
+
+  const openWindow = (overrides = {}) => {
+    const now = new Date();
+    return ScheduleWindow.create({
+      startsAt: overrides.startsAt || new Date(now.getTime() - 60_000),
+      endsAt: overrides.endsAt || new Date(now.getTime() + 60_000 * 60),
+      isActive: true,
+      createdBy: 'coordinator_1',
+      ...overrides,
+    });
+  };
+
+  // ── Setup / teardown ─────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+
+    Group = require('../src/models/Group');
+    User = require('../src/models/User');
+    ScheduleWindow = require('../src/models/ScheduleWindow');
+    ({ createGroup } = require('../src/controllers/groups'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      Group.deleteMany({}),
+      User.deleteMany({}),
+      ScheduleWindow.deleteMany({}),
+    ]);
+  });
+
+  // ── Happy path ───────────────────────────────────────────────────────────────
+
+  describe('happy path', () => {
+    it('returns 201 with group_id, status pending_validation, created_at', async () => {
+      const leader = await createActiveUser({ userId: 'usr_leader1' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'Alpha Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.groupId).toMatch(/^grp_/);
+      expect(body.status).toBe('pending_validation');
+      expect(body.createdAt).toBeDefined();
+    });
+
+    it('auto-assigns requesting user as Team Leader in members list', async () => {
+      const leader = await createActiveUser({ userId: 'usr_leader2' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'Beta Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      const leaderMember = body.members.find((m) => m.userId === leader.userId);
+      expect(leaderMember).toBeDefined();
+      expect(leaderMember.role).toBe('leader');
+      expect(leaderMember.status).toBe('accepted');
+    });
+
+    it('persists leaderId on the group document (f18)', async () => {
+      const leader = await createActiveUser({ userId: 'usr_leader3' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'Gamma Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      const saved = await Group.findOne({ groupId: body.groupId });
+      expect(saved.leaderId).toBe(leader.userId);
+    });
+
+    it('stores optional github and jira fields when provided', async () => {
+      const leader = await createActiveUser({ userId: 'usr_leader4' });
+      await openWindow();
+
+      const req = makeReq(
+        {
+          groupName: 'Delta Team',
+          leaderId: leader.userId,
+          githubPat: 'ghp_abc123',
+          githubOrg: 'my-org',
+          jiraUrl: 'https://myteam.atlassian.net',
+          jiraUsername: 'user@test.com',
+          jiraToken: 'jira_token',
+          projectKey: 'DELTA',
+        },
+        leader.userId
+      );
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      const saved = await Group.findOne({ groupId: body.groupId });
+      expect(saved.githubPat).toBe('ghp_abc123');
+      expect(saved.githubOrg).toBe('my-org');
+      expect(saved.jiraUrl).toBe('https://myteam.atlassian.net');
+      expect(saved.projectKey).toBe('DELTA');
+    });
+
+    it('stores group with null integration fields when not provided', async () => {
+      const leader = await createActiveUser({ userId: 'usr_leader5' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'Epsilon Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      const saved = await Group.findOne({ groupId: body.groupId });
+      expect(saved.githubPat).toBeNull();
+      expect(saved.githubOrg).toBeNull();
+      expect(saved.jiraUrl).toBeNull();
+    });
+  });
+
+  // ── Schedule window enforcement ───────────────────────────────────────────────
+
+  describe('schedule boundary enforcement', () => {
+    it('returns 403 OUTSIDE_SCHEDULE_WINDOW when no window exists', async () => {
+      const leader = await createActiveUser({ userId: 'usr_nosched' });
+
+      const req = makeReq({ groupName: 'No Window Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('OUTSIDE_SCHEDULE_WINDOW');
+    });
+
+    it('returns 403 when window exists but is in the future', async () => {
+      const leader = await createActiveUser({ userId: 'usr_futuresched' });
+      const future = new Date(Date.now() + 60_000 * 60);
+      await ScheduleWindow.create({
+        startsAt: new Date(future.getTime()),
+        endsAt: new Date(future.getTime() + 60_000 * 60),
+        isActive: true,
+        createdBy: 'coord_1',
+      });
+
+      const req = makeReq({ groupName: 'Future Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('OUTSIDE_SCHEDULE_WINDOW');
+    });
+
+    it('returns 403 when window has expired', async () => {
+      const leader = await createActiveUser({ userId: 'usr_expiredsched' });
+      await ScheduleWindow.create({
+        startsAt: new Date(Date.now() - 60_000 * 120),
+        endsAt: new Date(Date.now() - 60_000),
+        isActive: true,
+        createdBy: 'coord_1',
+      });
+
+      const req = makeReq({ groupName: 'Expired Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('OUTSIDE_SCHEDULE_WINDOW');
+    });
+
+    it('returns 403 when window is deactivated (isActive: false)', async () => {
+      const leader = await createActiveUser({ userId: 'usr_inactivesched' });
+      const now = new Date();
+      await ScheduleWindow.create({
+        startsAt: new Date(now.getTime() - 60_000),
+        endsAt: new Date(now.getTime() + 60_000 * 60),
+        isActive: false,
+        createdBy: 'coord_1',
+      });
+
+      const req = makeReq({ groupName: 'Inactive Window Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('OUTSIDE_SCHEDULE_WINDOW');
+    });
+
+    it('allows creation when an active window is open', async () => {
+      const leader = await createActiveUser({ userId: 'usr_opensched' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'Open Window Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+  });
+
+  // ── Duplicate name ────────────────────────────────────────────────────────────
+
+  describe('duplicate group name', () => {
+    it('returns 409 GROUP_NAME_TAKEN when name already exists', async () => {
+      const leader = await createActiveUser({ userId: 'usr_dup1' });
+      await openWindow();
+      await Group.create({ groupName: 'Taken Name', leaderId: leader.userId });
+
+      const req = makeReq({ groupName: 'Taken Name', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NAME_TAKEN');
+    });
+
+    it('name check is case-insensitive', async () => {
+      const leader = await createActiveUser({ userId: 'usr_dup2' });
+      await openWindow();
+      await Group.create({ groupName: 'Case Team', leaderId: leader.userId });
+
+      const req = makeReq({ groupName: 'CASE TEAM', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NAME_TAKEN');
+    });
+  });
+
+  // ── Input validation ──────────────────────────────────────────────────────────
+
+  describe('input validation', () => {
+    it('returns 400 when groupName is empty', async () => {
+      await openWindow();
+      const req = makeReq({ groupName: '', leaderId: 'usr_x' }, 'usr_x');
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 when groupName is missing', async () => {
+      await openWindow();
+      const req = makeReq({ leaderId: 'usr_x' }, 'usr_x');
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 when leaderId is missing', async () => {
+      await openWindow();
+      const req = makeReq({ groupName: 'Some Team' }, 'usr_x');
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_INPUT');
+    });
+
+    it('returns 403 when leaderId does not match authenticated user', async () => {
+      await openWindow();
+      const req = makeReq({ groupName: 'Mismatch Team', leaderId: 'usr_other' }, 'usr_actual');
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('FORBIDDEN');
+    });
+
+    it('returns 400 LEADER_NOT_FOUND when leaderId does not exist in D1', async () => {
+      await openWindow();
+      const req = makeReq({ groupName: 'Ghost Leader Team', leaderId: 'usr_ghost' }, 'usr_ghost');
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('LEADER_NOT_FOUND');
+    });
+
+    it('returns 400 LEADER_ACCOUNT_INACTIVE when leader account is not active', async () => {
+      const leader = await createActiveUser({ userId: 'usr_inactive', accountStatus: 'pending' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'Inactive Leader Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('LEADER_ACCOUNT_INACTIVE');
+    });
+  });
+
+  // ── f02: forwarding to process 2.2 ───────────────────────────────────────────
+
+  describe('f02: groupName + leaderId forwarded to process 2.2', () => {
+    it('persisted group document contains groupName and leaderId (D2 write)', async () => {
+      const leader = await createActiveUser({ userId: 'usr_f02' });
+      await openWindow();
+
+      const req = makeReq({ groupName: 'F02 Team', leaderId: leader.userId }, leader.userId);
+      const res = makeRes();
+
+      await createGroup(req, res);
+
+      const body = res.json.mock.calls[0][0];
+      const saved = await Group.findOne({ groupId: body.groupId });
+      expect(saved.groupName).toBe('F02 Team');
+      expect(saved.leaderId).toBe(leader.userId);
+    });
+  });
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -13,6 +13,7 @@ import AdminPasswordReset from './components/AdminPasswordReset';
 import AdminProfessorCreation from './components/AdminProfessorCreation';
 import GitHubCallbackHandler from './components/GitHubCallbackHandler';
 import GroupDashboard from './components/GroupDashboard';
+import GroupCreationPage from './components/GroupCreationPage';
 import CoordinatorPanel from './components/CoordinatorPanel';
 import './App.css';
 
@@ -71,6 +72,10 @@ function App() {
           element={<ProtectedRoute component={Dashboard} />}
         />
         <Route
+          path="/groups/new"
+          element={<ProtectedRoute component={GroupCreationPage} />}
+        />
+        <Route
           path="/groups/:group_id"
           element={<ProtectedRoute component={GroupDashboard} />}
         />
@@ -92,3 +97,4 @@ function App() {
 }
 
 export default App;
+

--- a/frontend/src/api/groupService.js
+++ b/frontend/src/api/groupService.js
@@ -5,6 +5,55 @@ import apiClient from './apiClient';
  */
 
 /**
+ * Create a new group (Process 2.1 → 2.2, flow f01/f02)
+ * @param {object} payload
+ * @param {string} payload.groupName   - Required
+ * @param {string} payload.leaderId    - Required, must match authenticated user
+ * @param {string} [payload.githubPat]
+ * @param {string} [payload.githubOrg]
+ * @param {string} [payload.jiraUrl]
+ * @param {string} [payload.jiraUsername]
+ * @param {string} [payload.jiraToken]
+ * @param {string} [payload.projectKey]
+ * @returns {Promise<{groupId, groupName, leaderId, status, createdAt}>}
+ */
+export const createGroup = async ({
+  groupName,
+  leaderId,
+  githubPat,
+  githubOrg,
+  jiraUrl,
+  jiraUsername,
+  jiraToken,
+  projectKey,
+}) => {
+  const response = await apiClient.post('/groups', {
+    groupName,
+    leaderId,
+    githubPat: githubPat || undefined,
+    githubOrg: githubOrg || undefined,
+    jiraUrl: jiraUrl || undefined,
+    jiraUsername: jiraUsername || undefined,
+    jiraToken: jiraToken || undefined,
+    projectKey: projectKey || undefined,
+  });
+  return response.data;
+};
+
+/**
+ * Check if the group creation schedule window is currently open
+ * @returns {Promise<{open: boolean, window: object|null}>}
+ */
+export const getScheduleWindow = async () => {
+  try {
+    const response = await apiClient.get('/schedule-window/active');
+    return response.data;
+  } catch {
+    return { open: false, window: null };
+  }
+};
+
+/**
  * Get group details
  * @param {string} groupId - The group ID
  * @returns {Promise} Group data

--- a/frontend/src/components/GroupCreationPage.css
+++ b/frontend/src/components/GroupCreationPage.css
@@ -1,0 +1,186 @@
+.group-creation-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 40px 20px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+}
+
+.group-creation-form {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  padding: 40px;
+  width: 100%;
+  max-width: 560px;
+}
+
+.group-creation-form h2 {
+  margin: 0 0 8px 0;
+  font-size: 1.8rem;
+  color: #333;
+  font-weight: 700;
+  text-align: center;
+}
+
+.form-subtitle {
+  text-align: center;
+  color: #666;
+  margin: 0 0 28px 0;
+  font-size: 0.9rem;
+}
+
+/* Schedule window banner */
+.schedule-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 24px;
+  font-size: 0.88rem;
+}
+
+.schedule-banner.open {
+  background: #d4edda;
+  border: 1px solid #c3e6cb;
+  color: #155724;
+}
+
+.schedule-banner.closed {
+  background: #f8d7da;
+  border: 1px solid #f5c6cb;
+  color: #721c24;
+}
+
+.schedule-banner .banner-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+/* Form sections */
+.form-section-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #888;
+  margin: 24px 0 12px 0;
+  padding-bottom: 6px;
+  border-bottom: 1px solid #eee;
+}
+
+.form-group {
+  margin-bottom: 18px;
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  margin-bottom: 6px;
+  font-weight: 600;
+  color: #333;
+  font-size: 0.9rem;
+}
+
+.form-group label .optional {
+  font-weight: 400;
+  color: #999;
+  font-size: 0.8rem;
+  margin-left: 4px;
+}
+
+.form-group input[type='text'],
+.form-group input[type='password'],
+.form-group input[type='url'] {
+  padding: 11px 14px;
+  border: 2px solid #e0e0e0;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease;
+}
+
+.form-group input:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.12);
+}
+
+.form-group input.input-error {
+  border-color: #e74c3c;
+}
+
+.form-group input.input-error:focus {
+  box-shadow: 0 0 0 3px rgba(231, 76, 60, 0.1);
+}
+
+.field-error {
+  color: #e74c3c;
+  font-size: 0.82rem;
+  margin-top: 4px;
+}
+
+/* Error / success alerts */
+.alert {
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 20px;
+  font-size: 0.9rem;
+}
+
+.alert.error {
+  background: #f8d7da;
+  border: 1px solid #f5c6cb;
+  color: #721c24;
+}
+
+.alert.success {
+  background: #d4edda;
+  border: 1px solid #c3e6cb;
+  color: #155724;
+}
+
+/* Submit button */
+.submit-button {
+  width: 100%;
+  padding: 13px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+  margin-top: 8px;
+}
+
+.submit-button:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.submit-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.back-link {
+  display: block;
+  text-align: center;
+  margin-top: 16px;
+  color: #667eea;
+  font-size: 0.9rem;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/components/GroupCreationPage.js
+++ b/frontend/src/components/GroupCreationPage.js
@@ -1,0 +1,257 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useAuthStore from '../store/authStore';
+import { createGroup, getScheduleWindow } from '../api/groupService';
+import './GroupCreationPage.css';
+
+/**
+ * Group Creation Page — Process 2.1
+ *
+ * Student submits a group creation request. The requesting student is
+ * automatically set as Team Leader. Data is forwarded to process 2.2
+ * for validation (DFD flow f01 → f02).
+ */
+const GroupCreationPage = () => {
+  const navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
+
+  const [scheduleWindow, setScheduleWindow] = useState(null);
+  const [scheduleLoading, setScheduleLoading] = useState(true);
+
+  const [formData, setFormData] = useState({
+    groupName: '',
+    githubPat: '',
+    githubOrg: '',
+    jiraUrl: '',
+    jiraUsername: '',
+    jiraToken: '',
+    projectKey: '',
+  });
+
+  const [fieldErrors, setFieldErrors] = useState({});
+  const [submitError, setSubmitError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  // Check schedule window on mount
+  useEffect(() => {
+    getScheduleWindow().then((data) => {
+      setScheduleWindow(data);
+      setScheduleLoading(false);
+    });
+  }, []);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    if (fieldErrors[name]) {
+      setFieldErrors((prev) => ({ ...prev, [name]: '' }));
+    }
+  };
+
+  const validate = () => {
+    const errors = {};
+    if (!formData.groupName.trim()) {
+      errors.groupName = 'Group name is required.';
+    }
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitError('');
+
+    if (!validate()) return;
+
+    setLoading(true);
+    try {
+      const result = await createGroup({
+        groupName: formData.groupName.trim(),
+        leaderId: user.userId,
+        githubPat: formData.githubPat.trim() || undefined,
+        githubOrg: formData.githubOrg.trim() || undefined,
+        jiraUrl: formData.jiraUrl.trim() || undefined,
+        jiraUsername: formData.jiraUsername.trim() || undefined,
+        jiraToken: formData.jiraToken.trim() || undefined,
+        projectKey: formData.projectKey.trim() || undefined,
+      });
+
+      navigate(`/groups/${result.groupId}`);
+    } catch (err) {
+      const data = err.response?.data;
+      if (data?.code === 'GROUP_NAME_TAKEN') {
+        setFieldErrors({ groupName: 'A group with this name already exists. Please choose a different name.' });
+      } else if (data?.code === 'OUTSIDE_SCHEDULE_WINDOW') {
+        setSubmitError('Group creation is currently closed. Please check the coordinator-defined schedule.');
+      } else {
+        setSubmitError(data?.message || 'An unexpected error occurred. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isWindowClosed = !scheduleLoading && (!scheduleWindow || !scheduleWindow.open);
+
+  return (
+    <div className="group-creation-container">
+      <div className="group-creation-form">
+        <h2>Create a Group</h2>
+        <p className="form-subtitle">
+          You will automatically be assigned as Team Leader.
+        </p>
+
+        {/* Schedule window status banner */}
+        {!scheduleLoading && (
+          <div className={`schedule-banner ${scheduleWindow?.open ? 'open' : 'closed'}`}>
+            <span className="banner-icon">{scheduleWindow?.open ? '✓' : '✕'}</span>
+            <span>
+              {scheduleWindow?.open
+                ? scheduleWindow.window?.label
+                  ? `Group creation is open: ${scheduleWindow.window.label}`
+                  : 'Group creation is currently open.'
+                : 'Group creation is currently closed. Contact your coordinator for the schedule.'}
+            </span>
+          </div>
+        )}
+
+        {submitError && (
+          <div className="alert error">{submitError}</div>
+        )}
+
+        <form onSubmit={handleSubmit} noValidate>
+          {/* ── Required ── */}
+          <div className="form-section-title">Group Details</div>
+
+          <div className="form-group">
+            <label htmlFor="groupName">Group Name</label>
+            <input
+              id="groupName"
+              name="groupName"
+              type="text"
+              value={formData.groupName}
+              onChange={handleChange}
+              placeholder="e.g. Alpha Team"
+              className={fieldErrors.groupName ? 'input-error' : ''}
+              disabled={loading || isWindowClosed}
+              autoFocus
+            />
+            {fieldErrors.groupName && (
+              <span className="field-error">{fieldErrors.groupName}</span>
+            )}
+          </div>
+
+          {/* ── Optional: GitHub ── */}
+          <div className="form-section-title">GitHub Integration <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, fontSize: '0.75rem' }}>(optional)</span></div>
+
+          <div className="form-group">
+            <label htmlFor="githubOrg">
+              GitHub Organisation <span className="optional">optional</span>
+            </label>
+            <input
+              id="githubOrg"
+              name="githubOrg"
+              type="text"
+              value={formData.githubOrg}
+              onChange={handleChange}
+              placeholder="e.g. my-org"
+              disabled={loading || isWindowClosed}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="githubPat">
+              GitHub Personal Access Token <span className="optional">optional</span>
+            </label>
+            <input
+              id="githubPat"
+              name="githubPat"
+              type="password"
+              value={formData.githubPat}
+              onChange={handleChange}
+              placeholder="ghp_••••••••"
+              disabled={loading || isWindowClosed}
+            />
+          </div>
+
+          {/* ── Optional: Jira ── */}
+          <div className="form-section-title">Jira Integration <span style={{ fontWeight: 400, textTransform: 'none', letterSpacing: 0, fontSize: '0.75rem' }}>(optional)</span></div>
+
+          <div className="form-group">
+            <label htmlFor="jiraUrl">
+              Jira URL <span className="optional">optional</span>
+            </label>
+            <input
+              id="jiraUrl"
+              name="jiraUrl"
+              type="url"
+              value={formData.jiraUrl}
+              onChange={handleChange}
+              placeholder="https://yourteam.atlassian.net"
+              disabled={loading || isWindowClosed}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="jiraUsername">
+              Jira Username / Email <span className="optional">optional</span>
+            </label>
+            <input
+              id="jiraUsername"
+              name="jiraUsername"
+              type="text"
+              value={formData.jiraUsername}
+              onChange={handleChange}
+              placeholder="user@example.com"
+              disabled={loading || isWindowClosed}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="jiraToken">
+              Jira API Token <span className="optional">optional</span>
+            </label>
+            <input
+              id="jiraToken"
+              name="jiraToken"
+              type="password"
+              value={formData.jiraToken}
+              onChange={handleChange}
+              placeholder="••••••••"
+              disabled={loading || isWindowClosed}
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="projectKey">
+              Project Key <span className="optional">optional</span>
+            </label>
+            <input
+              id="projectKey"
+              name="projectKey"
+              type="text"
+              value={formData.projectKey}
+              onChange={handleChange}
+              placeholder="e.g. ALPHA"
+              disabled={loading || isWindowClosed}
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="submit-button"
+            disabled={loading || isWindowClosed}
+          >
+            {loading ? 'Creating group…' : 'Create Group'}
+          </button>
+        </form>
+
+        <button className="back-link" onClick={() => navigate('/dashboard')}>
+          ← Back to dashboard
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default GroupCreationPage;


### PR DESCRIPTION
- Add GroupCreationPage with group name input, GitHub/Jira optional fields, and schedule window open/closed banner
- Add POST /groups handling for github_pat, github_org, jira_url, jira_username, jira_token, project_key fields; persist to Group model
- Add ScheduleWindow model and controller (create, get active, deactivate)
- Add schedule boundary enforcement in createGroup — blocks creation outside coordinator-defined window with 403 OUTSIDE_SCHEDULE_WINDOW
- Add /api/v1/schedule-window routes (coordinator/admin only for write)
- Add createGroup and getScheduleWindow to frontend groupService
- Add /groups/new protected route in App.js
- Add coordinator role to User model enum
- Add coordinator seed user (coordinator@university.edu)
- Add groupCreation.test.js covering happy path, schedule enforcement, duplicate name, input validation, and f02 forwarding