### PR TITLE
42 be coordinator override addremove member

### DIFF
--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -1,9 +1,10 @@
 const Group = require('../models/Group');
 const ApprovalQueue = require('../models/ApprovalQueue');
 const GroupMembership = require('../models/GroupMembership');
+const Override = require('../models/Override');
 const User = require('../models/User');
 const { createAuditLog } = require('../services/auditService');
-const { forwardToMemberRequestPipeline } = require('../services/groupService');
+const { forwardToMemberRequestPipeline, forwardOverrideToReconciliation } = require('../services/groupService');
 
 const VALID_DECISIONS = new Set(['approved', 'rejected']);
 
@@ -314,4 +315,154 @@ const formatGroupResponse = (group) => ({
   updatedAt: group.updatedAt,
 });
 
-module.exports = { forwardApprovalResults, createGroup, getGroup };
+const VALID_OVERRIDE_ACTIONS = new Set(['add_member', 'remove_member']);
+
+/**
+ * PATCH /groups/:groupId/override
+ *
+ * Process 2.8 — Coordinator Override: forcibly add or remove a student from a group,
+ * bypassing the standard invitation/approval flow.
+ *
+ * DFD flows:
+ *   f16 — Coordinator → 2.8 (override request received)
+ *   f21 — 2.8 → D2  (member records updated immediately)
+ *   f17 — 2.8 → 2.5 (override confirmation forwarded for reconciliation)
+ *
+ * Role guard: coordinator only (403 for all other roles).
+ * Not restricted by coordinator-defined schedule windows.
+ */
+const coordinatorOverride = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const { action, target_student_id, reason } = req.body;
+
+    if (!action || !VALID_OVERRIDE_ACTIONS.has(action)) {
+      return res.status(400).json({
+        code: 'INVALID_ACTION',
+        message: "action must be 'add_member' or 'remove_member'",
+      });
+    }
+
+    if (!target_student_id || typeof target_student_id !== 'string' || !target_student_id.trim()) {
+      return res.status(400).json({
+        code: 'MISSING_TARGET_STUDENT',
+        message: 'target_student_id is required',
+      });
+    }
+
+    if (!reason || typeof reason !== 'string' || !reason.trim()) {
+      return res.status(400).json({
+        code: 'MISSING_REASON',
+        message: 'reason is required',
+      });
+    }
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({
+        code: 'GROUP_NOT_FOUND',
+        message: 'Group not found',
+      });
+    }
+
+    const targetStudent = await User.findOne({ userId: target_student_id.trim() });
+    if (!targetStudent) {
+      return res.status(404).json({
+        code: 'STUDENT_NOT_FOUND',
+        message: 'Target student not found',
+      });
+    }
+
+    const studentId = target_student_id.trim();
+    const timestamp = new Date();
+
+    // f21: Update D2 member records immediately
+    if (action === 'add_member') {
+      const alreadyMember = group.members.some((m) => m.userId === studentId && m.status === 'accepted');
+      if (!alreadyMember) {
+        // Remove any existing non-accepted entry for this student first
+        group.members = group.members.filter((m) => m.userId !== studentId);
+        group.members.push({
+          userId: studentId,
+          role: 'member',
+          status: 'accepted',
+          joinedAt: timestamp,
+        });
+        await group.save();
+      }
+
+      await GroupMembership.findOneAndUpdate(
+        { groupId, studentId },
+        {
+          $set: {
+            status: 'approved',
+            decidedBy: req.user.userId,
+            decidedAt: timestamp,
+          },
+          $setOnInsert: {
+            membershipId: `mem_${require('uuid').v4().split('-')[0]}`,
+          },
+        },
+        { upsert: true, new: true }
+      );
+    } else {
+      // remove_member
+      group.members = group.members.filter((m) => m.userId !== studentId);
+      await group.save();
+
+      await GroupMembership.findOneAndUpdate(
+        { groupId, studentId },
+        {
+          $set: {
+            status: 'rejected',
+            decidedBy: req.user.userId,
+            decidedAt: timestamp,
+          },
+        }
+      );
+    }
+
+    // Persist override record to D2
+    const override = await Override.create({
+      groupId,
+      action,
+      targetStudentId: studentId,
+      reason: reason.trim(),
+      coordinatorId: req.user.userId,
+      status: 'applied',
+    });
+
+    // f17: Forward override confirmation to process 2.5 for reconciliation
+    await forwardOverrideToReconciliation(override);
+
+    // Audit log (non-fatal)
+    try {
+      await createAuditLog({
+        action: 'COORDINATOR_OVERRIDE',
+        actorId: req.user.userId,
+        targetId: groupId,
+        changes: { action, targetStudentId: studentId, reason: reason.trim() },
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed (non-fatal):', auditError.message);
+    }
+
+    return res.status(200).json({
+      override_id: override.overrideId,
+      action: override.action,
+      status: 'applied',
+      confirmation: `${action === 'add_member' ? 'Student added to' : 'Student removed from'} group ${groupId} by coordinator override`,
+      timestamp: override.createdAt.toISOString(),
+    });
+  } catch (err) {
+    console.error('coordinatorOverride error:', err);
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    });
+  }
+};
+
+module.exports = { forwardApprovalResults, createGroup, getGroup, coordinatorOverride };

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -27,6 +27,7 @@ const auditLogSchema = new mongoose.Schema(
         'EMAIL_DELIVERY_FAILED',
         'GROUP_CREATED',
         'GROUP_RETRIEVED',
+        'COORDINATOR_OVERRIDE',
       ],
     },
     actorId: {

--- a/backend/src/models/Override.js
+++ b/backend/src/models/Override.js
@@ -1,0 +1,51 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const overrideSchema = new mongoose.Schema(
+  {
+    overrideId: {
+      type: String,
+      default: () => `ovr_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+    },
+    groupId: {
+      type: String,
+      required: true,
+    },
+    action: {
+      type: String,
+      enum: ['add_member', 'remove_member'],
+      required: true,
+    },
+    targetStudentId: {
+      type: String,
+      required: true,
+    },
+    reason: {
+      type: String,
+      required: true,
+    },
+    coordinatorId: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ['applied', 'reconciled', 'failed'],
+      default: 'applied',
+    },
+    reconciledAt: {
+      type: Date,
+      default: null,
+    },
+  },
+  { timestamps: true }
+);
+
+overrideSchema.index({ groupId: 1, status: 1 });
+overrideSchema.index({ coordinatorId: 1 });
+
+const Override = mongoose.model('Override', overrideSchema);
+
+module.exports = Override;

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -22,7 +22,7 @@ const userSchema = new mongoose.Schema(
     },
     role: {
       type: String,
-      enum: ['student', 'professor', 'admin', 'committee_member'],
+      enum: ['student', 'professor', 'admin', 'committee_member', 'coordinator'],
       default: 'student',
     },
     githubUsername: {

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { authMiddleware, roleMiddleware } = require('../middleware/auth');
-const { forwardApprovalResults, createGroup, getGroup } = require('../controllers/groups');
+const { forwardApprovalResults, createGroup, getGroup, coordinatorOverride } = require('../controllers/groups');
 
 // POST /api/v1/groups — Process 2.1 + 2.2: create, validate, persist, forward to 2.5
 router.post('/', authMiddleware, createGroup);
@@ -16,6 +16,15 @@ router.post(
   authMiddleware,
   roleMiddleware(['committee_member', 'professor', 'admin']),
   forwardApprovalResults
+);
+
+// PATCH /api/v1/groups/:groupId/override
+// Process 2.8: Coordinator override — add/remove member, bypassing standard flow
+router.patch(
+  '/:groupId/override',
+  authMiddleware,
+  roleMiddleware(['coordinator']),
+  coordinatorOverride
 );
 
 module.exports = router;

--- a/backend/src/services/groupService.js
+++ b/backend/src/services/groupService.js
@@ -31,4 +31,18 @@ const forwardToMemberRequestPipeline = async (group) => {
   return group;
 };
 
-module.exports = { forwardToMemberRequestPipeline };
+/**
+ * Forward override confirmation to process 2.5 for reconciliation.
+ * (DFD flow f17: 2.8 → 2.5)
+ *
+ * @param {object} override - Mongoose Override document (already saved to D2)
+ * @returns {object} Updated override document
+ */
+const forwardOverrideToReconciliation = async (override) => {
+  override.status = 'reconciled';
+  override.reconciledAt = new Date();
+  await override.save();
+  return override;
+};
+
+module.exports = { forwardToMemberRequestPipeline, forwardOverrideToReconciliation };

--- a/backend/tests/coordinatorOverride.test.js
+++ b/backend/tests/coordinatorOverride.test.js
@@ -1,0 +1,375 @@
+/**
+ * Coordinator Override Integration Tests
+ *
+ * Tests for the coordinatorOverride controller (PATCH /groups/:groupId/override).
+ * Process 2.8 — DFD flows f16 (Coordinator → 2.8), f21 (2.8 → D2), f17 (2.8 → 2.5).
+ *
+ * Run: npm test -- coordinatorOverride.test.js
+ */
+
+const mongoose = require('mongoose');
+
+describe('PATCH /groups/:groupId/override — coordinatorOverride', () => {
+  const mongoUri =
+    process.env.MONGODB_TEST_URI ||
+    'mongodb://localhost:27017/senior-app-test-coordinator-override';
+
+  let Group;
+  let GroupMembership;
+  let Override;
+  let User;
+  let coordinatorOverride;
+
+  // ── Test helpers ─────────────────────────────────────────────────────────────
+
+  const makeReq = (params = {}, body = {}, userOverrides = {}) => ({
+    params,
+    body,
+    user: { userId: 'usr_coordinator', role: 'coordinator', ...userOverrides },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent' },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  const makeGroup = (overrides = {}) =>
+    Group.create({
+      groupName: `Test Group ${Date.now()}-${Math.random()}`,
+      leaderId: 'usr_leader',
+      ...overrides,
+    });
+
+  const makeStudent = (overrides = {}) =>
+    User.create({
+      userId: `usr_stu_${Date.now()}-${Math.random()}`,
+      email: `student_${Date.now()}@test.com`,
+      hashedPassword: 'hashed',
+      role: 'student',
+      accountStatus: 'active',
+      ...overrides,
+    });
+
+  // ── Setup / teardown ─────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+
+    Group = require('../src/models/Group');
+    GroupMembership = require('../src/models/GroupMembership');
+    Override = require('../src/models/Override');
+    User = require('../src/models/User');
+    ({ coordinatorOverride } = require('../src/controllers/groups'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      Group.deleteMany({}),
+      GroupMembership.deleteMany({}),
+      Override.deleteMany({}),
+      User.deleteMany({}),
+    ]);
+  });
+
+  // ── Happy path: add_member ────────────────────────────────────────────────────
+
+  describe('action: add_member', () => {
+    it('returns 200 with override_id, action, status applied, confirmation, timestamp', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      const req = makeReq(
+        { groupId: group.groupId },
+        { action: 'add_member', target_student_id: student.userId, reason: 'Project reassignment' }
+      );
+      const res = makeRes();
+
+      await coordinatorOverride(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.override_id).toMatch(/^ovr_/);
+      expect(body.action).toBe('add_member');
+      expect(body.status).toBe('applied');
+      expect(body.confirmation).toBeDefined();
+      expect(body.timestamp).toBeDefined();
+    });
+
+    it('adds the student to Group.members with status accepted (f21: D2 update)', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'add_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      const member = updated.members.find((m) => m.userId === student.userId);
+      expect(member).toBeDefined();
+      expect(member.status).toBe('accepted');
+      expect(member.role).toBe('member');
+      expect(member.joinedAt).toBeDefined();
+    });
+
+    it('upserts GroupMembership with status approved (f21: D2 update)', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'add_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        makeRes()
+      );
+
+      const membership = await GroupMembership.findOne({
+        groupId: group.groupId,
+        studentId: student.userId,
+      });
+      expect(membership).not.toBeNull();
+      expect(membership.status).toBe('approved');
+      expect(membership.decidedBy).toBe('usr_coordinator');
+    });
+
+    it('forwards override to process 2.5 — Override record has status reconciled (f17)', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'add_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        makeRes()
+      );
+
+      const override = await Override.findOne({ groupId: group.groupId, targetStudentId: student.userId });
+      expect(override).not.toBeNull();
+      expect(override.status).toBe('reconciled');
+      expect(override.reconciledAt).toBeDefined();
+    });
+
+    it('is idempotent — re-adding an already-accepted member does not duplicate members', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      const body = { action: 'add_member', target_student_id: student.userId, reason: 'Override' };
+
+      await coordinatorOverride(makeReq({ groupId: group.groupId }, body), makeRes());
+      await coordinatorOverride(makeReq({ groupId: group.groupId }, body), makeRes());
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      const entries = updated.members.filter((m) => m.userId === student.userId);
+      expect(entries).toHaveLength(1);
+    });
+  });
+
+  // ── Happy path: remove_member ─────────────────────────────────────────────────
+
+  describe('action: remove_member', () => {
+    it('returns 200 with override_id, action, status applied, confirmation, timestamp', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      group.members.push({ userId: student.userId, role: 'member', status: 'accepted', joinedAt: new Date() });
+      await group.save();
+
+      const req = makeReq(
+        { groupId: group.groupId },
+        { action: 'remove_member', target_student_id: student.userId, reason: 'Policy violation' }
+      );
+      const res = makeRes();
+
+      await coordinatorOverride(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.override_id).toMatch(/^ovr_/);
+      expect(body.action).toBe('remove_member');
+      expect(body.status).toBe('applied');
+    });
+
+    it('removes the student from Group.members (f21: D2 update)', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      group.members.push({ userId: student.userId, role: 'member', status: 'accepted', joinedAt: new Date() });
+      await group.save();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'remove_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      const member = updated.members.find((m) => m.userId === student.userId);
+      expect(member).toBeUndefined();
+    });
+
+    it('updates GroupMembership status to rejected (f21: D2 update)', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await GroupMembership.create({
+        groupId: group.groupId,
+        studentId: student.userId,
+        status: 'approved',
+        decidedBy: 'usr_leader',
+        decidedAt: new Date(),
+      });
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'remove_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        makeRes()
+      );
+
+      const membership = await GroupMembership.findOne({
+        groupId: group.groupId,
+        studentId: student.userId,
+      });
+      expect(membership.status).toBe('rejected');
+      expect(membership.decidedBy).toBe('usr_coordinator');
+    });
+
+    it('forwards override to process 2.5 — Override record has status reconciled (f17)', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'remove_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        makeRes()
+      );
+
+      const override = await Override.findOne({ groupId: group.groupId, action: 'remove_member' });
+      expect(override.status).toBe('reconciled');
+    });
+  });
+
+  // ── 400 Bad Request ───────────────────────────────────────────────────────────
+
+  describe('400 Bad Request', () => {
+    it('returns 400 INVALID_ACTION when action is missing', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { target_student_id: 'usr_x', reason: 'test' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_ACTION');
+    });
+
+    it('returns 400 INVALID_ACTION when action is unrecognized', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { action: 'kick_member', target_student_id: 'usr_x', reason: 'test' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_ACTION');
+    });
+
+    it('returns 400 MISSING_TARGET_STUDENT when target_student_id is missing', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { action: 'add_member', reason: 'test' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_TARGET_STUDENT');
+    });
+
+    it('returns 400 MISSING_REASON when reason is missing', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { action: 'add_member', target_student_id: 'usr_x' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_REASON');
+    });
+
+    it('returns 400 MISSING_REASON when reason is whitespace only', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { action: 'add_member', target_student_id: 'usr_x', reason: '   ' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_REASON');
+    });
+  });
+
+  // ── 404 Not Found ─────────────────────────────────────────────────────────────
+
+  describe('404 Not Found', () => {
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const student = await makeStudent();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: 'grp_nonexistent' },
+          { action: 'add_member', target_student_id: student.userId, reason: 'Override' }
+        ),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+
+    it('returns 404 STUDENT_NOT_FOUND when target student does not exist', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'add_member', target_student_id: 'usr_ghost', reason: 'Override' }
+        ),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('STUDENT_NOT_FOUND');
+    });
+  });
+});


### PR DESCRIPTION
feat(groups): coordinator override add/remove member

- PATCH /groups/:groupId/override, coordinator role only (403 for others)
- Updates Group.members and GroupMembership immediately (f21)
- Forwards confirmation to process 2.5 for reconciliation (f17)
- Adds Override model, coordinator role, and COORDINATOR_OVERRIDE audit action
- 16 integration tests
