### PR TITLE
feat(audit): implement audit logging for group formation events

### DIFF
--- a/backend/src/controllers/auditLogs.js
+++ b/backend/src/controllers/auditLogs.js
@@ -1,0 +1,66 @@
+const AuditLog = require('../models/AuditLog');
+
+/**
+ * GET /api/v1/audit-logs
+ *
+ * Read-only query endpoint for audit log entries.
+ * Supports filtering by group_id and/or event_type.
+ * Append-only guarantee: no write, update, or delete endpoints exist.
+ *
+ * Query params:
+ *   group_id   - Filter by groupId (required for non-admin callers unless event_type supplied)
+ *   event_type - Filter by action/event type
+ *   limit      - Max results (default 100, max 500)
+ *   offset     - Skip N results for pagination
+ */
+const getAuditLogs = async (req, res) => {
+  try {
+    const { group_id, event_type, limit: limitParam, offset: offsetParam } = req.query;
+
+    if (!group_id && !event_type) {
+      return res.status(400).json({
+        code: 'MISSING_FILTER',
+        message: 'At least one of group_id or event_type is required',
+      });
+    }
+
+    const limit = Math.min(parseInt(limitParam, 10) || 100, 500);
+    const offset = parseInt(offsetParam, 10) || 0;
+
+    const filter = {};
+    if (group_id) filter.groupId = group_id;
+    if (event_type) filter.action = event_type;
+
+    const [entries, total] = await Promise.all([
+      AuditLog.find(filter)
+        .sort({ createdAt: -1 })
+        .skip(offset)
+        .limit(limit)
+        .lean(),
+      AuditLog.countDocuments(filter),
+    ]);
+
+    return res.status(200).json({
+      total,
+      limit,
+      offset,
+      entries: entries.map((e) => ({
+        event_id: e.auditId,
+        event_type: e.action,
+        actor_id: e.actorId,
+        group_id: e.groupId,
+        target_id: e.targetId,
+        payload: e.payload,
+        timestamp: e.timestamp || e.createdAt,
+      })),
+    });
+  } catch (err) {
+    console.error('getAuditLogs error:', err);
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    });
+  }
+};
+
+module.exports = { getAuditLogs };

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -1,6 +1,7 @@
 const axios = require('axios');
 const Group = require('../models/Group');
 const SyncErrorLog = require('../models/SyncErrorLog');
+const { createAuditLog } = require('../services/auditService');
 
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 100;
@@ -83,13 +84,30 @@ const configureGithub = async (req, res) => {
         return res.status(422).json({ code: 'INVALID_PAT', message: 'GitHub PAT is invalid or has insufficient permissions' });
       }
       // Network/timeout failures — log sync error
