### PR TITLE
feat(override): extend coordinator override with update_group action

### DIFF
--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -1,0 +1,295 @@
+const axios = require('axios');
+const Group = require('../models/Group');
+const SyncErrorLog = require('../models/SyncErrorLog');
+
+const MAX_RETRY_ATTEMPTS = 3;
+
+/**
+ * Retry wrapper: calls fn up to maxAttempts times.
+ * Returns the result on first success, or throws the last error.
+ */
+const withRetry = async (fn, maxAttempts = MAX_RETRY_ATTEMPTS) => {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      // Client errors (4xx) are not transient — fail immediately without retry
+      if (err.response?.status >= 400 && err.response?.status < 500) {
+        throw err;
+      }
+      lastError = err;
+    }
+  }
+  throw lastError;
+};
+
+/**
+ * POST /groups/:groupId/github
+ *
+ * Process 2.6 — Validate GitHub PAT + org and store config in D2.
+ *
+ * DFD flows:
+ *   f10 — Team Leader → 2.6 (submit GitHub PAT + org)
+ *   f11 — 2.6 → GitHub API (validate PAT, retrieve org data)
+ *   f12 — GitHub API → 2.6 (return org data)
+ *   f24 — 2.6 → D2 (store validated GitHub config)
+ *
+ * Error codes:
+ *   422 INVALID_PAT         — GitHub API rejects the token (401/403)
+ *   422 ORG_NOT_FOUND       — org does not exist or PAT lacks access
+ *   503 GITHUB_API_UNAVAILABLE — 3 consecutive timeouts/5xx errors
+ */
+const configureGithub = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const { pat, org } = req.body;
+
+    if (!pat || typeof pat !== 'string' || !pat.trim()) {
+      return res.status(400).json({ code: 'MISSING_PAT', message: 'pat is required' });
+    }
+    if (!org || typeof org !== 'string' || !org.trim()) {
+      return res.status(400).json({ code: 'MISSING_ORG', message: 'org is required' });
+    }
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    if (group.leaderId !== req.user.userId) {
+      return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can configure GitHub' });
+    }
+
+    // f11: validate PAT against GitHub API (with retry)
+    let orgData;
+    try {
+      await withRetry(() =>
+        axios.get('https://api.github.com/user', {
+          headers: { Authorization: `Bearer ${pat.trim()}`, 'User-Agent': 'senior-app' },
+          timeout: 5000,
+        })
+      );
+    } catch (err) {
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        return res.status(422).json({ code: 'INVALID_PAT', message: 'GitHub PAT is invalid or has insufficient permissions' });
+      }
+      // Network/timeout failures — log sync error
+      await SyncErrorLog.create({
+        service: 'github',
+        groupId,
+        actorId: req.user.userId,
+        attempts: MAX_RETRY_ATTEMPTS,
+        lastError: err.message,
+      });
+      return res.status(503).json({ code: 'GITHUB_API_UNAVAILABLE', message: 'GitHub API unavailable after maximum retry attempts' });
+    }
+
+    // f12: retrieve org data
+    try {
+      const orgResponse = await withRetry(() =>
+        axios.get(`https://api.github.com/orgs/${org.trim()}`, {
+          headers: { Authorization: `Bearer ${pat.trim()}`, 'User-Agent': 'senior-app' },
+          timeout: 5000,
+        })
+      );
+      orgData = orgResponse.data;
+    } catch (err) {
+      const status = err.response?.status;
+      if (status === 404) {
+        return res.status(422).json({ code: 'ORG_NOT_FOUND', message: 'GitHub organisation not found or PAT lacks access' });
+      }
+      await SyncErrorLog.create({
+        service: 'github',
+        groupId,
+        actorId: req.user.userId,
+        attempts: MAX_RETRY_ATTEMPTS,
+        lastError: err.message,
+      });
+      return res.status(503).json({ code: 'GITHUB_API_UNAVAILABLE', message: 'GitHub API unavailable after maximum retry attempts' });
+    }
+
+    // f24: store config in D2
+    group.githubPat = pat.trim();
+    group.githubOrg = org.trim();
+    await group.save();
+
+    return res.status(200).json({
+      github_org: group.githubOrg,
+      validated: true,
+      org_data: { login: orgData.login, id: orgData.id, name: orgData.name },
+    });
+  } catch (err) {
+    console.error('configureGithub error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+/**
+ * GET /groups/:groupId/github
+ *
+ * Returns the stored GitHub config for the group (PAT excluded).
+ */
+const getGithub = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    return res.status(200).json({
+      group_id: groupId,
+      github_org: group.githubOrg,
+      validated: !!group.githubOrg,
+    });
+  } catch (err) {
+    console.error('getGithub error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+/**
+ * POST /groups/:groupId/jira
+ *
+ * Process 2.7 — Validate JIRA credentials + project key and store config in D2.
+ *
+ * DFD flows:
+ *   f13 — Team Leader → 2.7 (submit JIRA credentials)
+ *   f14 — 2.7 → JIRA API (validate credentials + project)
+ *   f15 — JIRA API → 2.7 (confirm binding)
+ *   f25 — 2.7 → D2 (store validated JIRA config)
+ *
+ * Error codes:
+ *   422 INVALID_JIRA_CREDENTIALS — JIRA rejects username/token (401/403)
+ *   422 INVALID_PROJECT_KEY      — project key not found in JIRA (404)
+ *   503 JIRA_API_UNAVAILABLE     — 3 consecutive timeouts/5xx errors
+ */
+const configureJira = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const { jira_url, jira_username, jira_token, project_key } = req.body;
+
+    if (!jira_url || typeof jira_url !== 'string' || !jira_url.trim()) {
+      return res.status(400).json({ code: 'MISSING_JIRA_URL', message: 'jira_url is required' });
+    }
+    if (!jira_username || typeof jira_username !== 'string' || !jira_username.trim()) {
+      return res.status(400).json({ code: 'MISSING_JIRA_USERNAME', message: 'jira_username is required' });
+    }
+    if (!jira_token || typeof jira_token !== 'string' || !jira_token.trim()) {
+      return res.status(400).json({ code: 'MISSING_JIRA_TOKEN', message: 'jira_token is required' });
+    }
+    if (!project_key || typeof project_key !== 'string' || !project_key.trim()) {
+      return res.status(400).json({ code: 'MISSING_PROJECT_KEY', message: 'project_key is required' });
+    }
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    if (group.leaderId !== req.user.userId) {
+      return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can configure JIRA' });
+    }
+
+    const baseUrl = jira_url.trim().replace(/\/$/, '');
+    const auth = Buffer.from(`${jira_username.trim()}:${jira_token.trim()}`).toString('base64');
+
+    // f14: validate credentials against JIRA API
+    try {
+      await withRetry(() =>
+        axios.get(`${baseUrl}/rest/api/3/myself`, {
+          headers: { Authorization: `Basic ${auth}`, 'Content-Type': 'application/json' },
+          timeout: 5000,
+        })
+      );
+    } catch (err) {
+      const status = err.response?.status;
+      if (status === 401 || status === 403) {
+        return res.status(422).json({ code: 'INVALID_JIRA_CREDENTIALS', message: 'JIRA credentials are invalid' });
+      }
+      await SyncErrorLog.create({
+        service: 'jira',
+        groupId,
+        actorId: req.user.userId,
+        attempts: MAX_RETRY_ATTEMPTS,
+        lastError: err.message,
+      });
+      return res.status(503).json({ code: 'JIRA_API_UNAVAILABLE', message: 'JIRA API unavailable after maximum retry attempts' });
+    }
+
+    // f15: validate project key
+    let projectData;
+    try {
+      const projResponse = await withRetry(() =>
+        axios.get(`${baseUrl}/rest/api/3/project/${project_key.trim()}`, {
+          headers: { Authorization: `Basic ${auth}`, 'Content-Type': 'application/json' },
+          timeout: 5000,
+        })
+      );
+      projectData = projResponse.data;
+    } catch (err) {
+      const status = err.response?.status;
+      if (status === 404) {
+        return res.status(422).json({ code: 'INVALID_PROJECT_KEY', message: 'JIRA project key not found' });
+      }
+      await SyncErrorLog.create({
+        service: 'jira',
+        groupId,
+        actorId: req.user.userId,
+        attempts: MAX_RETRY_ATTEMPTS,
+        lastError: err.message,
+      });
+      return res.status(503).json({ code: 'JIRA_API_UNAVAILABLE', message: 'JIRA API unavailable after maximum retry attempts' });
+    }
+
+    // f25: store config in D2
+    group.jiraUrl = baseUrl;
+    group.jiraUsername = jira_username.trim();
+    group.jiraToken = jira_token.trim();
+    group.projectKey = project_key.trim();
+    group.jiraProject = projectData.name || project_key.trim();
+    await group.save();
+
+    return res.status(200).json({
+      jira_url: group.jiraUrl,
+      jira_project: group.jiraProject,
+      project_key: group.projectKey,
+      validated: true,
+    });
+  } catch (err) {
+    console.error('configureJira error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+/**
+ * GET /groups/:groupId/jira
+ *
+ * Returns the stored JIRA config for the group (token excluded).
+ */
+const getJira = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    return res.status(200).json({
+      group_id: groupId,
+      jira_url: group.jiraUrl,
+      jira_project: group.jiraProject,
+      project_key: group.projectKey,
+      validated: !!group.jiraUrl,
+    });
+  } catch (err) {
+    console.error('getJira error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+module.exports = { configureGithub, getGithub, configureJira, getJira };

--- a/backend/src/controllers/groupMembers.js
+++ b/backend/src/controllers/groupMembers.js
@@ -1,0 +1,307 @@
+const Group = require('../models/Group');
+const GroupMembership = require('../models/GroupMembership');
+const MemberInvitation = require('../models/MemberInvitation');
+const User = require('../models/User');
+const { dispatchInvitationNotification } = require('../services/notificationService');
+const SyncErrorLog = require('../models/SyncErrorLog');
+
+const VALID_DECISIONS = new Set(['accepted', 'rejected']);
+const MAX_RETRY_ATTEMPTS = 3;
+
+/**
+ * POST /groups/:groupId/members
+ *
+ * Process 2.3 — Team leader invites a student to the group.
+ *
+ * DFD flows:
+ *   f05 — Student (leader) → 2.3 (add member request)
+ *   f19 — 2.3 → D2 (write pending member record)
+ *
+ * Business rule: a student may only belong to one active group at a time.
+ * If the invitee already has an approved membership elsewhere, the request
+ * is auto-denied with 409 STUDENT_ALREADY_IN_GROUP.
+ */
+const addMember = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const { invitee_id } = req.body;
+
+    if (!invitee_id || typeof invitee_id !== 'string' || !invitee_id.trim()) {
+      return res.status(400).json({ code: 'MISSING_INVITEE_ID', message: 'invitee_id is required' });
+    }
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    if (group.leaderId !== req.user.userId) {
+      return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can invite members' });
+    }
+
+    const invitee = await User.findOne({ userId: invitee_id.trim() });
+    if (!invitee) {
+      return res.status(404).json({ code: 'STUDENT_NOT_FOUND', message: 'Invitee not found' });
+    }
+
+    // Auto-denial: one active group per student (f08 pre-check)
+    const existingApproved = await GroupMembership.findOne({
+      studentId: invitee_id.trim(),
+      status: 'approved',
+      groupId: { $ne: groupId },
+    });
+    if (existingApproved) {
+      return res.status(409).json({
+        code: 'STUDENT_ALREADY_IN_GROUP',
+        message: 'Student already belongs to an active group and cannot be invited to another',
+      });
+    }
+
+    // Check for existing invitation to this group
+    const existing = await MemberInvitation.findOne({ groupId, inviteeId: invitee_id.trim() });
+    if (existing) {
+      return res.status(409).json({
+        code: 'ALREADY_INVITED',
+        message: 'Student has already been invited to this group',
+      });
+    }
+
+    // f19: write pending member record to D2
+    const invitation = await MemberInvitation.create({
+      groupId,
+      inviteeId: invitee_id.trim(),
+      invitedBy: req.user.userId,
+    });
+
+    await GroupMembership.create({
+      groupId,
+      studentId: invitee_id.trim(),
+      status: 'pending',
+    });
+
+    return res.status(201).json({
+      invitation_id: invitation.invitationId,
+      group_id: groupId,
+      invitee_id: invitation.inviteeId,
+      invited_by: invitation.invitedBy,
+      status: invitation.status,
+      created_at: invitation.createdAt,
+    });
+  } catch (err) {
+    console.error('addMember error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+/**
+ * GET /groups/:groupId/members
+ *
+ * Returns the current member list from D2 (Group.members embedded array).
+ */
+const getMembers = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    return res.status(200).json({
+      group_id: groupId,
+      members: group.members.map((m) => ({
+        userId: m.userId,
+        role: m.role,
+        status: m.status,
+        joinedAt: m.joinedAt,
+      })),
+    });
+  } catch (err) {
+    console.error('getMembers error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+/**
+ * POST /groups/:groupId/notifications
+ *
+ * Process 2.3 — Dispatch invitation notification to the invitee.
+ *
+ * DFD flow:
+ *   f06 — 2.3 → Notification Service (send invitation to student)
+ *
+ * Calls the external Notification Service (mocked in tests).
+ * On 3 consecutive failures, logs a SyncErrorLog entry and returns 503.
+ */
+const dispatchNotification = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const { invitee_id } = req.body;
+
+    if (!invitee_id || typeof invitee_id !== 'string' || !invitee_id.trim()) {
+      return res.status(400).json({ code: 'MISSING_INVITEE_ID', message: 'invitee_id is required' });
+    }
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    if (group.leaderId !== req.user.userId) {
+      return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can dispatch notifications' });
+    }
+
+    const invitation = await MemberInvitation.findOne({ groupId, inviteeId: invitee_id.trim() });
+    if (!invitation) {
+      return res.status(404).json({ code: 'INVITATION_NOT_FOUND', message: 'No pending invitation found for this student' });
+    }
+
+    // Retry up to MAX_RETRY_ATTEMPTS times
+    let notifResult;
+    let lastError;
+    for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+      try {
+        notifResult = await dispatchInvitationNotification({
+          groupId,
+          groupName: group.groupName,
+          inviteeId: invitee_id.trim(),
+          invitedBy: req.user.userId,
+        });
+        lastError = null;
+        break;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+
+    if (lastError) {
+      await SyncErrorLog.create({
+        service: 'notification',
+        groupId,
+        actorId: req.user.userId,
+        attempts: MAX_RETRY_ATTEMPTS,
+        lastError: lastError.message,
+      });
+      return res.status(503).json({
+        code: 'NOTIFICATION_SERVICE_UNAVAILABLE',
+        message: 'Notification service failed after maximum retry attempts',
+      });
+    }
+
+    invitation.notifiedAt = new Date();
+    invitation.notificationId = notifResult.notification_id || null;
+    await invitation.save();
+
+    return res.status(200).json({
+      notification_id: invitation.notificationId,
+      invitee_id: invitation.inviteeId,
+      notified_at: invitation.notifiedAt,
+    });
+  } catch (err) {
+    console.error('dispatchNotification error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+/**
+ * POST /groups/:groupId/membership-decisions
+ *
+ * Process 2.4 — Invited student accepts or rejects the group invitation.
+ *
+ * DFD flows:
+ *   f07 — Student (invitee) → 2.4 (membership decision)
+ *   f08 — 2.4 validates decision and updates D2 records
+ *
+ * Business rule: if the student has already accepted another group invitation,
+ * auto-deny this one to enforce the one-active-group constraint.
+ */
+const membershipDecision = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const { decision } = req.body;
+
+    if (!decision || !VALID_DECISIONS.has(decision)) {
+      return res.status(400).json({
+        code: 'INVALID_DECISION',
+        message: "decision must be 'accepted' or 'rejected'",
+      });
+    }
+
+    const group = await Group.findOne({ groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    const studentId = req.user.userId;
+
+    const invitation = await MemberInvitation.findOne({ groupId, inviteeId: studentId });
+    if (!invitation) {
+      return res.status(404).json({ code: 'INVITATION_NOT_FOUND', message: 'No invitation found for this student' });
+    }
+
+    if (invitation.status !== 'pending') {
+      return res.status(409).json({
+        code: 'DECISION_ALREADY_MADE',
+        message: `Invitation has already been ${invitation.status}`,
+      });
+    }
+
+    // Auto-denial: one active group per student
+    if (decision === 'accepted') {
+      const existingApproved = await GroupMembership.findOne({
+        studentId,
+        status: 'approved',
+        groupId: { $ne: groupId },
+      });
+      if (existingApproved) {
+        // Auto-deny this invitation
+        invitation.status = 'rejected';
+        invitation.decidedAt = new Date();
+        await invitation.save();
+        await GroupMembership.findOneAndUpdate(
+          { groupId, studentId },
+          { $set: { status: 'rejected', decidedBy: studentId, decidedAt: new Date() } }
+        );
+        return res.status(409).json({
+          code: 'STUDENT_ALREADY_IN_GROUP',
+          message: 'Student already belongs to an active group. Invitation auto-denied.',
+          auto_denied: true,
+        });
+      }
+    }
+
+    // f08: update D2 records
+    const decidedAt = new Date();
+    invitation.status = decision;
+    invitation.decidedAt = decidedAt;
+    await invitation.save();
+
+    const membershipStatus = decision === 'accepted' ? 'approved' : 'rejected';
+    await GroupMembership.findOneAndUpdate(
+      { groupId, studentId },
+      { $set: { status: membershipStatus, decidedBy: studentId, decidedAt } }
+    );
+
+    // If accepted, add to group.members embedded array
+    if (decision === 'accepted') {
+      const alreadyMember = group.members.some((m) => m.userId === studentId);
+      if (!alreadyMember) {
+        group.members.push({ userId: studentId, role: 'member', status: 'accepted', joinedAt: decidedAt });
+        await group.save();
+      }
+    }
+
+    return res.status(200).json({
+      invitation_id: invitation.invitationId,
+      group_id: groupId,
+      student_id: studentId,
+      decision,
+      decided_at: decidedAt,
+    });
+  } catch (err) {
+    console.error('membershipDecision error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+module.exports = { addMember, getMembers, dispatchNotification, membershipDecision };

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -347,7 +347,15 @@ const formatGroupResponse = (group) => ({
   updatedAt: group.updatedAt,
 });
 
-const VALID_OVERRIDE_ACTIONS = new Set(['add_member', 'remove_member']);
+const VALID_OVERRIDE_ACTIONS = new Set(['add_member', 'remove_member', 'update_group']);
+
+const VALID_GROUP_FIELDS = new Set([
+  'groupName', 'leaderId', 'advisor', 'status',
+  'githubOrg', 'githubPat', 'jiraProject', 'jiraUrl',
+  'jiraUsername', 'jiraToken', 'projectKey',
+]);
+
+const VALID_GROUP_STATUSES = new Set(['pending_validation', 'active', 'inactive', 'archived']);
 
 /**
  * PATCH /groups/:groupId/override
@@ -366,19 +374,12 @@ const VALID_OVERRIDE_ACTIONS = new Set(['add_member', 'remove_member']);
 const coordinatorOverride = async (req, res) => {
   try {
     const { groupId } = req.params;
-    const { action, target_student_id, reason } = req.body;
+    const { action, target_student_id, updates, reason } = req.body;
 
     if (!action || !VALID_OVERRIDE_ACTIONS.has(action)) {
       return res.status(400).json({
         code: 'INVALID_ACTION',
-        message: "action must be 'add_member' or 'remove_member'",
-      });
-    }
-
-    if (!target_student_id || typeof target_student_id !== 'string' || !target_student_id.trim()) {
-      return res.status(400).json({
-        code: 'MISSING_TARGET_STUDENT',
-        message: 'target_student_id is required',
+        message: "action must be 'add_member', 'remove_member', or 'update_group'",
       });
     }
 
@@ -397,6 +398,82 @@ const coordinatorOverride = async (req, res) => {
       });
     }
 
+    const timestamp = new Date();
+
+    if (action === 'update_group') {
+      // Validate updates payload
+      if (
+        !updates ||
+        typeof updates !== 'object' ||
+        Array.isArray(updates) ||
+        Object.keys(updates).length === 0
+      ) {
+        return res.status(400).json({
+          code: 'MISSING_UPDATES',
+          message: 'updates must be a non-empty object',
+        });
+      }
+
+      const unknownFields = Object.keys(updates).filter((k) => !VALID_GROUP_FIELDS.has(k));
+      if (unknownFields.length > 0) {
+        return res.status(400).json({
+          code: 'UNKNOWN_FIELDS',
+          message: `Unknown field(s): ${unknownFields.join(', ')}`,
+        });
+      }
+
+      if (updates.status !== undefined && !VALID_GROUP_STATUSES.has(updates.status)) {
+        return res.status(400).json({
+          code: 'INVALID_STATUS',
+          message: `status must be one of: ${[...VALID_GROUP_STATUSES].join(', ')}`,
+        });
+      }
+
+      // f21: Apply partial update to D2 group record
+      Object.assign(group, updates);
+      await group.save();
+
+      const override = await Override.create({
+        groupId,
+        action,
+        updates,
+        reason: reason.trim(),
+        coordinatorId: req.user.userId,
+        status: 'applied',
+      });
+
+      await forwardOverrideToReconciliation(override);
+
+      try {
+        await createAuditLog({
+          action: 'COORDINATOR_OVERRIDE',
+          actorId: req.user.userId,
+          targetId: groupId,
+          changes: { action, updates, reason: reason.trim() },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('Audit log failed (non-fatal):', auditError.message);
+      }
+
+      return res.status(200).json({
+        override_id: override.overrideId,
+        action: override.action,
+        status: 'applied',
+        confirmation: `Group ${groupId} fields updated by coordinator override`,
+        timestamp: override.createdAt.toISOString(),
+      });
+    }
+
+    // add_member / remove_member
+    if (!target_student_id || typeof target_student_id !== 'string' || !target_student_id.trim()) {
+      return res.status(400).json({
+        code: 'MISSING_TARGET_STUDENT',
+        message: 'target_student_id is required',
+      });
+    }
+
     const targetStudent = await User.findOne({ userId: target_student_id.trim() });
     if (!targetStudent) {
       return res.status(404).json({
@@ -406,13 +483,11 @@ const coordinatorOverride = async (req, res) => {
     }
 
     const studentId = target_student_id.trim();
-    const timestamp = new Date();
 
     // f21: Update D2 member records immediately
     if (action === 'add_member') {
       const alreadyMember = group.members.some((m) => m.userId === studentId && m.status === 'accepted');
       if (!alreadyMember) {
-        // Remove any existing non-accepted entry for this student first
         group.members = group.members.filter((m) => m.userId !== studentId);
         group.members.push({
           userId: studentId,
@@ -454,7 +529,6 @@ const coordinatorOverride = async (req, res) => {
       );
     }
 
-    // Persist override record to D2
     const override = await Override.create({
       groupId,
       action,
@@ -464,10 +538,8 @@ const coordinatorOverride = async (req, res) => {
       status: 'applied',
     });
 
-    // f17: Forward override confirmation to process 2.5 for reconciliation
     await forwardOverrideToReconciliation(override);
 
-    // Audit log (non-fatal)
     try {
       await createAuditLog({
         action: 'COORDINATOR_OVERRIDE',

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -28,6 +28,11 @@ const auditLogSchema = new mongoose.Schema(
         'GROUP_CREATED',
         'GROUP_RETRIEVED',
         'COORDINATOR_OVERRIDE',
+        'MEMBER_INVITED',
+        'NOTIFICATION_DISPATCHED',
+        'MEMBERSHIP_DECISION_MADE',
+        'GITHUB_CONFIGURED',
+        'JIRA_CONFIGURED',
       ],
     },
     actorId: {

--- a/backend/src/models/MemberInvitation.js
+++ b/backend/src/models/MemberInvitation.js
@@ -1,0 +1,39 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * MemberInvitation — D2 record for Process 2.3 (f05, f19)
+ *
+ * Tracks invitations sent by a group leader to a student.
+ * One invitation per (group, invitee) pair — enforced by unique index.
+ * Distinct from GroupMembership: this tracks the invitation lifecycle,
+ * while GroupMembership tracks the final committee-approved membership.
+ */
+const memberInvitationSchema = new mongoose.Schema(
+  {
+    invitationId: {
+      type: String,
+      default: () => `inv_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+    },
+    groupId: { type: String, required: true },
+    inviteeId: { type: String, required: true },
+    invitedBy: { type: String, required: true },
+    status: {
+      type: String,
+      enum: ['pending', 'accepted', 'rejected'],
+      default: 'pending',
+    },
+    notifiedAt: { type: Date, default: null },
+    decidedAt: { type: Date, default: null },
+    notificationId: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+// One invitation record per student per group
+memberInvitationSchema.index({ groupId: 1, inviteeId: 1 }, { unique: true });
+memberInvitationSchema.index({ inviteeId: 1, status: 1 });
+
+module.exports = mongoose.model('MemberInvitation', memberInvitationSchema);

--- a/backend/src/models/Override.js
+++ b/backend/src/models/Override.js
@@ -15,12 +15,16 @@ const overrideSchema = new mongoose.Schema(
     },
     action: {
       type: String,
-      enum: ['add_member', 'remove_member'],
+      enum: ['add_member', 'remove_member', 'update_group'],
       required: true,
     },
     targetStudentId: {
       type: String,
-      required: true,
+      default: null,
+    },
+    updates: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
     },
     reason: {
       type: String,

--- a/backend/src/models/SyncErrorLog.js
+++ b/backend/src/models/SyncErrorLog.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * SyncErrorLog — records failed external API sync attempts.
+ *
+ * Written when an external API (GitHub, JIRA, Notification Service)
+ * fails after all retry attempts. Used by the retry logic test to
+ * confirm a sync error entry is persisted after 3 consecutive failures.
+ */
+const syncErrorLogSchema = new mongoose.Schema(
+  {
+    errorId: {
+      type: String,
+      default: () => `ser_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+    },
+    service: {
+      type: String,
+      enum: ['github', 'jira', 'notification'],
+      required: true,
+    },
+    groupId: { type: String, required: true },
+    actorId: { type: String, required: true },
+    attempts: { type: Number, default: 3 },
+    lastError: { type: String, default: null },
+  },
+  { timestamps: true }
+);
+
+syncErrorLogSchema.index({ groupId: 1, service: 1 });
+
+module.exports = mongoose.model('SyncErrorLog', syncErrorLogSchema);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -2,12 +2,26 @@ const express = require('express');
 const router = express.Router();
 const { authMiddleware, roleMiddleware } = require('../middleware/auth');
 const { forwardApprovalResults, createGroup, getGroup, coordinatorOverride } = require('../controllers/groups');
+const { addMember, getMembers, dispatchNotification, membershipDecision } = require('../controllers/groupMembers');
+const { configureGithub, getGithub, configureJira, getJira } = require('../controllers/groupIntegrations');
 
 // POST /api/v1/groups — Process 2.1 + 2.2: create, validate, persist, forward to 2.5
 router.post('/', authMiddleware, createGroup);
 
 // GET /api/v1/groups/:groupId — Process 2.2: retrieve validated group record from D2
 router.get('/:groupId', authMiddleware, getGroup);
+
+// POST /api/v1/groups/:groupId/members — Process 2.3: leader invites a student (f05, f19)
+router.post('/:groupId/members', authMiddleware, addMember);
+
+// GET /api/v1/groups/:groupId/members — return current member list from D2
+router.get('/:groupId/members', authMiddleware, getMembers);
+
+// POST /api/v1/groups/:groupId/notifications — Process 2.3: dispatch invitation notification (f06)
+router.post('/:groupId/notifications', authMiddleware, dispatchNotification);
+
+// POST /api/v1/groups/:groupId/membership-decisions — Process 2.4: student accepts/rejects (f07, f08)
+router.post('/:groupId/membership-decisions', authMiddleware, membershipDecision);
 
 // POST /api/v1/groups/:groupId/approval-results
 // Flow f09: process 2.4 → 2.5 — forward collected approval results to the queue
@@ -17,6 +31,18 @@ router.post(
   roleMiddleware(['committee_member', 'professor', 'admin']),
   forwardApprovalResults
 );
+
+// POST /api/v1/groups/:groupId/github — Process 2.6: validate PAT + org, store config (f10-f12, f24)
+router.post('/:groupId/github', authMiddleware, configureGithub);
+
+// GET /api/v1/groups/:groupId/github — return stored GitHub config
+router.get('/:groupId/github', authMiddleware, getGithub);
+
+// POST /api/v1/groups/:groupId/jira — Process 2.7: validate credentials + project key (f13-f15, f25)
+router.post('/:groupId/jira', authMiddleware, configureJira);
+
+// GET /api/v1/groups/:groupId/jira — return stored JIRA config
+router.get('/:groupId/jira', authMiddleware, getJira);
 
 // PATCH /api/v1/groups/:groupId/override
 // Process 2.8: Coordinator override — add/remove member, bypassing standard flow

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -1,0 +1,26 @@
+const axios = require('axios');
+
+const NOTIFICATION_SERVICE_URL =
+  process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000';
+
+/**
+ * Dispatch a GROUP_INVITATION notification to a student.
+ * Called by Process 2.3 (DFD flow f06: 2.3 → Notification Service).
+ *
+ * @param {object} payload
+ * @param {string} payload.groupId
+ * @param {string} payload.groupName
+ * @param {string} payload.inviteeId   - student receiving the invitation
+ * @param {string} payload.invitedBy   - leader who sent the invite
+ * @returns {object} { notification_id }
+ */
+const dispatchInvitationNotification = async ({ groupId, groupName, inviteeId, invitedBy }) => {
+  const response = await axios.post(
+    `${NOTIFICATION_SERVICE_URL}/api/notifications`,
+    { type: 'GROUP_INVITATION', groupId, groupName, inviteeId, invitedBy },
+    { timeout: 5000 }
+  );
+  return response.data;
+};
+
+module.exports = { dispatchInvitationNotification };

--- a/backend/tests/coordinatorOverride.test.js
+++ b/backend/tests/coordinatorOverride.test.js
@@ -268,6 +268,162 @@ describe('PATCH /groups/:groupId/override — coordinatorOverride', () => {
     });
   });
 
+  // ── Happy path: update_group ──────────────────────────────────────────────────
+
+  describe('action: update_group', () => {
+    it('returns 200 with override_id, action: update_group, status applied, confirmation, timestamp', async () => {
+      const group = await makeGroup();
+
+      const req = makeReq(
+        { groupId: group.groupId },
+        { action: 'update_group', updates: { status: 'active' }, reason: 'Coordinator approval' }
+      );
+      const res = makeRes();
+
+      await coordinatorOverride(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.override_id).toMatch(/^ovr_/);
+      expect(body.action).toBe('update_group');
+      expect(body.status).toBe('applied');
+      expect(body.confirmation).toBeDefined();
+      expect(body.timestamp).toBeDefined();
+    });
+
+    it('applies partial update to D2 group record (f21)', async () => {
+      const group = await makeGroup();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          {
+            action: 'update_group',
+            updates: { status: 'active', advisor: 'usr_advisor_1' },
+            reason: 'Coordinator setting advisor',
+          }
+        ),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      expect(updated.status).toBe('active');
+      expect(updated.advisor).toBe('usr_advisor_1');
+    });
+
+    it('creates override log entry with override_id, action, updates, reason, coordinatorId (f16→D2)', async () => {
+      const group = await makeGroup();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          {
+            action: 'update_group',
+            updates: { githubOrg: 'my-org' },
+            reason: 'Setting GitHub org',
+          }
+        ),
+        makeRes()
+      );
+
+      const override = await Override.findOne({ groupId: group.groupId, action: 'update_group' });
+      expect(override).not.toBeNull();
+      expect(override.overrideId).toMatch(/^ovr_/);
+      expect(override.reason).toBe('Setting GitHub org');
+      expect(override.coordinatorId).toBe('usr_coordinator');
+      expect(override.updates).toMatchObject({ githubOrg: 'my-org' });
+    });
+
+    it('forwards override to process 2.5 — Override record has status reconciled (f17)', async () => {
+      const group = await makeGroup();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'update_group', updates: { status: 'inactive' }, reason: 'Deactivating group' }
+        ),
+        makeRes()
+      );
+
+      const override = await Override.findOne({ groupId: group.groupId, action: 'update_group' });
+      expect(override.status).toBe('reconciled');
+      expect(override.reconciledAt).toBeDefined();
+    });
+
+    it('returns 400 MISSING_UPDATES when updates is missing', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { action: 'update_group', reason: 'test' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_UPDATES');
+    });
+
+    it('returns 400 MISSING_UPDATES when updates is an empty object', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq({ groupId: group.groupId }, { action: 'update_group', updates: {}, reason: 'test' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_UPDATES');
+    });
+
+    it('returns 400 UNKNOWN_FIELDS when updates contains an unknown field', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'update_group', updates: { fakeField: 'value' }, reason: 'test' }
+        ),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('UNKNOWN_FIELDS');
+    });
+
+    it('returns 400 INVALID_STATUS when status value is not a valid enum', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: group.groupId },
+          { action: 'update_group', updates: { status: 'deleted' }, reason: 'test' }
+        ),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_STATUS');
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await coordinatorOverride(
+        makeReq(
+          { groupId: 'grp_nonexistent' },
+          { action: 'update_group', updates: { status: 'active' }, reason: 'test' }
+        ),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+  });
+
   // ── 400 Bad Request ───────────────────────────────────────────────────────────
 
   describe('400 Bad Request', () => {

--- a/backend/tests/githubIntegration.test.js
+++ b/backend/tests/githubIntegration.test.js
@@ -1,0 +1,379 @@
+/**
+ * GitHub Integration Integration Tests
+ *
+ * Tests for groupIntegrations.js controller:
+ *   configureGithub (f10, f11, f12, f24) — validate PAT + org, store config
+ *   getGithub                             — retrieve stored GitHub config
+ *
+ * Axios is mocked so no real HTTP calls are made.
+ *
+ * Run: npm test -- githubIntegration.test.js
+ */
+
+const mongoose = require('mongoose');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
+  const mongoUri =
+    process.env.MONGODB_TEST_URI ||
+    'mongodb://localhost:27017/senior-app-test-github-integration';
+
+  let Group;
+  let SyncErrorLog;
+  let configureGithub;
+  let getGithub;
+
+  // ── Helpers ────────────────────────────────────────────────────────────────────
+
+  const makeReq = (params = {}, body = {}, userOverrides = {}) => ({
+    params,
+    body,
+    user: { userId: 'usr_leader', role: 'student', ...userOverrides },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent' },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  const makeGroup = (overrides = {}) =>
+    Group.create({
+      groupName: `Test Group ${Date.now()}-${Math.random()}`,
+      leaderId: 'usr_leader',
+      status: 'active',
+      ...overrides,
+    });
+
+  // GitHub API mock helpers
+  const mockValidPat = () => {
+    axios.get.mockResolvedValueOnce({ status: 200, data: { login: 'usr_leader' } });
+  };
+
+  const mockValidOrg = (orgName = 'my-org') => {
+    axios.get.mockResolvedValueOnce({
+      status: 200,
+      data: { login: orgName, id: 42, name: 'My Org' },
+    });
+  };
+
+  const mockInvalidPat = () => {
+    const err = new Error('Unauthorized');
+    err.response = { status: 401 };
+    axios.get.mockRejectedValueOnce(err);
+  };
+
+  const mockForbiddenPat = () => {
+    const err = new Error('Forbidden');
+    err.response = { status: 403 };
+    axios.get.mockRejectedValueOnce(err);
+  };
+
+  const mockOrgNotFound = () => {
+    const err = new Error('Not Found');
+    err.response = { status: 404 };
+    axios.get.mockRejectedValueOnce(err);
+  };
+
+  const mockNetworkFailure = (times = 3) => {
+    const err = new Error('ETIMEDOUT');
+    for (let i = 0; i < times; i++) {
+      axios.get.mockRejectedValueOnce(err);
+    }
+  };
+
+  // ── Setup / teardown ───────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+
+    Group = require('../src/models/Group');
+    SyncErrorLog = require('../src/models/SyncErrorLog');
+    ({ configureGithub, getGithub } = require('../src/controllers/groupIntegrations'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([Group.deleteMany({}), SyncErrorLog.deleteMany({})]);
+    jest.clearAllMocks();
+  });
+
+  // ── configureGithub happy path ─────────────────────────────────────────────────
+
+  describe('POST /groups/:groupId/github — configureGithub', () => {
+    it('returns 200 with github_org, validated: true, org_data on success', async () => {
+      mockValidPat();
+      mockValidOrg('cool-org');
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_validtoken', org: 'cool-org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.validated).toBe(true);
+      expect(body.github_org).toBe('cool-org');
+      expect(body.org_data).toMatchObject({ login: 'cool-org', id: 42 });
+    });
+
+    it('f24: stores githubPat and githubOrg in D2 group record', async () => {
+      mockValidPat();
+      mockValidOrg('my-org');
+
+      const group = await makeGroup();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_secret', org: 'my-org' }),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      expect(updated.githubPat).toBe('ghp_secret');
+      expect(updated.githubOrg).toBe('my-org');
+    });
+
+    it('f11: makes PAT validation call to https://api.github.com/user', async () => {
+      mockValidPat();
+      mockValidOrg();
+
+      const group = await makeGroup();
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_token', org: 'my-org' }),
+        makeRes()
+      );
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://api.github.com/user',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer ghp_token' }),
+        })
+      );
+    });
+
+    it('f12: makes org data call to https://api.github.com/orgs/:org', async () => {
+      mockValidPat();
+      mockValidOrg('target-org');
+
+      const group = await makeGroup();
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_token', org: 'target-org' }),
+        makeRes()
+      );
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://api.github.com/orgs/target-org',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: 'Bearer ghp_token' }),
+        })
+      );
+    });
+
+    // ── 400 validation ───────────────────────────────────────────────────────────
+
+    it('returns 400 MISSING_PAT when pat is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(makeReq({ groupId: group.groupId }, { org: 'my-org' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_PAT');
+    });
+
+    it('returns 400 MISSING_ORG when org is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(makeReq({ groupId: group.groupId }, { pat: 'ghp_x' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_ORG');
+    });
+
+    // ── 403 / 404 ────────────────────────────────────────────────────────────────
+
+    it('returns 403 FORBIDDEN when caller is not the group leader', async () => {
+      const group = await makeGroup({ leaderId: 'usr_other' });
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_x', org: 'org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('FORBIDDEN');
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: 'grp_none' }, { pat: 'ghp_x', org: 'org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+
+    // ── 422 invalid credentials / org ────────────────────────────────────────────
+
+    it('returns 422 INVALID_PAT when GitHub returns 401', async () => {
+      mockInvalidPat();
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_bad', org: 'my-org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_PAT');
+    });
+
+    it('returns 422 INVALID_PAT when GitHub returns 403', async () => {
+      mockForbiddenPat();
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_bad', org: 'my-org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_PAT');
+    });
+
+    it('returns 422 ORG_NOT_FOUND when org lookup returns 404', async () => {
+      mockValidPat();
+      mockOrgNotFound();
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_valid', org: 'ghost-org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json.mock.calls[0][0].code).toBe('ORG_NOT_FOUND');
+    });
+
+    // ── 503 retry exhaustion ──────────────────────────────────────────────────────
+
+    it('returns 503 GITHUB_API_UNAVAILABLE after 3 network failures on PAT validation', async () => {
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_timeout', org: 'my-org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json.mock.calls[0][0].code).toBe('GITHUB_API_UNAVAILABLE');
+    });
+
+    it('writes SyncErrorLog entry after PAT validation retry exhaustion', async () => {
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_timeout', org: 'my-org' }),
+        makeRes()
+      );
+
+      const errLog = await SyncErrorLog.findOne({ service: 'github', groupId: group.groupId });
+      expect(errLog).not.toBeNull();
+      expect(errLog.attempts).toBe(3);
+    });
+
+    it('returns 503 GITHUB_API_UNAVAILABLE after 3 network failures on org lookup', async () => {
+      mockValidPat();
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureGithub(
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_valid', org: 'my-org' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json.mock.calls[0][0].code).toBe('GITHUB_API_UNAVAILABLE');
+    });
+  });
+
+  // ── getGithub ──────────────────────────────────────────────────────────────────
+
+  describe('GET /groups/:groupId/github — getGithub', () => {
+    it('returns 200 with group_id, github_org, validated: true when config is set', async () => {
+      const group = await makeGroup({ githubOrg: 'stored-org', githubPat: 'ghp_stored' });
+      const res = makeRes();
+
+      await getGithub(makeReq({ groupId: group.groupId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.group_id).toBe(group.groupId);
+      expect(body.github_org).toBe('stored-org');
+      expect(body.validated).toBe(true);
+    });
+
+    it('does not expose githubPat in the response', async () => {
+      const group = await makeGroup({ githubOrg: 'stored-org', githubPat: 'ghp_secret' });
+      const res = makeRes();
+
+      await getGithub(makeReq({ groupId: group.groupId }), res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.githubPat).toBeUndefined();
+    });
+
+    it('returns validated: false when no GitHub config is set', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await getGithub(makeReq({ groupId: group.groupId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json.mock.calls[0][0].validated).toBe(false);
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await getGithub(makeReq({ groupId: 'grp_none' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+  });
+});

--- a/backend/tests/jiraIntegration.test.js
+++ b/backend/tests/jiraIntegration.test.js
@@ -1,0 +1,428 @@
+/**
+ * JIRA Integration Integration Tests
+ *
+ * Tests for groupIntegrations.js controller:
+ *   configureJira (f13, f14, f15, f25) — validate credentials + project key, store config
+ *   getJira                             — retrieve stored JIRA config
+ *
+ * Axios is mocked so no real HTTP calls are made.
+ *
+ * Run: npm test -- jiraIntegration.test.js
+ */
+
+const mongoose = require('mongoose');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('groupIntegrations — JIRA (f13-f15, f25)', () => {
+  const mongoUri =
+    process.env.MONGODB_TEST_URI ||
+    'mongodb://localhost:27017/senior-app-test-jira-integration';
+
+  let Group;
+  let SyncErrorLog;
+  let configureJira;
+  let getJira;
+
+  // ── Helpers ────────────────────────────────────────────────────────────────────
+
+  const makeReq = (params = {}, body = {}, userOverrides = {}) => ({
+    params,
+    body,
+    user: { userId: 'usr_leader', role: 'student', ...userOverrides },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent' },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  const makeGroup = (overrides = {}) =>
+    Group.create({
+      groupName: `Test Group ${Date.now()}-${Math.random()}`,
+      leaderId: 'usr_leader',
+      status: 'active',
+      ...overrides,
+    });
+
+  const validJiraBody = (overrides = {}) => ({
+    jira_url: 'https://mycompany.atlassian.net',
+    jira_username: 'user@example.com',
+    jira_token: 'jira_token_abc',
+    project_key: 'PROJ',
+    ...overrides,
+  });
+
+  // JIRA API mock helpers
+  const mockValidCredentials = () => {
+    axios.get.mockResolvedValueOnce({ status: 200, data: { accountId: 'acc_123' } });
+  };
+
+  const mockValidProject = (key = 'PROJ') => {
+    axios.get.mockResolvedValueOnce({
+      status: 200,
+      data: { key, name: 'My Project', id: '10001' },
+    });
+  };
+
+  const mockInvalidCredentials = (status = 401) => {
+    const err = new Error('Unauthorized');
+    err.response = { status };
+    axios.get.mockRejectedValueOnce(err);
+  };
+
+  const mockProjectNotFound = () => {
+    const err = new Error('Not Found');
+    err.response = { status: 404 };
+    axios.get.mockRejectedValueOnce(err);
+  };
+
+  const mockNetworkFailure = (times = 3) => {
+    const err = new Error('ETIMEDOUT');
+    for (let i = 0; i < times; i++) {
+      axios.get.mockRejectedValueOnce(err);
+    }
+  };
+
+  // ── Setup / teardown ───────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+
+    Group = require('../src/models/Group');
+    SyncErrorLog = require('../src/models/SyncErrorLog');
+    ({ configureJira, getJira } = require('../src/controllers/groupIntegrations'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([Group.deleteMany({}), SyncErrorLog.deleteMany({})]);
+    jest.clearAllMocks();
+  });
+
+  // ── configureJira happy path ───────────────────────────────────────────────────
+
+  describe('POST /groups/:groupId/jira — configureJira', () => {
+    it('returns 200 with jira_url, jira_project, project_key, validated: true on success', async () => {
+      mockValidCredentials();
+      mockValidProject('PROJ');
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.validated).toBe(true);
+      expect(body.jira_url).toBe('https://mycompany.atlassian.net');
+      expect(body.project_key).toBe('PROJ');
+      expect(body.jira_project).toBe('My Project');
+    });
+
+    it('f25: stores jiraUrl, jiraUsername, jiraToken, projectKey in D2 group record', async () => {
+      mockValidCredentials();
+      mockValidProject();
+
+      const group = await makeGroup();
+
+      await configureJira(
+        makeReq({ groupId: group.groupId }, validJiraBody()),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      expect(updated.jiraUrl).toBe('https://mycompany.atlassian.net');
+      expect(updated.jiraUsername).toBe('user@example.com');
+      expect(updated.jiraToken).toBe('jira_token_abc');
+      expect(updated.projectKey).toBe('PROJ');
+      expect(updated.jiraProject).toBe('My Project');
+    });
+
+    it('f14: makes credentials call to /rest/api/3/myself', async () => {
+      mockValidCredentials();
+      mockValidProject();
+
+      const group = await makeGroup();
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), makeRes());
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://mycompany.atlassian.net/rest/api/3/myself',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: expect.stringMatching(/^Basic /) }),
+        })
+      );
+    });
+
+    it('f15: makes project validation call to /rest/api/3/project/:key', async () => {
+      mockValidCredentials();
+      mockValidProject('PROJ');
+
+      const group = await makeGroup();
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), makeRes());
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://mycompany.atlassian.net/rest/api/3/project/PROJ',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: expect.stringMatching(/^Basic /) }),
+        })
+      );
+    });
+
+    it('strips trailing slash from jira_url before storing', async () => {
+      mockValidCredentials();
+      mockValidProject();
+
+      const group = await makeGroup();
+      await configureJira(
+        makeReq(
+          { groupId: group.groupId },
+          validJiraBody({ jira_url: 'https://mycompany.atlassian.net/' })
+        ),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      expect(updated.jiraUrl).toBe('https://mycompany.atlassian.net');
+    });
+
+    // ── 400 validation ───────────────────────────────────────────────────────────
+
+    it('returns 400 MISSING_JIRA_URL when jira_url is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(
+        makeReq({ groupId: group.groupId }, validJiraBody({ jira_url: undefined })),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_JIRA_URL');
+    });
+
+    it('returns 400 MISSING_JIRA_USERNAME when jira_username is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(
+        makeReq({ groupId: group.groupId }, validJiraBody({ jira_username: undefined })),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_JIRA_USERNAME');
+    });
+
+    it('returns 400 MISSING_JIRA_TOKEN when jira_token is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(
+        makeReq({ groupId: group.groupId }, validJiraBody({ jira_token: undefined })),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_JIRA_TOKEN');
+    });
+
+    it('returns 400 MISSING_PROJECT_KEY when project_key is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(
+        makeReq({ groupId: group.groupId }, validJiraBody({ project_key: undefined })),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_PROJECT_KEY');
+    });
+
+    // ── 403 / 404 ────────────────────────────────────────────────────────────────
+
+    it('returns 403 FORBIDDEN when caller is not the group leader', async () => {
+      const group = await makeGroup({ leaderId: 'usr_other' });
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('FORBIDDEN');
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: 'grp_none' }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+
+    // ── 422 invalid credentials / project ────────────────────────────────────────
+
+    it('returns 422 INVALID_JIRA_CREDENTIALS when JIRA returns 401', async () => {
+      mockInvalidCredentials(401);
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_JIRA_CREDENTIALS');
+    });
+
+    it('returns 422 INVALID_JIRA_CREDENTIALS when JIRA returns 403', async () => {
+      mockInvalidCredentials(403);
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_JIRA_CREDENTIALS');
+    });
+
+    it('returns 422 INVALID_PROJECT_KEY when project lookup returns 404', async () => {
+      mockValidCredentials();
+      mockProjectNotFound();
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(
+        makeReq({ groupId: group.groupId }, validJiraBody({ project_key: 'GHOST' })),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_PROJECT_KEY');
+    });
+
+    // ── 503 retry exhaustion ──────────────────────────────────────────────────────
+
+    it('returns 503 JIRA_API_UNAVAILABLE after 3 network failures on credentials check', async () => {
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json.mock.calls[0][0].code).toBe('JIRA_API_UNAVAILABLE');
+    });
+
+    it('writes SyncErrorLog entry after credentials check retry exhaustion', async () => {
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), makeRes());
+
+      const errLog = await SyncErrorLog.findOne({ service: 'jira', groupId: group.groupId });
+      expect(errLog).not.toBeNull();
+      expect(errLog.attempts).toBe(3);
+    });
+
+    it('returns 503 JIRA_API_UNAVAILABLE after 3 network failures on project lookup', async () => {
+      mockValidCredentials();
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), res);
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json.mock.calls[0][0].code).toBe('JIRA_API_UNAVAILABLE');
+    });
+
+    it('writes SyncErrorLog entry after project lookup retry exhaustion', async () => {
+      mockValidCredentials();
+      mockNetworkFailure(3);
+
+      const group = await makeGroup();
+
+      await configureJira(makeReq({ groupId: group.groupId }, validJiraBody()), makeRes());
+
+      const errLog = await SyncErrorLog.findOne({ service: 'jira', groupId: group.groupId });
+      expect(errLog).not.toBeNull();
+      expect(errLog.attempts).toBe(3);
+    });
+  });
+
+  // ── getJira ────────────────────────────────────────────────────────────────────
+
+  describe('GET /groups/:groupId/jira — getJira', () => {
+    it('returns 200 with group_id, jira_url, jira_project, project_key, validated: true when config is set', async () => {
+      const group = await makeGroup({
+        jiraUrl: 'https://mycompany.atlassian.net',
+        jiraProject: 'My Project',
+        projectKey: 'PROJ',
+        jiraUsername: 'user@example.com',
+        jiraToken: 'tok_secret',
+      });
+
+      const res = makeRes();
+      await getJira(makeReq({ groupId: group.groupId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.group_id).toBe(group.groupId);
+      expect(body.jira_url).toBe('https://mycompany.atlassian.net');
+      expect(body.jira_project).toBe('My Project');
+      expect(body.project_key).toBe('PROJ');
+      expect(body.validated).toBe(true);
+    });
+
+    it('does not expose jiraToken in the response', async () => {
+      const group = await makeGroup({
+        jiraUrl: 'https://mycompany.atlassian.net',
+        jiraToken: 'tok_secret',
+      });
+
+      const res = makeRes();
+      await getJira(makeReq({ groupId: group.groupId }), res);
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.jiraToken).toBeUndefined();
+    });
+
+    it('returns validated: false when no JIRA config is set', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await getJira(makeReq({ groupId: group.groupId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json.mock.calls[0][0].validated).toBe(false);
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await getJira(makeReq({ groupId: 'grp_none' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+  });
+});

--- a/backend/tests/memberInvitation.test.js
+++ b/backend/tests/memberInvitation.test.js
@@ -1,0 +1,641 @@
+/**
+ * Member Invitation Integration Tests
+ *
+ * Tests for groupMembers.js controller:
+ *   addMember            (f05, f19) — leader invites student, writes D2 record
+ *   dispatchNotification (f06)      — dispatch invitation via Notification Service
+ *   membershipDecision   (f07, f08) — student accepts / rejects invitation
+ *   getMembers                      — retrieve current member list from D2
+ *
+ * Run: npm test -- memberInvitation.test.js
+ */
+
+const mongoose = require('mongoose');
+
+// Mock the Notification Service so tests never hit a real HTTP endpoint
+jest.mock('../src/services/notificationService');
+
+describe('groupMembers controller', () => {
+  const mongoUri =
+    process.env.MONGODB_TEST_URI ||
+    'mongodb://localhost:27017/senior-app-test-member-invitation';
+
+  let Group;
+  let GroupMembership;
+  let MemberInvitation;
+  let SyncErrorLog;
+  let User;
+  let notificationService;
+  let addMember;
+  let getMembers;
+  let dispatchNotification;
+  let membershipDecision;
+
+  // ── Helpers ────────────────────────────────────────────────────────────────────
+
+  const makeReq = (params = {}, body = {}, userOverrides = {}) => ({
+    params,
+    body,
+    user: { userId: 'usr_leader', role: 'student', ...userOverrides },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent' },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  const makeGroup = (overrides = {}) =>
+    Group.create({
+      groupName: `Test Group ${Date.now()}-${Math.random()}`,
+      leaderId: 'usr_leader',
+      status: 'active',
+      ...overrides,
+    });
+
+  const makeStudent = (overrides = {}) =>
+    User.create({
+      userId: `usr_stu_${Date.now()}_${Math.random()}`,
+      email: `student_${Date.now()}_${Math.random()}@test.com`,
+      hashedPassword: 'hashed',
+      role: 'student',
+      accountStatus: 'active',
+      ...overrides,
+    });
+
+  // ── Setup / teardown ───────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
+    await mongoose.connect(mongoUri);
+    await mongoose.connection.dropDatabase();
+
+    Group = require('../src/models/Group');
+    GroupMembership = require('../src/models/GroupMembership');
+    MemberInvitation = require('../src/models/MemberInvitation');
+    SyncErrorLog = require('../src/models/SyncErrorLog');
+    User = require('../src/models/User');
+    notificationService = require('../src/services/notificationService');
+    ({ addMember, getMembers, dispatchNotification, membershipDecision } =
+      require('../src/controllers/groupMembers'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      Group.deleteMany({}),
+      GroupMembership.deleteMany({}),
+      MemberInvitation.deleteMany({}),
+      SyncErrorLog.deleteMany({}),
+      User.deleteMany({}),
+    ]);
+    jest.clearAllMocks();
+  });
+
+  // ── addMember (f05, f19) ───────────────────────────────────────────────────────
+
+  describe('POST /groups/:groupId/members — addMember (f05, f19)', () => {
+    it('returns 201 with invitation_id, group_id, invitee_id, invited_by, status pending', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      const req = makeReq({ groupId: group.groupId }, { invitee_id: student.userId });
+      const res = makeRes();
+
+      await addMember(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.invitation_id).toMatch(/^inv_/);
+      expect(body.group_id).toBe(group.groupId);
+      expect(body.invitee_id).toBe(student.userId);
+      expect(body.invited_by).toBe('usr_leader');
+      expect(body.status).toBe('pending');
+      expect(body.created_at).toBeDefined();
+    });
+
+    it('f19: writes a pending MemberInvitation record to D2', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await addMember(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeRes()
+      );
+
+      const inv = await MemberInvitation.findOne({ groupId: group.groupId, inviteeId: student.userId });
+      expect(inv).not.toBeNull();
+      expect(inv.status).toBe('pending');
+      expect(inv.invitedBy).toBe('usr_leader');
+    });
+
+    it('f19: also writes a pending GroupMembership record to D2', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await addMember(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeRes()
+      );
+
+      const mem = await GroupMembership.findOne({ groupId: group.groupId, studentId: student.userId });
+      expect(mem).not.toBeNull();
+      expect(mem.status).toBe('pending');
+    });
+
+    it('returns 400 MISSING_INVITEE_ID when invitee_id is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await addMember(makeReq({ groupId: group.groupId }, {}), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_INVITEE_ID');
+    });
+
+    it('returns 400 MISSING_INVITEE_ID when invitee_id is whitespace only', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await addMember(makeReq({ groupId: group.groupId }, { invitee_id: '   ' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_INVITEE_ID');
+    });
+
+    it('returns 403 FORBIDDEN when caller is not the group leader', async () => {
+      const group = await makeGroup({ leaderId: 'usr_other_leader' });
+      const student = await makeStudent();
+      const res = makeRes();
+
+      await addMember(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }, { userId: 'usr_leader' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('FORBIDDEN');
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const student = await makeStudent();
+      const res = makeRes();
+
+      await addMember(makeReq({ groupId: 'grp_nonexistent' }, { invitee_id: student.userId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+
+    it('returns 404 STUDENT_NOT_FOUND when invitee does not exist', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await addMember(makeReq({ groupId: group.groupId }, { invitee_id: 'usr_ghost' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('STUDENT_NOT_FOUND');
+    });
+
+    it('returns 409 ALREADY_INVITED when the student has already been invited', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      await addMember(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeRes()
+      );
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json.mock.calls[0][0].code).toBe('ALREADY_INVITED');
+    });
+
+    it('returns 409 STUDENT_ALREADY_IN_GROUP when the student is approved in another group', async () => {
+      const group = await makeGroup();
+      const otherGroup = await makeGroup({ leaderId: 'usr_leader', groupName: `Other ${Date.now()}` });
+      const student = await makeStudent();
+
+      // Student already approved in another group
+      await GroupMembership.create({
+        groupId: otherGroup.groupId,
+        studentId: student.userId,
+        status: 'approved',
+      });
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json.mock.calls[0][0].code).toBe('STUDENT_ALREADY_IN_GROUP');
+    });
+  });
+
+  // ── getMembers ─────────────────────────────────────────────────────────────────
+
+  describe('GET /groups/:groupId/members — getMembers', () => {
+    it('returns 200 with group_id and members array', async () => {
+      const group = await makeGroup();
+      group.members.push({ userId: 'usr_m1', role: 'member', status: 'accepted', joinedAt: new Date() });
+      await group.save();
+
+      const res = makeRes();
+      await getMembers(makeReq({ groupId: group.groupId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.group_id).toBe(group.groupId);
+      expect(body.members).toHaveLength(1);
+      expect(body.members[0].userId).toBe('usr_m1');
+    });
+
+    it('returns 200 with empty members array when group has no members', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await getMembers(makeReq({ groupId: group.groupId }), res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json.mock.calls[0][0].members).toHaveLength(0);
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await getMembers(makeReq({ groupId: 'grp_none' }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+  });
+
+  // ── dispatchNotification (f06) ─────────────────────────────────────────────────
+
+  describe('POST /groups/:groupId/notifications — dispatchNotification (f06)', () => {
+    it('returns 200 with notification_id and notified_at when service succeeds', async () => {
+      notificationService.dispatchInvitationNotification.mockResolvedValue({
+        notification_id: 'notif_abc123',
+      });
+
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await MemberInvitation.create({
+        groupId: group.groupId,
+        inviteeId: student.userId,
+        invitedBy: 'usr_leader',
+      });
+
+      const res = makeRes();
+      await dispatchNotification(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.notification_id).toBe('notif_abc123');
+      expect(body.invitee_id).toBe(student.userId);
+      expect(body.notified_at).toBeDefined();
+    });
+
+    it('f06: sets invitation.notifiedAt and notificationId after successful dispatch', async () => {
+      notificationService.dispatchInvitationNotification.mockResolvedValue({
+        notification_id: 'notif_xyz',
+      });
+
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await MemberInvitation.create({
+        groupId: group.groupId,
+        inviteeId: student.userId,
+        invitedBy: 'usr_leader',
+      });
+
+      await dispatchNotification(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeRes()
+      );
+
+      const inv = await MemberInvitation.findOne({ groupId: group.groupId, inviteeId: student.userId });
+      expect(inv.notificationId).toBe('notif_xyz');
+      expect(inv.notifiedAt).not.toBeNull();
+    });
+
+    it('returns 503 NOTIFICATION_SERVICE_UNAVAILABLE after 3 failures and writes SyncErrorLog', async () => {
+      notificationService.dispatchInvitationNotification.mockRejectedValue(
+        new Error('Connection timeout')
+      );
+
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await MemberInvitation.create({
+        groupId: group.groupId,
+        inviteeId: student.userId,
+        invitedBy: 'usr_leader',
+      });
+
+      const res = makeRes();
+      await dispatchNotification(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json.mock.calls[0][0].code).toBe('NOTIFICATION_SERVICE_UNAVAILABLE');
+
+      const errLog = await SyncErrorLog.findOne({ service: 'notification', groupId: group.groupId });
+      expect(errLog).not.toBeNull();
+      expect(errLog.attempts).toBe(3);
+      expect(errLog.lastError).toBe('Connection timeout');
+    });
+
+    it('returns 400 MISSING_INVITEE_ID when invitee_id is absent', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await dispatchNotification(makeReq({ groupId: group.groupId }, {}), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_INVITEE_ID');
+    });
+
+    it('returns 403 FORBIDDEN when caller is not the group leader', async () => {
+      const group = await makeGroup({ leaderId: 'usr_other' });
+      const student = await makeStudent();
+      const res = makeRes();
+
+      await dispatchNotification(
+        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json.mock.calls[0][0].code).toBe('FORBIDDEN');
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const res = makeRes();
+
+      await dispatchNotification(
+        makeReq({ groupId: 'grp_none' }, { invitee_id: 'usr_x' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+
+    it('returns 404 INVITATION_NOT_FOUND when no pending invitation exists', async () => {
+      const group = await makeGroup();
+      const res = makeRes();
+
+      await dispatchNotification(
+        makeReq({ groupId: group.groupId }, { invitee_id: 'usr_no_invite' }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('INVITATION_NOT_FOUND');
+    });
+  });
+
+  // ── membershipDecision (f07, f08) ──────────────────────────────────────────────
+
+  describe('POST /groups/:groupId/membership-decisions — membershipDecision (f07, f08)', () => {
+    const setupInvitation = async (groupId, studentId) => {
+      await MemberInvitation.create({ groupId, inviteeId: studentId, invitedBy: 'usr_leader' });
+      await GroupMembership.create({ groupId, studentId, status: 'pending' });
+    };
+
+    it('returns 200 with invitation_id, group_id, student_id, decision, decided_at on accept', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      const res = makeRes();
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      const body = res.json.mock.calls[0][0];
+      expect(body.invitation_id).toMatch(/^inv_/);
+      expect(body.group_id).toBe(group.groupId);
+      expect(body.student_id).toBe(student.userId);
+      expect(body.decision).toBe('accepted');
+      expect(body.decided_at).toBeDefined();
+    });
+
+    it('f08: accepted decision updates MemberInvitation status to accepted', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        makeRes()
+      );
+
+      const inv = await MemberInvitation.findOne({ groupId: group.groupId, inviteeId: student.userId });
+      expect(inv.status).toBe('accepted');
+      expect(inv.decidedAt).not.toBeNull();
+    });
+
+    it('f08: accepted decision updates GroupMembership status to approved', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        makeRes()
+      );
+
+      const mem = await GroupMembership.findOne({ groupId: group.groupId, studentId: student.userId });
+      expect(mem.status).toBe('approved');
+    });
+
+    it('f08: accepted decision adds student to Group.members with role member and status accepted', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      const member = updated.members.find((m) => m.userId === student.userId);
+      expect(member).toBeDefined();
+      expect(member.role).toBe('member');
+      expect(member.status).toBe('accepted');
+      expect(member.joinedAt).toBeDefined();
+    });
+
+    it('f08: rejected decision updates MemberInvitation status to rejected', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'rejected' }, { userId: student.userId }),
+        makeRes()
+      );
+
+      const inv = await MemberInvitation.findOne({ groupId: group.groupId, inviteeId: student.userId });
+      expect(inv.status).toBe('rejected');
+    });
+
+    it('f08: rejected decision updates GroupMembership status to rejected', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'rejected' }, { userId: student.userId }),
+        makeRes()
+      );
+
+      const mem = await GroupMembership.findOne({ groupId: group.groupId, studentId: student.userId });
+      expect(mem.status).toBe('rejected');
+    });
+
+    it('f08: rejected decision does NOT add student to Group.members', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'rejected' }, { userId: student.userId }),
+        makeRes()
+      );
+
+      const updated = await Group.findOne({ groupId: group.groupId });
+      const member = updated.members.find((m) => m.userId === student.userId);
+      expect(member).toBeUndefined();
+    });
+
+    it('returns 400 INVALID_DECISION when decision is missing', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      const res = makeRes();
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, {}, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_DECISION');
+    });
+
+    it('returns 400 INVALID_DECISION when decision value is unrecognized', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await setupInvitation(group.groupId, student.userId);
+
+      const res = makeRes();
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'maybe' }, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json.mock.calls[0][0].code).toBe('INVALID_DECISION');
+    });
+
+    it('returns 404 GROUP_NOT_FOUND when group does not exist', async () => {
+      const student = await makeStudent();
+      const res = makeRes();
+
+      await membershipDecision(
+        makeReq({ groupId: 'grp_none' }, { decision: 'accepted' }, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
+    });
+
+    it('returns 404 INVITATION_NOT_FOUND when no invitation exists for the student', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      const res = makeRes();
+
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json.mock.calls[0][0].code).toBe('INVITATION_NOT_FOUND');
+    });
+
+    it('returns 409 DECISION_ALREADY_MADE when invitation is no longer pending', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+      await MemberInvitation.create({
+        groupId: group.groupId,
+        inviteeId: student.userId,
+        invitedBy: 'usr_leader',
+        status: 'accepted',
+        decidedAt: new Date(),
+      });
+
+      const res = makeRes();
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json.mock.calls[0][0].code).toBe('DECISION_ALREADY_MADE');
+    });
+
+    it('f08: auto-denies and returns 409 STUDENT_ALREADY_IN_GROUP when student is approved elsewhere', async () => {
+      const group = await makeGroup();
+      const otherGroup = await makeGroup({ groupName: `Other ${Date.now()}`, leaderId: 'usr_leader' });
+      const student = await makeStudent();
+
+      // Student approved in another group
+      await GroupMembership.create({ groupId: otherGroup.groupId, studentId: student.userId, status: 'approved' });
+
+      await setupInvitation(group.groupId, student.userId);
+
+      const res = makeRes();
+      await membershipDecision(
+        makeReq({ groupId: group.groupId }, { decision: 'accepted' }, { userId: student.userId }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      const body = res.json.mock.calls[0][0];
+      expect(body.code).toBe('STUDENT_ALREADY_IN_GROUP');
+      expect(body.auto_denied).toBe(true);
+
+      // Invitation is auto-rejected in D2
+      const inv = await MemberInvitation.findOne({ groupId: group.groupId, inviteeId: student.userId });
+      expect(inv.status).toBe('rejected');
+    });
+  });
+});


### PR DESCRIPTION
Add update_group action to PATCH /groups/:groupId/override. Coordinators can now submit arbitrary group field updates via an updates{} payload, which is validated against known fields, applied directly to the D2 group record, and recorded in an override log entry with reason and coordinator_id. Extends the Override model to support the new action and adds 9 integration tests covering happy-path and all error cases.