### PR TITLE
34 fs add team members UI endpoint

### DIFF
--- a/backend/src/controllers/groupMembers.js
+++ b/backend/src/controllers/groupMembers.js
@@ -63,7 +63,7 @@ const addMember = async (req, res) => {
       }
 
       const existingApproved = await GroupMembership.findOne({
-        studentId: inviteeId,
+        studentId: invitee.userId,
         status: 'approved',
         groupId: { $ne: groupId },
       });
@@ -72,7 +72,7 @@ const addMember = async (req, res) => {
         continue;
       }
 
-      const existing = await MemberInvitation.findOne({ groupId, inviteeId });
+      const existing = await MemberInvitation.findOne({ groupId, inviteeId: invitee.userId });
       if (existing) {
         errors.push({ student_id: inviteeId, code: 'ALREADY_INVITED', message: 'Student has already been invited to this group' });
         continue;
@@ -81,13 +81,13 @@ const addMember = async (req, res) => {
       // f19: write pending member record to D2
       const invitation = await MemberInvitation.create({
         groupId,
-        inviteeId,
+        inviteeId: invitee.userId,
         invitedBy: req.user.userId,
       });
 
       await GroupMembership.create({
         groupId,
-        studentId: inviteeId,
+        studentId: invitee.userId,
         status: 'pending',
       });
 
@@ -126,7 +126,7 @@ const addMember = async (req, res) => {
 
       added.push({
         invitation_id: invitation.invitationId,
-        invitee_id: inviteeId,
+        invitee_id: invitee.userId,
         status: 'pending',
         notified: !!notificationId,
       });
@@ -355,4 +355,38 @@ const membershipDecision = async (req, res) => {
   }
 };
 
-module.exports = { addMember, getMembers, dispatchNotification, membershipDecision };
+/**
+ * GET /groups/pending-invitation
+ *
+ * Returns the current user's pending group invitation with group details.
+ * Used by invited students to discover and navigate to their group.
+ */
+const getMyPendingInvitation = async (req, res) => {
+  try {
+    const studentId = req.user.userId;
+
+    const invitation = await MemberInvitation.findOne({ inviteeId: studentId, status: 'pending' });
+    if (!invitation) {
+      return res.status(404).json({ code: 'NO_PENDING_INVITATION', message: 'No pending invitation found' });
+    }
+
+    const group = await Group.findOne({ groupId: invitation.groupId });
+    if (!group) {
+      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    }
+
+    return res.status(200).json({
+      invitation_id: invitation.invitationId,
+      group_id: invitation.groupId,
+      group_name: group.groupName,
+      invited_by: invitation.invitedBy,
+      status: invitation.status,
+      created_at: invitation.createdAt,
+    });
+  } catch (err) {
+    console.error('getMyPendingInvitation error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+module.exports = { addMember, getMembers, dispatchNotification, membershipDecision, getMyPendingInvitation };

--- a/backend/src/controllers/groupMembers.js
+++ b/backend/src/controllers/groupMembers.js
@@ -11,25 +11,28 @@ const MAX_RETRY_ATTEMPTS = 3;
 /**
  * POST /groups/:groupId/members
  *
- * Process 2.3 — Team leader invites a student to the group.
+ * Process 2.3 — Team leader invites one or more students to the group.
  *
  * DFD flows:
  *   f05 — Student (leader) → 2.3 (add member request)
+ *   f06 — 2.3 → 2.4 (forward invitee IDs + group ID for notification dispatch)
  *   f19 — 2.3 → D2 (write pending member record)
+ *   f32 — D2 → 2.3 (read current group data before processing)
  *
  * Business rule: a student may only belong to one active group at a time.
- * If the invitee already has an approved membership elsewhere, the request
- * is auto-denied with 409 STUDENT_ALREADY_IN_GROUP.
+ * Per-student errors are collected and returned alongside successes so that
+ * a batch request with mixed validity still adds the valid students.
  */
 const addMember = async (req, res) => {
   try {
     const { groupId } = req.params;
-    const { invitee_id } = req.body;
+    const { student_ids } = req.body;
 
-    if (!invitee_id || typeof invitee_id !== 'string' || !invitee_id.trim()) {
-      return res.status(400).json({ code: 'MISSING_INVITEE_ID', message: 'invitee_id is required' });
+    if (!Array.isArray(student_ids) || student_ids.length === 0) {
+      return res.status(400).json({ code: 'MISSING_STUDENT_IDS', message: 'student_ids must be a non-empty array' });
     }
 
+    // f32: read current group data from D2
     const group = await Group.findOne({ groupId });
     if (!group) {
       return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
@@ -39,53 +42,101 @@ const addMember = async (req, res) => {
       return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can invite members' });
     }
 
-    const invitee = await User.findOne({ userId: invitee_id.trim() });
-    if (!invitee) {
-      return res.status(404).json({ code: 'STUDENT_NOT_FOUND', message: 'Invitee not found' });
-    }
+    const added = [];
+    const errors = [];
 
-    // Auto-denial: one active group per student (f08 pre-check)
-    const existingApproved = await GroupMembership.findOne({
-      studentId: invitee_id.trim(),
-      status: 'approved',
-      groupId: { $ne: groupId },
-    });
-    if (existingApproved) {
-      return res.status(409).json({
-        code: 'STUDENT_ALREADY_IN_GROUP',
-        message: 'Student already belongs to an active group and cannot be invited to another',
+    for (const rawId of student_ids) {
+      const inviteeId = typeof rawId === 'string' ? rawId.trim() : '';
+
+      if (!inviteeId) {
+        errors.push({ student_id: rawId, code: 'INVALID_STUDENT_ID', message: 'Student ID must be a non-empty string' });
+        continue;
+      }
+
+      // Accept either userId or email address
+      const invitee = await User.findOne({
+        $or: [{ userId: inviteeId }, { email: inviteeId.toLowerCase() }],
+      });
+      if (!invitee) {
+        errors.push({ student_id: inviteeId, code: 'STUDENT_NOT_FOUND', message: 'Student not found' });
+        continue;
+      }
+
+      const existingApproved = await GroupMembership.findOne({
+        studentId: inviteeId,
+        status: 'approved',
+        groupId: { $ne: groupId },
+      });
+      if (existingApproved) {
+        errors.push({ student_id: inviteeId, code: 'STUDENT_ALREADY_IN_GROUP', message: 'Student already belongs to an active group' });
+        continue;
+      }
+
+      const existing = await MemberInvitation.findOne({ groupId, inviteeId });
+      if (existing) {
+        errors.push({ student_id: inviteeId, code: 'ALREADY_INVITED', message: 'Student has already been invited to this group' });
+        continue;
+      }
+
+      // f19: write pending member record to D2
+      const invitation = await MemberInvitation.create({
+        groupId,
+        inviteeId,
+        invitedBy: req.user.userId,
+      });
+
+      await GroupMembership.create({
+        groupId,
+        studentId: inviteeId,
+        status: 'pending',
+      });
+
+      // f06: forward to process 2.4 — dispatch invitation notification (non-fatal)
+      let notificationId = null;
+      let lastError;
+      for (let attempt = 1; attempt <= MAX_RETRY_ATTEMPTS; attempt++) {
+        try {
+          const notifResult = await dispatchInvitationNotification({
+            groupId,
+            groupName: group.groupName,
+            inviteeId,
+            invitedBy: req.user.userId,
+          });
+          notificationId = notifResult.notification_id || null;
+          lastError = null;
+          break;
+        } catch (err) {
+          lastError = err;
+        }
+      }
+
+      if (lastError) {
+        await SyncErrorLog.create({
+          service: 'notification',
+          groupId,
+          actorId: req.user.userId,
+          attempts: MAX_RETRY_ATTEMPTS,
+          lastError: lastError.message,
+        });
+      } else if (notificationId) {
+        invitation.notifiedAt = new Date();
+        invitation.notificationId = notificationId;
+        await invitation.save();
+      }
+
+      added.push({
+        invitation_id: invitation.invitationId,
+        invitee_id: inviteeId,
+        status: 'pending',
+        notified: !!notificationId,
       });
     }
-
-    // Check for existing invitation to this group
-    const existing = await MemberInvitation.findOne({ groupId, inviteeId: invitee_id.trim() });
-    if (existing) {
-      return res.status(409).json({
-        code: 'ALREADY_INVITED',
-        message: 'Student has already been invited to this group',
-      });
-    }
-
-    // f19: write pending member record to D2
-    const invitation = await MemberInvitation.create({
-      groupId,
-      inviteeId: invitee_id.trim(),
-      invitedBy: req.user.userId,
-    });
-
-    await GroupMembership.create({
-      groupId,
-      studentId: invitee_id.trim(),
-      status: 'pending',
-    });
 
     return res.status(201).json({
-      invitation_id: invitation.invitationId,
+      added,
+      ...(errors.length > 0 && { errors }),
       group_id: groupId,
-      invitee_id: invitation.inviteeId,
-      invited_by: invitation.invitedBy,
-      status: invitation.status,
-      created_at: invitation.createdAt,
+      total_members: group.members.length + added.length,
     });
   } catch (err) {
     console.error('addMember error:', err);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -2,11 +2,14 @@ const express = require('express');
 const router = express.Router();
 const { authMiddleware, roleMiddleware } = require('../middleware/auth');
 const { forwardApprovalResults, createGroup, getGroup, createMemberRequest, decideMemberRequest, coordinatorOverride } = require('../controllers/groups');
-const { addMember, getMembers, dispatchNotification, membershipDecision } = require('../controllers/groupMembers');
+const { addMember, getMembers, dispatchNotification, membershipDecision, getMyPendingInvitation } = require('../controllers/groupMembers');
 const { configureGithub, getGithub, configureJira, getJira } = require('../controllers/groupIntegrations');
 
 // POST /api/v1/groups — Process 2.1 + 2.2: create, validate, persist, forward to 2.5
 router.post('/', authMiddleware, roleMiddleware(['student']), createGroup);
+
+// GET /api/v1/groups/pending-invitation — return current user's pending invitation with group info
+router.get('/pending-invitation', authMiddleware, getMyPendingInvitation);
 
 // GET /api/v1/groups/:groupId — Process 2.2: retrieve validated group record from D2
 router.get('/:groupId', authMiddleware, getGroup);

--- a/backend/tests/memberInvitation.test.js
+++ b/backend/tests/memberInvitation.test.js
@@ -101,26 +101,64 @@ describe('groupMembers controller', () => {
     jest.clearAllMocks();
   });
 
-  // ── addMember (f05, f19) ───────────────────────────────────────────────────────
+  // ── addMember (f05, f06, f19, f32) ───────────────────────────────────────────
 
-  describe('POST /groups/:groupId/members — addMember (f05, f19)', () => {
-    it('returns 201 with invitation_id, group_id, invitee_id, invited_by, status pending', async () => {
+  describe('POST /groups/:groupId/members — addMember (f05, f06, f19, f32)', () => {
+    beforeEach(() => {
+      // Default: notification service succeeds
+      notificationService.dispatchInvitationNotification = jest.fn().mockResolvedValue({ notification_id: 'notif_test' });
+    });
+
+    it('returns 201 with added[], group_id, total_members for a single valid student', async () => {
       const group = await makeGroup();
       const student = await makeStudent();
 
-      const req = makeReq({ groupId: group.groupId }, { invitee_id: student.userId });
+      const req = makeReq({ groupId: group.groupId }, { student_ids: [student.userId] });
       const res = makeRes();
 
       await addMember(req, res);
 
       expect(res.status).toHaveBeenCalledWith(201);
       const body = res.json.mock.calls[0][0];
-      expect(body.invitation_id).toMatch(/^inv_/);
       expect(body.group_id).toBe(group.groupId);
-      expect(body.invitee_id).toBe(student.userId);
-      expect(body.invited_by).toBe('usr_leader');
-      expect(body.status).toBe('pending');
-      expect(body.created_at).toBeDefined();
+      expect(body.total_members).toBeDefined();
+      expect(Array.isArray(body.added)).toBe(true);
+      expect(body.added).toHaveLength(1);
+      expect(body.added[0].invitation_id).toMatch(/^inv_/);
+      expect(body.added[0].invitee_id).toBe(student.userId);
+      expect(body.added[0].status).toBe('pending');
+    });
+
+    it('returns 201 with added[] for multiple valid students', async () => {
+      const group = await makeGroup();
+      const s1 = await makeStudent();
+      const s2 = await makeStudent();
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { student_ids: [s1.userId, s2.userId] }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.added).toHaveLength(2);
+      expect(body.total_members).toBe(group.members.length + 2);
+    });
+
+    it('f32: reads current group data from D2 before processing', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
+        res
+      );
+
+      // total_members reflects group.members.length at time of request
+      const body = res.json.mock.calls[0][0];
+      expect(body.total_members).toBe(group.members.length + 1);
     });
 
     it('f19: writes a pending MemberInvitation record to D2', async () => {
@@ -128,7 +166,7 @@ describe('groupMembers controller', () => {
       const student = await makeStudent();
 
       await addMember(
-        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
         makeRes()
       );
 
@@ -143,7 +181,7 @@ describe('groupMembers controller', () => {
       const student = await makeStudent();
 
       await addMember(
-        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
         makeRes()
       );
 
@@ -152,24 +190,68 @@ describe('groupMembers controller', () => {
       expect(mem.status).toBe('pending');
     });
 
-    it('returns 400 MISSING_INVITEE_ID when invitee_id is absent', async () => {
+    it('f06: dispatches invitation notification for each added student', async () => {
+      const group = await makeGroup();
+      const s1 = await makeStudent();
+      const s2 = await makeStudent();
+
+      await addMember(
+        makeReq({ groupId: group.groupId }, { student_ids: [s1.userId, s2.userId] }),
+        makeRes()
+      );
+
+      expect(notificationService.dispatchInvitationNotification).toHaveBeenCalledTimes(2);
+    });
+
+    it('f06: marks added entry notified:true when dispatch succeeds', async () => {
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
+        res
+      );
+
+      const body = res.json.mock.calls[0][0];
+      expect(body.added[0].notified).toBe(true);
+    });
+
+    it('f06: still adds member and marks notified:false when notification service fails', async () => {
+      notificationService.dispatchInvitationNotification = jest.fn().mockRejectedValue(new Error('service down'));
+      const group = await makeGroup();
+      const student = await makeStudent();
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.added).toHaveLength(1);
+      expect(body.added[0].notified).toBe(false);
+    });
+
+    it('returns 400 MISSING_STUDENT_IDS when student_ids is absent', async () => {
       const group = await makeGroup();
       const res = makeRes();
 
       await addMember(makeReq({ groupId: group.groupId }, {}), res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json.mock.calls[0][0].code).toBe('MISSING_INVITEE_ID');
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_STUDENT_IDS');
     });
 
-    it('returns 400 MISSING_INVITEE_ID when invitee_id is whitespace only', async () => {
+    it('returns 400 MISSING_STUDENT_IDS when student_ids is an empty array', async () => {
       const group = await makeGroup();
       const res = makeRes();
 
-      await addMember(makeReq({ groupId: group.groupId }, { invitee_id: '   ' }), res);
+      await addMember(makeReq({ groupId: group.groupId }, { student_ids: [] }), res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json.mock.calls[0][0].code).toBe('MISSING_INVITEE_ID');
+      expect(res.json.mock.calls[0][0].code).toBe('MISSING_STUDENT_IDS');
     });
 
     it('returns 403 FORBIDDEN when caller is not the group leader', async () => {
@@ -178,7 +260,7 @@ describe('groupMembers controller', () => {
       const res = makeRes();
 
       await addMember(
-        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }, { userId: 'usr_leader' }),
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }, { userId: 'usr_leader' }),
         res
       );
 
@@ -190,47 +272,50 @@ describe('groupMembers controller', () => {
       const student = await makeStudent();
       const res = makeRes();
 
-      await addMember(makeReq({ groupId: 'grp_nonexistent' }, { invitee_id: student.userId }), res);
+      await addMember(makeReq({ groupId: 'grp_nonexistent' }, { student_ids: [student.userId] }), res);
 
       expect(res.status).toHaveBeenCalledWith(404);
       expect(res.json.mock.calls[0][0].code).toBe('GROUP_NOT_FOUND');
     });
 
-    it('returns 404 STUDENT_NOT_FOUND when invitee does not exist', async () => {
+    it('returns 201 with STUDENT_NOT_FOUND in errors[] when invitee does not exist', async () => {
       const group = await makeGroup();
       const res = makeRes();
 
-      await addMember(makeReq({ groupId: group.groupId }, { invitee_id: 'usr_ghost' }), res);
+      await addMember(makeReq({ groupId: group.groupId }, { student_ids: ['usr_ghost'] }), res);
 
-      expect(res.status).toHaveBeenCalledWith(404);
-      expect(res.json.mock.calls[0][0].code).toBe('STUDENT_NOT_FOUND');
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.added).toHaveLength(0);
+      expect(body.errors[0].code).toBe('STUDENT_NOT_FOUND');
     });
 
-    it('returns 409 ALREADY_INVITED when the student has already been invited', async () => {
+    it('returns 201 with ALREADY_INVITED in errors[] when student was already invited', async () => {
       const group = await makeGroup();
       const student = await makeStudent();
 
       await addMember(
-        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
         makeRes()
       );
 
       const res = makeRes();
       await addMember(
-        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
         res
       );
 
-      expect(res.status).toHaveBeenCalledWith(409);
-      expect(res.json.mock.calls[0][0].code).toBe('ALREADY_INVITED');
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.added).toHaveLength(0);
+      expect(body.errors[0].code).toBe('ALREADY_INVITED');
     });
 
-    it('returns 409 STUDENT_ALREADY_IN_GROUP when the student is approved in another group', async () => {
+    it('returns 201 with STUDENT_ALREADY_IN_GROUP in errors[] when student is approved elsewhere', async () => {
       const group = await makeGroup();
       const otherGroup = await makeGroup({ leaderId: 'usr_leader', groupName: `Other ${Date.now()}` });
       const student = await makeStudent();
 
-      // Student already approved in another group
       await GroupMembership.create({
         groupId: otherGroup.groupId,
         studentId: student.userId,
@@ -239,12 +324,32 @@ describe('groupMembers controller', () => {
 
       const res = makeRes();
       await addMember(
-        makeReq({ groupId: group.groupId }, { invitee_id: student.userId }),
+        makeReq({ groupId: group.groupId }, { student_ids: [student.userId] }),
         res
       );
 
-      expect(res.status).toHaveBeenCalledWith(409);
-      expect(res.json.mock.calls[0][0].code).toBe('STUDENT_ALREADY_IN_GROUP');
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.added).toHaveLength(0);
+      expect(body.errors[0].code).toBe('STUDENT_ALREADY_IN_GROUP');
+    });
+
+    it('partial batch: adds valid students and collects errors for invalid ones', async () => {
+      const group = await makeGroup();
+      const validStudent = await makeStudent();
+
+      const res = makeRes();
+      await addMember(
+        makeReq({ groupId: group.groupId }, { student_ids: [validStudent.userId, 'usr_ghost'] }),
+        res
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      const body = res.json.mock.calls[0][0];
+      expect(body.added).toHaveLength(1);
+      expect(body.added[0].invitee_id).toBe(validStudent.userId);
+      expect(body.errors).toHaveLength(1);
+      expect(body.errors[0].code).toBe('STUDENT_NOT_FOUND');
     });
   });
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,12 +15,12 @@ import GitHubCallbackHandler from './components/GitHubCallbackHandler';
 import GroupDashboard from './components/GroupDashboard';
 import GroupCreationPage from './components/GroupCreationPage';
 import CoordinatorPanel from './components/CoordinatorPanel';
+import Dashboard from './components/Dashboard';
 import './App.css';
 
 /**
  * Placeholder components for routes not yet implemented
  */
-const Dashboard = () => <div className="page">Dashboard - Coming Soon</div>;
 const Profile = () => <div className="page">Profile - Coming Soon</div>;
 const Unauthorized = () => <div className="page error">Unauthorized Access</div>;
 const NotFound = () => <div className="page error">Page Not Found</div>;

--- a/frontend/src/api/groupService.js
+++ b/frontend/src/api/groupService.js
@@ -54,6 +54,19 @@ export const getScheduleWindow = async () => {
 };
 
 /**
+ * Add members to a group (Process 2.3, flows f05, f06, f19, f32)
+ * @param {string} groupId
+ * @param {string[]} studentIds
+ * @returns {Promise<{added: object[], errors: object[], group_id: string, total_members: number}>}
+ */
+export const addGroupMembers = async (groupId, studentIds) => {
+  const response = await apiClient.post(`/groups/${groupId}/members`, {
+    student_ids: studentIds,
+  });
+  return response.data;
+};
+
+/**
  * Get group details
  * @param {string} groupId - The group ID
  * @returns {Promise} Group data

--- a/frontend/src/api/groupService.js
+++ b/frontend/src/api/groupService.js
@@ -67,6 +67,30 @@ export const addGroupMembers = async (groupId, studentIds) => {
 };
 
 /**
+ * Get the current user's pending group invitation
+ * @returns {Promise<{invitation_id, group_id, group_name, invited_by, status, created_at}|null>}
+ */
+export const getMyPendingInvitation = async () => {
+  try {
+    const response = await apiClient.get('/groups/pending-invitation');
+    return response.data;
+  } catch (error) {
+    if (error.response?.status === 404) return null;
+    throw error;
+  }
+};
+
+/**
+ * Accept or reject a group invitation
+ * @param {string} groupId
+ * @param {'accepted'|'rejected'} decision
+ */
+export const submitMembershipDecision = async (groupId, decision) => {
+  const response = await apiClient.post(`/groups/${groupId}/membership-decisions`, { decision });
+  return response.data;
+};
+
+/**
  * Get group details
  * @param {string} groupId - The group ID
  * @returns {Promise} Group data

--- a/frontend/src/components/AddMemberForm.js
+++ b/frontend/src/components/AddMemberForm.js
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { addGroupMembers } from '../api/groupService';
+
+/**
+ * AddMemberForm — Process 2.3
+ * Visible only to the Team Leader. Submits student email/ID to
+ * POST /groups/:groupId/members (flows f05, f06, f19, f32).
+ */
+const AddMemberForm = ({ groupId, onMemberAdded }) => {
+  const [studentInput, setStudentInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [successMsg, setSuccessMsg] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const trimmed = studentInput.trim();
+    if (!trimmed) return;
+
+    setLoading(true);
+    setSuccessMsg('');
+    setErrorMsg('');
+
+    try {
+      const result = await addGroupMembers(groupId, [trimmed]);
+
+      if (result.added && result.added.length > 0) {
+        setSuccessMsg(`Invitation sent to ${trimmed}.`);
+        setStudentInput('');
+        if (onMemberAdded) onMemberAdded(result);
+      } else if (result.errors && result.errors.length > 0) {
+        const err = result.errors[0];
+        if (err.code === 'STUDENT_NOT_FOUND') {
+          setErrorMsg('No student found with that email or ID.');
+        } else if (err.code === 'ALREADY_INVITED') {
+          setErrorMsg('This student has already been invited.');
+        } else if (err.code === 'STUDENT_ALREADY_IN_GROUP') {
+          setErrorMsg('This student already belongs to another group.');
+        } else {
+          setErrorMsg(err.message || 'Could not add student.');
+        }
+      }
+    } catch (err) {
+      const code = err.response?.data?.code;
+      if (code === 'FORBIDDEN') {
+        setErrorMsg('Only the group leader can add members.');
+      } else {
+        setErrorMsg(err.response?.data?.message || 'An unexpected error occurred.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="add-member-section">
+      <div className="members-header">
+        <h3>Invite a Member</h3>
+      </div>
+      <form onSubmit={handleSubmit} className="add-member-form">
+        <div className="add-member-input-group">
+          <input
+            type="text"
+            className={`add-member-input${errorMsg ? ' input-error' : ''}`}
+            value={studentInput}
+            onChange={(e) => {
+              setStudentInput(e.target.value);
+              setSuccessMsg('');
+              setErrorMsg('');
+            }}
+            placeholder="Student email (e.g. charlie@university.edu)"
+            disabled={loading}
+          />
+          <button
+            type="submit"
+            className="add-member-btn"
+            disabled={loading || !studentInput.trim()}
+          >
+            {loading ? 'Sending…' : 'Send Invite'}
+          </button>
+        </div>
+        {errorMsg && <p className="add-member-error">{errorMsg}</p>}
+        {successMsg && <p className="add-member-success">{successMsg}</p>}
+      </form>
+    </div>
+  );
+};
+
+export default AddMemberForm;

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useAuthStore from '../store/authStore';
+import { getMyPendingInvitation } from '../api/groupService';
+
+const Dashboard = () => {
+  const navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
+  const [invitation, setInvitation] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getMyPendingInvitation()
+      .then((inv) => setInvitation(inv))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const isStudent = user?.role === 'student';
+
+  return (
+    <div className="page" style={{ maxWidth: 600, margin: '40px auto', padding: '0 24px' }}>
+      <h2>Dashboard</h2>
+
+      {isStudent && (
+        <div style={{ marginTop: 24 }}>
+          {loading && <p style={{ color: '#666' }}>Checking for pending invitations…</p>}
+
+          {!loading && invitation && (
+            <div style={{
+              background: '#fff8e1',
+              border: '1px solid #f9a825',
+              borderRadius: 8,
+              padding: '16px 20px',
+            }}>
+              <p style={{ margin: '0 0 12px', color: '#5d4037' }}>
+                You have a pending invitation to join <strong>{invitation.group_name}</strong>.
+              </p>
+              <button
+                onClick={() => navigate(`/groups/${invitation.group_id}`)}
+                style={{
+                  padding: '8px 20px',
+                  background: '#1976d2',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                  fontWeight: 500,
+                }}
+              >
+                View Group &amp; Respond
+              </button>
+            </div>
+          )}
+
+          {!loading && !invitation && (
+            <p style={{ color: '#666' }}>
+              No pending group invitations.{' '}
+              <span
+                style={{ color: '#1976d2', cursor: 'pointer', textDecoration: 'underline' }}
+                onClick={() => navigate('/groups/new')}
+              >
+                Create a group
+              </span>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/components/GroupDashboard.css
+++ b/frontend/src/components/GroupDashboard.css
@@ -341,6 +341,87 @@
   font-size: 14px;
 }
 
+.add-member-section {
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  margin-top: 24px;
+}
+
+.add-member-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.add-member-input-group {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.add-member-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  font-size: 14px;
+  color: #333;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.add-member-input:focus {
+  border-color: #0969da;
+  box-shadow: 0 0 0 3px rgba(9, 105, 218, 0.1);
+}
+
+.add-member-input.input-error {
+  border-color: #da3633;
+}
+
+.add-member-input:disabled {
+  background: #f6f8fa;
+  color: #999;
+  cursor: not-allowed;
+}
+
+.add-member-btn {
+  padding: 8px 18px;
+  background-color: #0969da;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s;
+}
+
+.add-member-btn:hover:not(:disabled) {
+  background-color: #0860ca;
+}
+
+.add-member-btn:disabled {
+  background-color: #d0d0d0;
+  cursor: not-allowed;
+}
+
+.add-member-error {
+  margin: 0;
+  font-size: 12px;
+  color: #da3633;
+}
+
+.add-member-success {
+  margin: 0;
+  font-size: 12px;
+  color: #238636;
+}
+
 @media (max-width: 768px) {
   .group-dashboard {
     padding: 16px;

--- a/frontend/src/components/GroupDashboard.css
+++ b/frontend/src/components/GroupDashboard.css
@@ -457,3 +457,76 @@
     text-align: left;
   }
 }
+
+.invitation-banner {
+  background: #fff8e1;
+  border: 1px solid #f9a825;
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.invitation-banner p {
+  margin: 0;
+  flex: 1;
+  color: #5d4037;
+}
+
+.invitation-banner.resolved {
+  background: #e8f5e9;
+  border-color: #43a047;
+}
+
+.invitation-banner.resolved p {
+  color: #2e7d32;
+}
+
+.invitation-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.accept-btn {
+  padding: 8px 20px;
+  background: #43a047;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.accept-btn:hover:not(:disabled) {
+  background: #388e3c;
+}
+
+.reject-btn {
+  padding: 8px 20px;
+  background: white;
+  color: #c62828;
+  border: 1px solid #c62828;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.reject-btn:hover:not(:disabled) {
+  background: #ffebee;
+}
+
+.accept-btn:disabled,
+.reject-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.decision-msg {
+  width: 100%;
+  margin: 8px 0 0 0;
+  font-size: 13px;
+  color: #555;
+}

--- a/frontend/src/components/GroupDashboard.js
+++ b/frontend/src/components/GroupDashboard.js
@@ -5,6 +5,7 @@ import useAuthStore from '../store/authStore';
 import GitHubStatusCard from './GitHubStatusCard';
 import JiraStatusCard from './JiraStatusCard';
 import GroupMemberList from './GroupMemberList';
+import AddMemberForm from './AddMemberForm';
 import './GroupDashboard.css';
 
 /**
@@ -67,6 +68,9 @@ const GroupDashboard = () => {
 
   // Check if user is coordinator (has coordinator role or is admin)
   const isCoordinator = user?.role === 'coordinator' || user?.role === 'admin';
+
+  // Check if current user is the group leader
+  const isLeader = groupData?.leaderId === user?.userId;
 
   // Handle coordinator panel navigation
   const handleCoordinatorPanel = () => {
@@ -174,6 +178,14 @@ const GroupDashboard = () => {
             isLoading={isLoading}
             groupLeaderId={groupData?.leaderId}
           />
+
+          {/* Add Member — Team Leader only (Process 2.3) */}
+          {isLeader && (
+            <AddMemberForm
+              groupId={groupId}
+              onMemberAdded={() => fetchGroupDashboard(groupId)}
+            />
+          )}
 
           {/* Group Information Footer */}
           <div style={{ marginTop: '24px', fontSize: '12px', color: '#666', textAlign: 'center' }}>

--- a/frontend/src/components/GroupDashboard.js
+++ b/frontend/src/components/GroupDashboard.js
@@ -6,6 +6,7 @@ import GitHubStatusCard from './GitHubStatusCard';
 import JiraStatusCard from './JiraStatusCard';
 import GroupMemberList from './GroupMemberList';
 import AddMemberForm from './AddMemberForm';
+import { submitMembershipDecision, getMyPendingInvitation } from '../api/groupService';
 import './GroupDashboard.css';
 
 /**
@@ -18,6 +19,9 @@ const GroupDashboard = () => {
   const user = useAuthStore((state) => state.user);
   const pollingIntervalRef = useRef(null);
   const [manualRefresh, setManualRefresh] = useState(false);
+  const [invitationInfo, setInvitationInfo] = useState(null);
+  const [decisionLoading, setDecisionLoading] = useState(false);
+  const [decisionMsg, setDecisionMsg] = useState('');
 
   // Group store state
   const {
@@ -44,17 +48,40 @@ const GroupDashboard = () => {
   // Initial load and polling setup
   useEffect(() => {
     if (groupId) {
-      // Start polling for real-time updates (refresh every 30 seconds)
       pollingIntervalRef.current = startPolling(groupId, 30000);
     }
 
     return () => {
-      // Cleanup polling on unmount
       if (pollingIntervalRef.current) {
         stopPolling(pollingIntervalRef.current);
       }
     };
   }, [groupId, startPolling, stopPolling]);
+
+  // Check if the current user has a pending invitation for this group
+  useEffect(() => {
+    if (!groupId || !user) return;
+    getMyPendingInvitation().then((inv) => {
+      if (inv && inv.group_id === groupId) {
+        setInvitationInfo(inv);
+      }
+    }).catch(() => {});
+  }, [groupId, user]);
+
+  const handleDecision = async (decision) => {
+    setDecisionLoading(true);
+    setDecisionMsg('');
+    try {
+      await submitMembershipDecision(groupId, decision);
+      setInvitationInfo(null);
+      setDecisionMsg(decision === 'accepted' ? 'You have joined the group!' : 'Invitation declined.');
+      if (decision === 'accepted') fetchGroupDashboard(groupId);
+    } catch (err) {
+      setDecisionMsg(err.response?.data?.message || 'Could not process your decision.');
+    } finally {
+      setDecisionLoading(false);
+    }
+  };
 
   // Handle manual refresh
   const handleRefresh = async () => {
@@ -128,6 +155,35 @@ const GroupDashboard = () => {
       {/* Loading State */}
       {isLoading && !groupData && (
         <div className="loading">Loading group dashboard...</div>
+      )}
+
+      {/* Invitation Banner — visible to invited users who haven't responded yet */}
+      {invitationInfo && (
+        <div className="invitation-banner">
+          <p>You have been invited to join <strong>{groupData?.groupName || invitationInfo.group_name}</strong>.</p>
+          <div className="invitation-actions">
+            <button
+              className="accept-btn"
+              onClick={() => handleDecision('accepted')}
+              disabled={decisionLoading}
+            >
+              {decisionLoading ? 'Processing…' : 'Accept'}
+            </button>
+            <button
+              className="reject-btn"
+              onClick={() => handleDecision('rejected')}
+              disabled={decisionLoading}
+            >
+              Decline
+            </button>
+          </div>
+          {decisionMsg && <p className="decision-msg">{decisionMsg}</p>}
+        </div>
+      )}
+      {!invitationInfo && decisionMsg && (
+        <div className="invitation-banner resolved">
+          <p>{decisionMsg}</p>
+        </div>
       )}
 
       {/* Main Content */}


### PR DESCRIPTION
- Backend — bulk member invitation (Process 2.3): Refactored addMember to accept a student_ids array, supporting batch invites in a single request. Per-student errors are collected without aborting valid invites. Leaders can now invite by either userId or email address; invitations are always stored using invitee.userId (fixing a bug where email-keyed invitations could never be matched when the invitee responded).

- Backend — pending invitation endpoint: Added GET /groups/pending-invitation which returns the current user's pending invitation with group name and ID. Registered before /:groupId to avoid route conflicts.

- Frontend — leader invite UI (Process 2.3): Added AddMemberForm component to the Group Dashboard, visible to team leaders only. Submits to the batch invite endpoint and surfaces per-student errors inline.

- Frontend — invitee response flow: The Dashboard component now fetches the user's pending invitation on load and shows a "View Group & Respond" link. On the Group Dashboard, invited users see an Accept/Decline banner which calls POST /groups/:groupId/membership-decisions and refreshes the member list on acceptance.