-      await SyncErrorLog.create({
+      const syncErr = await SyncErrorLog.create({
         service: 'github',
         groupId,
         actorId: req.user.userId,
         attempts: MAX_RETRY_ATTEMPTS,
         lastError: err.message,
       });
+      try {
+        await createAuditLog({
+          action: 'sync_error',
+          actorId: req.user.userId,
+          groupId,
+          payload: {
+            api_type: 'github',
+            retry_count: MAX_RETRY_ATTEMPTS,
+            last_error: err.message,
+            sync_error_id: syncErr.errorId,
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('Audit log failed (non-fatal):', auditError.message);
+      }
       return res.status(503).json({ code: 'GITHUB_API_UNAVAILABLE', message: 'GitHub API unavailable after maximum retry attempts' });
     }
 
@@ -107,13 +125,30 @@ const configureGithub = async (req, res) => {
       if (status === 404) {
         return res.status(422).json({ code: 'ORG_NOT_FOUND', message: 'GitHub organisation not found or PAT lacks access' });
       }
-      await SyncErrorLog.create({
+      const syncErr2 = await SyncErrorLog.create({
         service: 'github',
         groupId,
         actorId: req.user.userId,
         attempts: MAX_RETRY_ATTEMPTS,
         lastError: err.message,
       });
+      try {
+        await createAuditLog({
+          action: 'sync_error',
+          actorId: req.user.userId,
+          groupId,
+          payload: {
+            api_type: 'github',
+            retry_count: MAX_RETRY_ATTEMPTS,
+            last_error: err.message,
+            sync_error_id: syncErr2.errorId,
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('Audit log failed (non-fatal):', auditError.message);
+      }
       return res.status(503).json({ code: 'GITHUB_API_UNAVAILABLE', message: 'GitHub API unavailable after maximum retry attempts' });
     }
 
@@ -122,6 +157,25 @@ const configureGithub = async (req, res) => {
     group.githubOrg = org.trim();
     group.githubRepoUrl = `https://github.com/${org.trim()}`;
     await group.save();
+
+    // Audit log: github_integration_setup (non-fatal)
+    try {
+      await createAuditLog({
+        action: 'github_integration_setup',
+        actorId: req.user.userId,
+        targetId: groupId,
+        groupId,
+        payload: {
+          status: 'success',
+          org: org.trim(),
+          github_repo_url: group.githubRepoUrl,
+        },
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed (non-fatal):', auditError.message);
+    }
 
     return res.status(201).json({
       github_org: group.githubOrg,
@@ -233,13 +287,30 @@ const configureJira = async (req, res) => {
       if (status === 401 || status === 403) {
         return res.status(422).json({ code: 'INVALID_JIRA_CREDENTIALS', message: 'JIRA credentials are invalid' });
       }
-      await SyncErrorLog.create({
+      const jiraSyncErr1 = await SyncErrorLog.create({
         service: 'jira',
         groupId,
         actorId: req.user.userId,
         attempts: MAX_RETRY_ATTEMPTS,
         lastError: err.message,
       });
+      try {
+        await createAuditLog({
+          action: 'sync_error',
+          actorId: req.user.userId,
+          groupId,
+          payload: {
+            api_type: 'jira',
+            retry_count: MAX_RETRY_ATTEMPTS,
+            last_error: err.message,
+            sync_error_id: jiraSyncErr1.errorId,
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('Audit log failed (non-fatal):', auditError.message);
+      }
       return res.status(503).json({ code: 'JIRA_API_UNAVAILABLE', message: 'JIRA API unavailable after maximum retry attempts' });
     }
 
@@ -258,13 +329,30 @@ const configureJira = async (req, res) => {
       if (status === 404) {
         return res.status(422).json({ code: 'INVALID_PROJECT_KEY', message: 'JIRA project key not found' });
       }
-      await SyncErrorLog.create({
+      const jiraSyncErr2 = await SyncErrorLog.create({
         service: 'jira',
         groupId,
         actorId: req.user.userId,
         attempts: MAX_RETRY_ATTEMPTS,
         lastError: err.message,
       });
+      try {
+        await createAuditLog({
+          action: 'sync_error',
+          actorId: req.user.userId,
+          groupId,
+          payload: {
+            api_type: 'jira',
+            retry_count: MAX_RETRY_ATTEMPTS,
+            last_error: err.message,
+            sync_error_id: jiraSyncErr2.errorId,
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('Audit log failed (non-fatal):', auditError.message);
+      }
       return res.status(503).json({ code: 'JIRA_API_UNAVAILABLE', message: 'JIRA API unavailable after maximum retry attempts' });
     }
 
@@ -276,6 +364,26 @@ const configureJira = async (req, res) => {
     group.jiraProject = projectData.name || project_key.trim();
     group.jiraBoardUrl = `${baseUrl}/jira/software/projects/${project_key.trim()}/boards`;
     await group.save();
+
+    // Audit log: jira_integration_setup (non-fatal)
+    try {
+      await createAuditLog({
+        action: 'jira_integration_setup',
+        actorId: req.user.userId,
+        targetId: groupId,
+        groupId,
+        payload: {
+          status: 'success',
+          jira_url: baseUrl,
+          project_key: project_key.trim(),
+          jira_board_url: group.jiraBoardUrl,
+        },
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditError) {
+      console.error('Audit log failed (non-fatal):', auditError.message);
+    }
 
     return res.status(201).json({
       jira_url: group.jiraUrl,

--- a/backend/src/controllers/groupMembers.js
+++ b/backend/src/controllers/groupMembers.js
@@ -113,15 +113,14 @@ const addMember = async (req, res) => {
 
       // Create audit log for member addition
       await createAuditLog({
-        action: 'MEMBER_ADDED',
+        action: 'member_added',
         actorId: req.user.userId,
-        actorRole: req.user.role,
         targetId: groupId,
-        targetType: 'group',
-        details: {
-          inviteeId: invitee.userId,
+        groupId,
+        payload: {
+          student_id: invitee.userId,
           status: 'pending',
-          sourceProcess: 'direct_invitation',
+          via: 'leader_invitation',
         },
         ipAddress: req.ip,
         userAgent: req.headers['user-agent'],
@@ -147,13 +146,30 @@ const addMember = async (req, res) => {
       }
 
       if (lastError) {
-        await SyncErrorLog.create({
+        const notifSyncErr = await SyncErrorLog.create({
           service: 'notification',
           groupId,
           actorId: req.user.userId,
           attempts: MAX_RETRY_ATTEMPTS,
           lastError: lastError.message,
         });
+        try {
+          await createAuditLog({
+            action: 'sync_error',
+            actorId: req.user.userId,
+            groupId,
+            payload: {
+              api_type: 'notification',
+              retry_count: MAX_RETRY_ATTEMPTS,
+              last_error: lastError.message,
+              sync_error_id: notifSyncErr.errorId,
+            },
+            ipAddress: req.ip,
+            userAgent: req.headers['user-agent'],
+          });
+        } catch (auditError) {
+          console.error('sync_error audit log failed (non-fatal):', auditError.message);
+        }
       } else if (notificationId) {
         invitation.notifiedAt = new Date();
         invitation.notificationId = notificationId;
@@ -353,14 +369,13 @@ const membershipDecision = async (req, res) => {
 
         // Create audit log for auto-deny
         await createAuditLog({
-          action: 'MEMBERSHIP_DECISION_AUTO_DENIED',
+          action: 'membership_decision',
           actorId: studentId,
-          actorRole: req.user.role,
           targetId: groupId,
-          targetType: 'group',
-          details: {
-            reason: 'student_already_in_approved_group',
+          groupId,
+          payload: {
             decision: 'auto_rejected',
+            reason: 'student_already_in_approved_group',
           },
           ipAddress: req.ip,
           userAgent: req.headers['user-agent'],
@@ -414,14 +429,14 @@ const membershipDecision = async (req, res) => {
 
         // Create audit log for each auto-denied invitation
         await createAuditLog({
-          action: 'MEMBERSHIP_DECISION_AUTO_DENIED',
+          action: 'membership_decision',
           actorId: studentId,
-          actorRole: req.user.role,
           targetId: otherInv.groupId,
-          targetType: 'group',
-          details: {
+          groupId: otherInv.groupId,
+          payload: {
+            decision: 'auto_rejected',
             reason: 'student_accepted_another_group',
-            acceptedGroupId: groupId,
+            accepted_group_id: groupId,
           },
           ipAddress: req.ip,
           userAgent: req.headers['user-agent'],
@@ -431,12 +446,11 @@ const membershipDecision = async (req, res) => {
 
     // Create audit log for membership decision
     await createAuditLog({
-      action: 'MEMBERSHIP_DECISION',
+      action: 'membership_decision',
       actorId: studentId,
-      actorRole: req.user.role,
       targetId: groupId,
-      targetType: 'group',
-      details: {
+      groupId,
+      payload: {
         decision,
         status: membershipStatus,
       },
@@ -464,13 +478,30 @@ const membershipDecision = async (req, res) => {
       }
     }
     if (notifLastError) {
-      await SyncErrorLog.create({
+      const decisionSyncErr = await SyncErrorLog.create({
         service: 'notification',
         groupId,
         actorId: studentId,
         attempts: MAX_RETRY_ATTEMPTS,
         lastError: notifLastError.message,
       });
+      try {
+        await createAuditLog({
+          action: 'sync_error',
+          actorId: studentId,
+          groupId,
+          payload: {
+            api_type: 'notification',
+            retry_count: MAX_RETRY_ATTEMPTS,
+            last_error: notifLastError.message,
+            sync_error_id: decisionSyncErr.errorId,
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('sync_error audit log failed (non-fatal):', auditError.message);
+      }
     } else if (decisionNotifId) {
       invitation.notificationId = decisionNotifId;
       invitation.notifiedAt = new Date();

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -296,24 +296,43 @@ const createGroup = async (req, res) => {
     }
     if (notifLastError) {
       try {
-        await SyncErrorLog.create({
+        const notifSyncErr = await SyncErrorLog.create({
           service: 'notification',
           groupId: group.groupId,
           actorId: leader.userId,
           attempts: 3,
           lastError: notifLastError.message,
         });
+        await createAuditLog({
+          action: 'sync_error',
+          actorId: leader.userId,
+          groupId: group.groupId,
+          payload: {
+            api_type: 'notification',
+            retry_count: 3,
+            last_error: notifLastError.message,
+            sync_error_id: notifSyncErr.errorId,
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
       } catch (logErr) {
-        console.error('SyncErrorLog write failed (non-fatal):', logErr.message);
+        console.error('SyncErrorLog/audit write failed (non-fatal):', logErr.message);
       }
     }
 
     // Audit log (non-fatal)
     try {
       await createAuditLog({
-        action: 'GROUP_CREATED',
+        action: 'group_created',
         actorId: leader.userId,
         targetId: group.groupId,
+        groupId: group.groupId,
+        payload: {
+          group_name: group.groupName,
+          leader_id: leader.userId,
+          status: group.status,
+        },
         ipAddress: req.ip,
         userAgent: req.headers['user-agent'],
       });
@@ -538,10 +557,15 @@ const coordinatorOverride = async (req, res) => {
 
       try {
         await createAuditLog({
-          action: 'COORDINATOR_OVERRIDE',
+          action: 'coordinator_override',
           actorId: req.user.userId,
           targetId: groupId,
-          changes: { action, updates, reason: reason.trim() },
+          groupId,
+          payload: {
+            action,
+            updates,
+            reason: reason.trim(),
+          },
           ipAddress: req.ip,
           userAgent: req.headers['user-agent'],
         });
@@ -624,6 +648,25 @@ const coordinatorOverride = async (req, res) => {
         },
         { upsert: true, new: true }
       );
+
+      // Audit log: member_added via coordinator override
+      try {
+        await createAuditLog({
+          action: 'member_added',
+          actorId: req.user.userId,
+          targetId: groupId,
+          groupId,
+          payload: {
+            student_id: studentId,
+            via: 'coordinator_override',
+            reason: reason.trim(),
+          },
+          ipAddress: req.ip,
+          userAgent: req.headers['user-agent'],
+        });
+      } catch (auditError) {
+        console.error('MEMBER_ADDED audit log failed (non-fatal):', auditError.message);
+      }
     } else {
       // remove_member
       group.members = group.members.filter((m) => m.userId !== studentId);
@@ -640,21 +683,23 @@ const coordinatorOverride = async (req, res) => {
         }
       );
 
-      // Log MEMBER_REMOVED action separately
+      // Log member_removed action
       try {
         await createAuditLog({
-          action: 'MEMBER_REMOVED',
+          action: 'member_removed',
           actorId: req.user.userId,
           targetId: groupId,
-          details: {
-            studentId,
+          groupId,
+          payload: {
+            student_id: studentId,
+            via: 'coordinator_override',
             reason: reason.trim(),
           },
           ipAddress: req.ip,
           userAgent: req.headers['user-agent'],
         });
       } catch (auditError) {
-        console.error('MEMBER_REMOVED audit log failed (non-fatal):', auditError.message);
+        console.error('member_removed audit log failed (non-fatal):', auditError.message);
       }
     }
 
@@ -671,10 +716,15 @@ const coordinatorOverride = async (req, res) => {
 
     try {
       await createAuditLog({
-        action: 'COORDINATOR_OVERRIDE',
+        action: 'coordinator_override',
         actorId: req.user.userId,
         targetId: groupId,
-        changes: { action, targetStudentId: studentId, reason: reason.trim() },
+        groupId,
+        payload: {
+          action,
+          target_student_id: studentId,
+          reason: reason.trim(),
+        },
         ipAddress: req.ip,
         userAgent: req.headers['user-agent'],
       });

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -6,6 +6,7 @@ const authRoutes = require('./routes/auth');
 const onboardingRoutes = require('./routes/onboarding');
 const groupRoutes = require('./routes/groups');
 const scheduleWindowRoutes = require('./routes/scheduleWindow');
+const auditLogRoutes = require('./routes/auditLogs');
 const { errorHandler } = require('./middleware/auth');
 
 const app = express();
@@ -53,6 +54,7 @@ app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/onboarding', onboardingRoutes);
 app.use('/api/v1/groups', groupRoutes);
 app.use('/api/v1/schedule-window', scheduleWindowRoutes);
+app.use('/api/v1/audit-logs', auditLogRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -13,6 +13,7 @@ const auditLogSchema = new mongoose.Schema(
       type: String,
       required: true,
       enum: [
+        // Auth & account events (SCREAMING_SNAKE_CASE, legacy)
         'ACCOUNT_CREATED',
         'ACCOUNT_RETRIEVED',
         'ACCOUNT_UPDATED',
@@ -20,11 +21,18 @@ const auditLogSchema = new mongoose.Schema(
         'PASSWORD_RESET_CONFIRMED',
         'PASSWORD_RESET_ADMIN_INITIATED',
         'GITHUB_OAUTH_LINKED',
+        'GITHUB_OAUTH_INITIATED',
+        'GITHUB_LINKED',
         'ONBOARDING_COMPLETED',
         'EMAIL_VERIFICATION_SENT',
         'EMAIL_PASSWORD_RESET_SENT',
         'EMAIL_ACCOUNT_READY_SENT',
         'EMAIL_DELIVERY_FAILED',
+        'EMAIL_VERIFIED',
+        'LOGIN_SUCCESS',
+        'LOGIN_FAILED',
+        'PASSWORD_CHANGED',
+        // Group formation events (SCREAMING_SNAKE_CASE, legacy)
         'GROUP_CREATED',
         'GROUP_RETRIEVED',
         'COORDINATOR_OVERRIDE',
@@ -39,15 +47,37 @@ const auditLogSchema = new mongoose.Schema(
         'STATUS_TRANSITION',
         'GITHUB_CONFIGURED',
         'JIRA_CONFIGURED',
+        // Group formation events (snake_case, per issue spec)
+        'group_created',
+        'member_added',
+        'member_removed',
+        'membership_decision',
+        'coordinator_override',
+        'github_integration_setup',
+        'jira_integration_setup',
+        'sync_error',
+        // Test sentinel (used in existing test suite)
+        'TEST_ACTION',
       ],
     },
     actorId: {
       type: String,
-      required: true,
+      default: null,
     },
     targetId: {
       type: String,
-      required: true,
+      default: null,
+    },
+    // First-class group reference for group formation events
+    groupId: {
+      type: String,
+      default: null,
+      index: true,
+    },
+    // Consolidated event-specific data (mirrors the issue spec payload{} field)
+    payload: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
     },
     // Captured for ACCOUNT_UPDATED: { previous: {}, updated: {} }
     changes: {
@@ -66,12 +96,21 @@ const auditLogSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    // Explicit timestamp field per issue spec (mirrors createdAt)
+    timestamp: {
+      type: Date,
+      default: Date.now,
+    },
   },
   { timestamps: true }
 );
 
+// Existing indexes
 auditLogSchema.index({ targetId: 1, createdAt: -1 });
 auditLogSchema.index({ actorId: 1, createdAt: -1 });
+// New indexes for group formation audit queries (group_id + event_type)
+auditLogSchema.index({ groupId: 1, action: 1, createdAt: -1 });
+auditLogSchema.index({ action: 1, createdAt: -1 });
 
 const AuditLog = mongoose.model('AuditLog', auditLogSchema);
 

--- a/backend/src/routes/auditLogs.js
+++ b/backend/src/routes/auditLogs.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { authMiddleware } = require('../middleware/auth');
+const { getAuditLogs } = require('../controllers/auditLogs');
+
+// GET /api/v1/audit-logs?group_id=xxx&event_type=xxx
+// Read-only. Append-only guarantee: no PUT/PATCH/DELETE routes exist.
+router.get('/', authMiddleware, getAuditLogs);
+
+module.exports = router;

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -4,9 +4,11 @@ const AuditLog = require('../models/AuditLog');
  * Record an audit event.
  *
  * @param {object} params
- * @param {string} params.action      - One of ACCOUNT_CREATED | ACCOUNT_RETRIEVED | ACCOUNT_UPDATED
- * @param {string} params.actorId     - userId of the requester performing the action
- * @param {string} params.targetId    - userId of the account being acted upon
+ * @param {string} params.action      - One of the AuditLog action enum values
+ * @param {string} [params.actorId]   - userId of the requester performing the action
+ * @param {string} [params.targetId]  - userId or entityId of the subject being acted upon
+ * @param {string} [params.groupId]   - groupId for group formation events (issue spec: group_id)
+ * @param {object} [params.payload]   - Event-specific data (issue spec: payload{})
  * @param {object} [params.changes]   - For ACCOUNT_UPDATED: { previous, updated }
  * @param {object} [params.details]   - Additional details for the action
  * @param {string} [params.ipAddress]
@@ -14,10 +16,30 @@ const AuditLog = require('../models/AuditLog');
  * @param {object} [session]          - Mongoose session for transactional writes
  */
 const createAuditLog = async (
-  { action, actorId, targetId, changes = null, details = null, ipAddress = null, userAgent = null },
+  {
+    action,
+    actorId = null,
+    targetId = null,
+    groupId = null,
+    payload = null,
+    changes = null,
+    details = null,
+    ipAddress = null,
+    userAgent = null,
+  },
   session = null
 ) => {
-  const log = new AuditLog({ action, actorId, targetId, changes, details, ipAddress, userAgent });
+  const log = new AuditLog({
+    action,
+    actorId,
+    targetId,
+    groupId,
+    payload,
+    changes,
+    details,
+    ipAddress,
+    userAgent,
+  });
   await log.save(session ? { session } : undefined);
   return log;
 };

--- a/backend/tests/audit-logging-group-events.test.js
+++ b/backend/tests/audit-logging-group-events.test.js
@@ -1,0 +1,656 @@
+/**
+ * Audit Logging — Group Formation Events
+ *
+ * Verifies that every write-path action in Process 2.0 produces an audit log
+ * entry with the required fields (event_type, actor_id, group_id, timestamp).
+ *
+ * Acceptance criteria covered:
+ *  ✓ group_created          — POST /groups (createGroup controller)
+ *  ✓ member_added           — POST /groups/:id/members (leader invitation)
+ *  ✓ member_added           — PATCH /groups/:id/override (add_member)
+ *  ✓ member_removed         — PATCH /groups/:id/override (remove_member)
+ *  ✓ membership_decision    — POST /groups/:id/membership-decisions
+ *  ✓ coordinator_override   — PATCH /groups/:id/override
+ *  ✓ github_integration_setup — POST /groups/:id/github
+ *  ✓ jira_integration_setup   — POST /groups/:id/jira
+ *  ✓ sync_error             — recorded when external API calls fail after retries
+ *  ✓ Append-only: no DELETE/PUT/PATCH on audit log entries via API
+ *  ✓ Queryable by group_id and event_type via GET /api/v1/audit-logs
+ *
+ * Run: npm test -- audit-logging-group-events.test.js
+ */
+
+const mongoose = require('mongoose');
+const axios = require('axios');
+const request = require('supertest');
+const app = require('../src/index');
+
+jest.mock('axios');
+jest.mock('../src/services/notificationService');
+
+const MONGO_URI =
+  process.env.MONGODB_TEST_URI ||
+  'mongodb://localhost:27017/senior-app-test-audit-group-events';
+
+describe('Audit Logging — Group Formation Events', () => {
+  // Models (populated in beforeAll)
+  let AuditLog, Group, GroupMembership, MemberInvitation, User, ScheduleWindow, SyncErrorLog;
+
+  // Controllers under test
+  let createGroupCtrl, addMember, membershipDecision, coordinatorOverride;
+  let configureGithub, configureJira;
+
+  // ── Request / response factories ────────────────────────────────────────────
+
+  const makeReq = (body = {}, params = {}, userOverrides = {}) => ({
+    body,
+    params,
+    user: { userId: 'usr_default', role: 'student', ...userOverrides },
+    ip: '127.0.0.1',
+    headers: { 'user-agent': 'test-agent' },
+  });
+
+  const makeRes = () => {
+    const res = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  };
+
+  // ── Setup / teardown ─────────────────────────────────────────────────────────
+
+  beforeAll(async () => {
+    if (mongoose.connection.readyState !== 0) await mongoose.disconnect();
+    await mongoose.connect(MONGO_URI);
+    await mongoose.connection.dropDatabase();
+
+    AuditLog = require('../src/models/AuditLog');
+    Group = require('../src/models/Group');
+    GroupMembership = require('../src/models/GroupMembership');
+    MemberInvitation = require('../src/models/MemberInvitation');
+    User = require('../src/models/User');
+    ScheduleWindow = require('../src/models/ScheduleWindow');
+    SyncErrorLog = require('../src/models/SyncErrorLog');
+
+    ({ createGroup: createGroupCtrl, coordinatorOverride } = require('../src/controllers/groups'));
+    ({ addMember, membershipDecision } = require('../src/controllers/groupMembers'));
+    ({ configureGithub, configureJira } = require('../src/controllers/groupIntegrations'));
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.dropDatabase();
+    await mongoose.disconnect();
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      AuditLog.deleteMany({}),
+      Group.deleteMany({}),
+      GroupMembership.deleteMany({}),
+      MemberInvitation.deleteMany({}),
+      User.deleteMany({}),
+      ScheduleWindow.deleteMany({}),
+      SyncErrorLog.deleteMany({}),
+    ]);
+    jest.clearAllMocks();
+  });
+
+  // ── Shared test helpers ───────────────────────────────────────────────────────
+
+  const makeUser = (overrides = {}) =>
+    User.create({
+      userId: `usr_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      email: `user_${Date.now()}_${Math.random().toString(36).slice(2)}@test.edu`,
+      hashedPassword: 'hashed',
+      role: 'student',
+      accountStatus: 'active',
+      ...overrides,
+    });
+
+  const makeGroup = (leaderId, overrides = {}) =>
+    Group.create({
+      groupName: `Group_${Date.now()}_${Math.random().toString(36).slice(2)}`,
+      leaderId,
+      status: 'active',
+      ...overrides,
+    });
+
+  const openWindow = (type = 'group_creation') => {
+    const now = new Date();
+    return ScheduleWindow.create({
+      operationType: type,
+      startsAt: new Date(now.getTime() - 60_000),
+      endsAt: new Date(now.getTime() + 3_600_000),
+      isActive: true,
+      createdBy: 'usr_coordinator',
+    });
+  };
+
+  const assertAuditEntry = (log, { event_type, actor_id, group_id, payload = {} }) => {
+    expect(log).not.toBeNull();
+    expect(log.action).toBe(event_type);
+    expect(log.actorId).toBe(actor_id);
+    expect(log.groupId).toBe(group_id);
+    expect(log.timestamp || log.createdAt).toBeTruthy();
+    Object.entries(payload).forEach(([k, v]) => {
+      expect(log.payload[k]).toEqual(v);
+    });
+  };
+
+  // ── group_created ─────────────────────────────────────────────────────────────
+
+  describe('group_created', () => {
+    it('produces a group_created audit entry on successful group creation', async () => {
+      await openWindow('group_creation');
+      const leader = await makeUser({ userId: 'usr_leader_gc' });
+
+      const req = makeReq(
+        { groupName: 'Alpha Team', leaderId: leader.userId },
+        {},
+        { userId: leader.userId, role: 'student' }
+      );
+
+      await createGroupCtrl(req, makeRes());
+
+      const log = await AuditLog.findOne({ action: 'group_created', actorId: leader.userId });
+      assertAuditEntry(log, {
+        event_type: 'group_created',
+        actor_id: leader.userId,
+        group_id: log.groupId,
+        payload: { leader_id: leader.userId, group_name: 'Alpha Team' },
+      });
+    });
+  });
+
+  // ── member_added (leader invitation) ─────────────────────────────────────────
+
+  describe('member_added (leader invitation)', () => {
+    it('produces a member_added entry when leader invites a student', async () => {
+      await openWindow('member_addition');
+      const leader = await makeUser({ userId: 'usr_leader_ma' });
+      const invitee = await makeUser({ userId: 'usr_invitee_ma' });
+      const group = await makeGroup(leader.userId);
+
+      const notifService = require('../src/services/notificationService');
+      notifService.dispatchInvitationNotification = jest.fn().mockResolvedValue({
+        notification_id: 'notif_001',
+      });
+
+      const req = makeReq(
+        { student_ids: [invitee.userId] },
+        { groupId: group.groupId },
+        { userId: leader.userId, role: 'student' }
+      );
+
+      await addMember(req, makeRes());
+
+      const log = await AuditLog.findOne({ action: 'member_added', groupId: group.groupId });
+      assertAuditEntry(log, {
+        event_type: 'member_added',
+        actor_id: leader.userId,
+        group_id: group.groupId,
+        payload: { student_id: invitee.userId, via: 'leader_invitation' },
+      });
+    });
+  });
+
+  // ── membership_decision ───────────────────────────────────────────────────────
+
+  describe('membership_decision', () => {
+    const setupInvitation = async (leaderId, studentId) => {
+      const group = await makeGroup(leaderId);
+      await MemberInvitation.create({
+        groupId: group.groupId,
+        inviteeId: studentId,
+        invitedBy: leaderId,
+        status: 'pending',
+      });
+      await GroupMembership.create({ groupId: group.groupId, studentId, status: 'pending' });
+      return group;
+    };
+
+    beforeEach(() => {
+      const notifService = require('../src/services/notificationService');
+      notifService.dispatchMembershipDecisionNotification = jest.fn().mockResolvedValue({
+        notification_id: 'notif_002',
+      });
+    });
+
+    it('produces a membership_decision entry when student accepts', async () => {
+      const leader = await makeUser({ userId: 'usr_leader_md_a' });
+      const student = await makeUser({ userId: 'usr_student_md_a' });
+      const group = await setupInvitation(leader.userId, student.userId);
+
+      const req = makeReq(
+        { decision: 'accepted' },
+        { groupId: group.groupId },
+        { userId: student.userId, role: 'student' }
+      );
+      await membershipDecision(req, makeRes());
+
+      const log = await AuditLog.findOne({
+        action: 'membership_decision',
+        groupId: group.groupId,
+        actorId: student.userId,
+        'payload.decision': 'accepted',
+      });
+      assertAuditEntry(log, {
+        event_type: 'membership_decision',
+        actor_id: student.userId,
+        group_id: group.groupId,
+        payload: { decision: 'accepted', status: 'approved' },
+      });
+    });
+
+    it('produces a membership_decision entry when student rejects', async () => {
+      const leader = await makeUser({ userId: 'usr_leader_md_r' });
+      const student = await makeUser({ userId: 'usr_student_md_r' });
+      const group = await setupInvitation(leader.userId, student.userId);
+
+      const req = makeReq(
+        { decision: 'rejected' },
+        { groupId: group.groupId },
+        { userId: student.userId, role: 'student' }
+      );
+      await membershipDecision(req, makeRes());
+
+      const log = await AuditLog.findOne({
+        action: 'membership_decision',
+        groupId: group.groupId,
+        actorId: student.userId,
+        'payload.decision': 'rejected',
+      });
+      assertAuditEntry(log, {
+        event_type: 'membership_decision',
+        actor_id: student.userId,
+        group_id: group.groupId,
+        payload: { decision: 'rejected', status: 'rejected' },
+      });
+    });
+  });
+
+  // ── coordinator_override ──────────────────────────────────────────────────────
+
+  describe('coordinator_override', () => {
+    it('produces coordinator_override + member_added entries for add_member', async () => {
+      const student = await makeUser({ userId: 'usr_stu_co_add' });
+      const group = await makeGroup('usr_leader_co_add');
+
+      const req = makeReq(
+        { action: 'add_member', target_student_id: student.userId, reason: 'Exception approval' },
+        { groupId: group.groupId },
+        { userId: 'usr_coord_add', role: 'coordinator' }
+      );
+      const res = makeRes();
+      await coordinatorOverride(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      const overrideLog = await AuditLog.findOne({
+        action: 'coordinator_override',
+        groupId: group.groupId,
+      });
+      assertAuditEntry(overrideLog, {
+        event_type: 'coordinator_override',
+        actor_id: 'usr_coord_add',
+        group_id: group.groupId,
+        payload: { action: 'add_member', target_student_id: student.userId },
+      });
+
+      const addedLog = await AuditLog.findOne({
+        action: 'member_added',
+        groupId: group.groupId,
+      });
+      assertAuditEntry(addedLog, {
+        event_type: 'member_added',
+        actor_id: 'usr_coord_add',
+        group_id: group.groupId,
+        payload: { student_id: student.userId, via: 'coordinator_override' },
+      });
+    });
+
+    it('produces coordinator_override + member_removed entries for remove_member', async () => {
+      const student = await makeUser({ userId: 'usr_stu_co_rem' });
+      const group = await makeGroup('usr_leader_co_rem', {
+        members: [{ userId: student.userId, role: 'member', status: 'accepted' }],
+      });
+      await GroupMembership.create({
+        groupId: group.groupId,
+        studentId: student.userId,
+        status: 'approved',
+      });
+
+      const req = makeReq(
+        { action: 'remove_member', target_student_id: student.userId, reason: 'Policy violation' },
+        { groupId: group.groupId },
+        { userId: 'usr_coord_rem', role: 'coordinator' }
+      );
+      const res = makeRes();
+      await coordinatorOverride(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      const removedLog = await AuditLog.findOne({
+        action: 'member_removed',
+        groupId: group.groupId,
+      });
+      assertAuditEntry(removedLog, {
+        event_type: 'member_removed',
+        actor_id: 'usr_coord_rem',
+        group_id: group.groupId,
+        payload: { student_id: student.userId, via: 'coordinator_override' },
+      });
+
+      const overrideLog = await AuditLog.findOne({
+        action: 'coordinator_override',
+        groupId: group.groupId,
+        'payload.action': 'remove_member',
+      });
+      expect(overrideLog).not.toBeNull();
+      expect(overrideLog.payload.target_student_id).toBe(student.userId);
+      expect(overrideLog.payload.reason).toBe('Policy violation');
+    });
+  });
+
+  // ── github_integration_setup ──────────────────────────────────────────────────
+
+  describe('github_integration_setup', () => {
+    it('produces a github_integration_setup entry on success', async () => {
+      const group = await makeGroup('usr_leader_gh');
+
+      axios.get
+        .mockResolvedValueOnce({ status: 200, data: { login: 'usr_leader_gh' } })
+        .mockResolvedValueOnce({ status: 200, data: { login: 'my-org', id: 42, name: 'My Org' } });
+
+      const req = makeReq(
+        { pat: 'ghp_validtoken', org: 'my-org' },
+        { groupId: group.groupId },
+        { userId: 'usr_leader_gh', role: 'student' }
+      );
+      const res = makeRes();
+      await configureGithub(req, res);
+      expect(res.status).toHaveBeenCalledWith(201);
+
+      const log = await AuditLog.findOne({
+        action: 'github_integration_setup',
+        groupId: group.groupId,
+      });
+      assertAuditEntry(log, {
+        event_type: 'github_integration_setup',
+        actor_id: 'usr_leader_gh',
+        group_id: group.groupId,
+        payload: { status: 'success', org: 'my-org' },
+      });
+    });
+
+    it('produces a sync_error entry when GitHub API is unavailable', async () => {
+      const group = await makeGroup('usr_leader_gh2');
+      axios.get.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+      const req = makeReq(
+        { pat: 'ghp_token', org: 'my-org' },
+        { groupId: group.groupId },
+        { userId: 'usr_leader_gh2', role: 'student' }
+      );
+      const res = makeRes();
+      await configureGithub(req, res);
+      expect(res.status).toHaveBeenCalledWith(503);
+
+      const log = await AuditLog.findOne({
+        action: 'sync_error',
+        groupId: group.groupId,
+        'payload.api_type': 'github',
+      });
+      assertAuditEntry(log, {
+        event_type: 'sync_error',
+        actor_id: 'usr_leader_gh2',
+        group_id: group.groupId,
+        payload: { api_type: 'github', retry_count: 3 },
+      });
+      expect(log.payload.last_error).toBeTruthy();
+      expect(log.payload.sync_error_id).toBeTruthy();
+    });
+  });
+
+  // ── jira_integration_setup ────────────────────────────────────────────────────
+
+  describe('jira_integration_setup', () => {
+    it('produces a jira_integration_setup entry on success', async () => {
+      const group = await makeGroup('usr_leader_jira');
+
+      axios.get
+        .mockResolvedValueOnce({ status: 200, data: { accountId: 'acc_123' } })
+        .mockResolvedValueOnce({ status: 200, data: { key: 'PROJ', name: 'My Project' } });
+
+      const req = makeReq(
+        {
+          jira_url: 'https://myorg.atlassian.net',
+          jira_username: 'me@example.com',
+          jira_token: 'token123',
+          project_key: 'PROJ',
+        },
+        { groupId: group.groupId },
+        { userId: 'usr_leader_jira', role: 'student' }
+      );
+      const res = makeRes();
+      await configureJira(req, res);
+      expect(res.status).toHaveBeenCalledWith(201);
+
+      const log = await AuditLog.findOne({
+        action: 'jira_integration_setup',
+        groupId: group.groupId,
+      });
+      assertAuditEntry(log, {
+        event_type: 'jira_integration_setup',
+        actor_id: 'usr_leader_jira',
+        group_id: group.groupId,
+        payload: { status: 'success', project_key: 'PROJ' },
+      });
+    });
+
+    it('produces a sync_error entry when JIRA API is unavailable', async () => {
+      const group = await makeGroup('usr_leader_jira2');
+      axios.get.mockRejectedValue(new Error('connect ETIMEDOUT'));
+
+      const req = makeReq(
+        {
+          jira_url: 'https://myorg.atlassian.net',
+          jira_username: 'me@example.com',
+          jira_token: 'token123',
+          project_key: 'PROJ',
+        },
+        { groupId: group.groupId },
+        { userId: 'usr_leader_jira2', role: 'student' }
+      );
+      const res = makeRes();
+      await configureJira(req, res);
+      expect(res.status).toHaveBeenCalledWith(503);
+
+      const log = await AuditLog.findOne({
+        action: 'sync_error',
+        groupId: group.groupId,
+        'payload.api_type': 'jira',
+      });
+      assertAuditEntry(log, {
+        event_type: 'sync_error',
+        actor_id: 'usr_leader_jira2',
+        group_id: group.groupId,
+        payload: { api_type: 'jira', retry_count: 3 },
+      });
+      expect(log.payload.last_error).toBeTruthy();
+      expect(log.payload.sync_error_id).toBeTruthy();
+    });
+  });
+
+  // ── sync_error (notification service) ────────────────────────────────────────
+
+  describe('sync_error (notification service)', () => {
+    it('produces a sync_error entry when invitation notification fails after retries', async () => {
+      await openWindow('member_addition');
+      const leader = await makeUser({ userId: 'usr_leader_notif' });
+      const invitee = await makeUser({ userId: 'usr_invitee_notif' });
+      const group = await makeGroup(leader.userId);
+
+      const notifService = require('../src/services/notificationService');
+      notifService.dispatchInvitationNotification = jest
+        .fn()
+        .mockRejectedValue(new Error('Notification service down'));
+
+      const req = makeReq(
+        { student_ids: [invitee.userId] },
+        { groupId: group.groupId },
+        { userId: leader.userId, role: 'student' }
+      );
+      const res = makeRes();
+      await addMember(req, res);
+      // Main operation still succeeds
+      expect(res.status).toHaveBeenCalledWith(201);
+
+      const syncLog = await AuditLog.findOne({
+        action: 'sync_error',
+        groupId: group.groupId,
+        'payload.api_type': 'notification',
+      });
+      expect(syncLog).not.toBeNull();
+      expect(syncLog.actorId).toBe(leader.userId);
+      expect(syncLog.payload.retry_count).toBe(3);
+      expect(syncLog.payload.last_error).toBeTruthy();
+      expect(syncLog.payload.sync_error_id).toBeTruthy();
+    });
+  });
+
+  // ── Schema compliance ─────────────────────────────────────────────────────────
+
+  describe('Schema compliance (event_type, actor_id, group_id, timestamp)', () => {
+    it('every group event log includes all minimum required fields', async () => {
+      const student = await makeUser({ userId: 'usr_stu_schema' });
+      const group = await makeGroup('usr_leader_schema', {
+        members: [{ userId: student.userId, role: 'member', status: 'accepted' }],
+      });
+      await GroupMembership.create({
+        groupId: group.groupId,
+        studentId: student.userId,
+        status: 'approved',
+      });
+
+      const req = makeReq(
+        { action: 'remove_member', target_student_id: student.userId, reason: 'Schema test' },
+        { groupId: group.groupId },
+        { userId: 'usr_coord_schema', role: 'coordinator' }
+      );
+      await coordinatorOverride(req, makeRes());
+
+      const logs = await AuditLog.find({ groupId: group.groupId });
+      expect(logs.length).toBeGreaterThan(0);
+
+      for (const log of logs) {
+        expect(log.action).toBeTruthy();                       // event_type
+        expect(log.actorId).toBeTruthy();                      // actor_id
+        expect(log.groupId).toBeTruthy();                      // group_id
+        expect(log.timestamp || log.createdAt).toBeTruthy();   // timestamp
+      }
+    });
+  });
+
+  // ── Append-only & queryability ────────────────────────────────────────────────
+
+  describe('Append-only guarantee and queryability', () => {
+    let generateTokenPair;
+
+    beforeAll(() => {
+      ({ generateTokenPair } = require('../src/utils/jwt'));
+    });
+
+    it('GET /api/v1/audit-logs returns entries queryable by group_id', async () => {
+      const coord = await makeUser({ userId: 'usr_coord_q1', role: 'coordinator' });
+      const { accessToken } = generateTokenPair(coord.userId, 'coordinator');
+
+      await AuditLog.create({
+        action: 'group_created',
+        actorId: coord.userId,
+        groupId: 'grp_query_test_1',
+        payload: { group_name: 'Query Group' },
+        timestamp: new Date(),
+      });
+
+      const res = await request(app)
+        .get('/api/v1/audit-logs?group_id=grp_query_test_1')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBeGreaterThanOrEqual(1);
+      const entry = res.body.entries[0];
+      expect(entry.event_type).toBe('group_created');
+      expect(entry.group_id).toBe('grp_query_test_1');
+      expect(entry.event_id).toBeTruthy();
+      expect(entry.timestamp).toBeTruthy();
+    });
+
+    it('GET /api/v1/audit-logs filters by event_type', async () => {
+      const coord = await makeUser({ userId: 'usr_coord_q2', role: 'coordinator' });
+      const { accessToken } = generateTokenPair(coord.userId, 'coordinator');
+
+      await AuditLog.create([
+        {
+          action: 'github_integration_setup',
+          actorId: coord.userId,
+          groupId: 'grp_et_test',
+          payload: { status: 'success' },
+          timestamp: new Date(),
+        },
+        {
+          action: 'jira_integration_setup',
+          actorId: coord.userId,
+          groupId: 'grp_et_test',
+          payload: { status: 'success' },
+          timestamp: new Date(),
+        },
+      ]);
+
+      const res = await request(app)
+        .get('/api/v1/audit-logs?group_id=grp_et_test&event_type=github_integration_setup')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.entries[0].event_type).toBe('github_integration_setup');
+    });
+
+    it('DELETE /api/v1/audit-logs/:id returns 404 — append-only, no delete endpoint exists', async () => {
+      const coord = await makeUser({ userId: 'usr_coord_del', role: 'coordinator' });
+      const { accessToken } = generateTokenPair(coord.userId, 'coordinator');
+
+      const log = await AuditLog.create({
+        action: 'group_created',
+        actorId: coord.userId,
+        groupId: 'grp_del_test',
+        timestamp: new Date(),
+      });
+
+      const res = await request(app)
+        .delete(`/api/v1/audit-logs/${log.auditId}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect([404, 405, 403]).toContain(res.status);
+
+      // Entry must still exist in the database
+      const still = await AuditLog.findById(log._id);
+      expect(still).not.toBeNull();
+    });
+
+    it('GET /api/v1/audit-logs returns 400 when no filter is provided', async () => {
+      const coord = await makeUser({ userId: 'usr_coord_nf', role: 'coordinator' });
+      const { accessToken } = generateTokenPair(coord.userId, 'coordinator');
+
+      const res = await request(app)
+        .get('/api/v1/audit-logs')
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('MISSING_FILTER');
+    });
+
+    it('GET /api/v1/audit-logs returns 401 for unauthenticated requests', async () => {
+      const res = await request(app).get('/api/v1/audit-logs?group_id=grp_any');
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
Adds append-only audit log entries for all write-path actions in Process 2.0, satisfying issue #50 acceptance criteria.

Schema: AuditLog extended with groupId, payload, and timestamp fields; new snake_case event types added alongside legacy uppercase variants; compound index on (groupId, action) for efficient queries.

Events logged:
- group_created (createGroup)
- member_added (leader invitation + coordinator add_member override)
- member_removed (coordinator override)
- membership_decision (accept / reject / auto-deny)
- coordinator_override (update_group, add_member, remove_member)
- github_integration_setup (success)
- jira_integration_setup (success)
- sync_error (GitHub, JIRA, and notification service failures)

New read-only endpoint: GET /api/v1/audit-logs?group_id=&event_type= Returns entries shaped as {event_id, event_type, actor_id, group_id, payload, timestamp}. No write/delete routes exist (append-only).

Tests: 17 new tests in audit-logging-group-events.test.js covering all event types, schema compliance, queryability, and append-only guarantee.