### PR TITLE
feat: implement GitHub integration setup for groups with PAT validation and repository configuration

### DIFF
--- a/backend/migrations/005_add_github_fields_to_groups.js
+++ b/backend/migrations/005_add_github_fields_to_groups.js
@@ -1,0 +1,65 @@
+/**
+ * Migration: 005_add_github_fields_to_groups
+ *
+ * Adds GitHub integration fields to the groups collection:
+ * - githubRepoName: repository name for the GitHub project
+ * - githubVisibility: visibility setting (private, public, internal) - defaults to 'private'
+ *
+ * Any pre-existing groups without these fields are backfilled with defaults.
+ */
+
+module.exports = {
+  name: '005_add_github_fields_to_groups',
+
+  up: async (db) => {
+    const conn = db.connection.db;
+
+    const collections = await conn.listCollections({ name: 'groups' }).toArray();
+    if (collections.length === 0) {
+      console.log('[MIGRATION] groups collection does not exist, skipping migration');
+      return;
+    }
+
+    const coll = conn.collection('groups');
+
+    // Backfill existing documents that lack githubRepoName and githubVisibility
+    const result = await coll.updateMany(
+      { $and: [{ githubRepoName: { $exists: false } }, { githubVisibility: { $exists: false } }] },
+      { $set: { githubRepoName: null, githubVisibility: 'private' } }
+    );
+    console.log(`[MIGRATION] Backfilled GitHub fields on ${result.modifiedCount} group document(s)`);
+
+    // Add indexes for GitHub integration queries
+    await coll.createIndex({ githubOrg: 1 });
+    console.log('[MIGRATION] Ensured index: groups.githubOrg');
+  },
+
+  down: async (db) => {
+    const conn = db.connection.db;
+
+    const collections = await conn.listCollections({ name: 'groups' }).toArray();
+    if (collections.length === 0) {
+      console.log('[MIGRATION] groups collection does not exist, skipping rollback');
+      return;
+    }
+
+    const coll = conn.collection('groups');
+
+    // Remove the added fields
+    const result = await coll.updateMany(
+      {},
+      { $unset: { githubRepoName: '', githubVisibility: '' } }
+    );
+    console.log(`[MIGRATION] Removed GitHub fields from ${result.modifiedCount} group document(s)`);
+
+    // Drop indexes
+    try {
+      await coll.dropIndex('githubOrg_1');
+      console.log('[MIGRATION] Dropped index: groups.githubOrg');
+    } catch (err) {
+      if (!err.message.includes('index not found')) {
+        throw err;
+      }
+    }
+  },
+};

--- a/backend/migrations/index.js
+++ b/backend/migrations/index.js
@@ -7,6 +7,7 @@ const migration001 = require('./001_create_user_schema');
 const migration002 = require('./002_add_githubUsername_unique_constraint');
 const migration003 = require('./003_create_group_schema');
 const migration004 = require('./004_add_operation_type_to_schedule_windows');
+const migration005 = require('./005_add_github_fields_to_groups');
 
 // Migrations are applied in order
 const migrations = [
@@ -14,6 +15,7 @@ const migrations = [
   migration002,
   migration003,
   migration004,
+  migration005,
 ];
 
 module.exports = migrations;

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -38,10 +38,21 @@ const withRetry = async (fn, maxAttempts = MAX_RETRY_ATTEMPTS) => {
  * Process 2.6 — Validate GitHub PAT + org and store config in D2.
  *
  * DFD flows:
- *   f10 — Team Leader → 2.6 (submit GitHub PAT + org)
+ *   f10 — Team Leader → 2.6 (submit GitHub PAT + org + repo_name + visibility)
  *   f11 — 2.6 → GitHub API (validate PAT, retrieve org data)
  *   f12 — GitHub API → 2.6 (return org data)
  *   f24 — 2.6 → D2 (store validated GitHub config)
+ *
+ * Request body:
+ *   - pat (required): GitHub Personal Access Token
+ *   - org_name (required): GitHub organization name
+ *   - repo_name (required): Repository name
+ *   - visibility (optional): Visibility setting (private, public, internal); default: private
+ *
+ * Response (201 Created):
+ *   - repo_url: Full GitHub repository URL
+ *   - status: "success"
+ *   - org_data: { id, login, name } from GitHub API
  *
  * Error codes:
  *   422 INVALID_PAT         — GitHub API rejects the token (401/403)
@@ -51,13 +62,20 @@ const withRetry = async (fn, maxAttempts = MAX_RETRY_ATTEMPTS) => {
 const configureGithub = async (req, res) => {
   try {
     const { groupId } = req.params;
-    const { pat, org } = req.body;
+    const { pat, org_name, repo_name, visibility = 'private' } = req.body;
 
+    // Validate required fields
     if (!pat || typeof pat !== 'string' || !pat.trim()) {
       return res.status(400).json({ code: 'MISSING_PAT', message: 'pat is required' });
     }
-    if (!org || typeof org !== 'string' || !org.trim()) {
-      return res.status(400).json({ code: 'MISSING_ORG', message: 'org is required' });
+    if (!org_name || typeof org_name !== 'string' || !org_name.trim()) {
+      return res.status(400).json({ code: 'MISSING_ORG', message: 'org_name is required' });
+    }
+    if (!repo_name || typeof repo_name !== 'string' || !repo_name.trim()) {
+      return res.status(400).json({ code: 'MISSING_REPO', message: 'repo_name is required' });
+    }
+    if (!['private', 'public', 'internal'].includes(visibility)) {
+      return res.status(400).json({ code: 'INVALID_VISIBILITY', message: 'visibility must be one of: private, public, internal' });
     }
 
     const group = await Group.findOne({ groupId });
@@ -114,7 +132,7 @@ const configureGithub = async (req, res) => {
     // f12: retrieve org data
     try {
       const orgResponse = await withRetry(() =>
-        axios.get(`https://api.github.com/orgs/${org.trim()}`, {
+        axios.get(`https://api.github.com/orgs/${org_name.trim()}`, {
           headers: { Authorization: `Bearer ${pat.trim()}`, 'User-Agent': 'senior-app' },
           timeout: 5000,
         })
@@ -154,8 +172,10 @@ const configureGithub = async (req, res) => {
 
     // f24: store config in D2
     group.githubPat = pat.trim();
-    group.githubOrg = org.trim();
-    group.githubRepoUrl = `https://github.com/${org.trim()}`;
+    group.githubOrg = org_name.trim();
+    group.githubRepoName = repo_name.trim();
+    group.githubVisibility = visibility;
+    group.githubRepoUrl = `https://github.com/${org_name.trim()}/${repo_name.trim()}`;
     await group.save();
 
     // Audit log: github_integration_setup (non-fatal)
@@ -167,7 +187,9 @@ const configureGithub = async (req, res) => {
         groupId,
         payload: {
           status: 'success',
-          org: org.trim(),
+          org_name: org_name.trim(),
+          repo_name: repo_name.trim(),
+          visibility: visibility,
           github_repo_url: group.githubRepoUrl,
         },
         ipAddress: req.ip,
@@ -178,10 +200,13 @@ const configureGithub = async (req, res) => {
     }
 
     return res.status(201).json({
-      github_org: group.githubOrg,
-      github_repo_url: group.githubRepoUrl,
-      validated: true,
-      org_data: { login: orgData.login, id: orgData.id, name: orgData.name },
+      repo_url: group.githubRepoUrl,
+      status: 'success',
+      org_data: { 
+        id: orgData.id, 
+        login: orgData.login, 
+        name: orgData.name 
+      },
     });
   } catch (err) {
     console.error('configureGithub error:', err);

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -47,9 +47,18 @@ const groupSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    githubRepoName: {
+      type: String,
+      default: null,
+    },
     githubRepoUrl: {
       type: String,
       default: null,
+    },
+    githubVisibility: {
+      type: String,
+      enum: ['private', 'public', 'internal'],
+      default: 'private',
     },
     githubPat: {
       type: String,

--- a/backend/tests/githubIntegration.test.js
+++ b/backend/tests/githubIntegration.test.js
@@ -114,7 +114,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
   // ── configureGithub happy path ─────────────────────────────────────────────────
 
   describe('POST /groups/:groupId/github — configureGithub', () => {
-    it('returns 200 with github_org, validated: true, org_data on success', async () => {
+    it('returns 201 with repo_url, status, org_data on success', async () => {
       mockValidPat();
       mockValidOrg('cool-org');
 
@@ -122,31 +122,33 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_validtoken', org: 'cool-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_validtoken', org_name: 'cool-org', repo_name: 'my-repo', visibility: 'private' }),
         res
       );
 
       expect(res.status).toHaveBeenCalledWith(201);
       const body = res.json.mock.calls[0][0];
-      expect(body.validated).toBe(true);
-      expect(body.github_org).toBe('cool-org');
+      expect(body.status).toBe('success');
+      expect(body.repo_url).toBe('https://github.com/cool-org/my-repo');
       expect(body.org_data).toMatchObject({ login: 'cool-org', id: 42 });
     });
 
-    it('f24: stores githubPat and githubOrg in D2 group record', async () => {
+    it('f24: stores githubPat, githubOrg, githubRepoName, and githubVisibility in D2', async () => {
       mockValidPat();
       mockValidOrg('my-org');
 
       const group = await makeGroup();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_secret', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_secret', org_name: 'my-org', repo_name: 'test-repo', visibility: 'public' }),
         makeRes()
       );
 
       const updated = await Group.findOne({ groupId: group.groupId });
       expect(updated.githubPat).toBe('ghp_secret');
       expect(updated.githubOrg).toBe('my-org');
+      expect(updated.githubRepoName).toBe('test-repo');
+      expect(updated.githubVisibility).toBe('public');
     });
 
     it('f11: makes PAT validation call to https://api.github.com/user', async () => {
@@ -155,7 +157,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
 
       const group = await makeGroup();
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_token', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_token', org_name: 'my-org', repo_name: 'my-repo' }),
         makeRes()
       );
 
@@ -173,7 +175,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
 
       const group = await makeGroup();
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_token', org: 'target-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_token', org_name: 'target-org', repo_name: 'my-repo' }),
         makeRes()
       );
 
@@ -191,17 +193,17 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const group = await makeGroup();
       const res = makeRes();
 
-      await configureGithub(makeReq({ groupId: group.groupId }, { org: 'my-org' }), res);
+      await configureGithub(makeReq({ groupId: group.groupId }, { org_name: 'my-org', repo_name: 'my-repo' }), res);
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json.mock.calls[0][0].code).toBe('MISSING_PAT');
     });
 
-    it('returns 400 MISSING_ORG when org is absent', async () => {
+    it('returns 400 MISSING_ORG when org_name is absent', async () => {
       const group = await makeGroup();
       const res = makeRes();
 
-      await configureGithub(makeReq({ groupId: group.groupId }, { pat: 'ghp_x' }), res);
+      await configureGithub(makeReq({ groupId: group.groupId }, { pat: 'ghp_x', repo_name: 'my-repo' }), res);
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json.mock.calls[0][0].code).toBe('MISSING_ORG');
@@ -214,7 +216,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_x', org: 'org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_x', org_name: 'org', repo_name: 'repo' }),
         res
       );
 
@@ -226,7 +228,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: 'grp_none' }, { pat: 'ghp_x', org: 'org' }),
+        makeReq({ groupId: 'grp_none' }, { pat: 'ghp_x', org_name: 'org', repo_name: 'repo' }),
         res
       );
 
@@ -243,7 +245,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_bad', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_bad', org_name: 'my-org', repo_name: 'my-repo' }),
         res
       );
 
@@ -258,7 +260,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_bad', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_bad', org_name: 'my-org', repo_name: 'my-repo' }),
         res
       );
 
@@ -274,7 +276,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_valid', org: 'ghost-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_valid', org_name: 'ghost-org', repo_name: 'my-repo' }),
         res
       );
 
@@ -291,7 +293,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_timeout', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_timeout', org_name: 'my-org', repo_name: 'my-repo' }),
         res
       );
 
@@ -305,7 +307,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const group = await makeGroup();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_timeout', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_timeout', org_name: 'my-org', repo_name: 'my-repo' }),
         makeRes()
       );
 
@@ -322,7 +324,7 @@ describe('groupIntegrations — GitHub (f10-f12, f24)', () => {
       const res = makeRes();
 
       await configureGithub(
-        makeReq({ groupId: group.groupId }, { pat: 'ghp_valid', org: 'my-org' }),
+        makeReq({ groupId: group.groupId }, { pat: 'ghp_valid', org_name: 'my-org', repo_name: 'my-repo' }),
         res
       );
 

--- a/frontend/src/api/groupService.js
+++ b/frontend/src/api/groupService.js
@@ -300,3 +300,28 @@ export const transitionGroupStatus = async (groupId, newStatus, reason) => {
   });
   return response.data;
 };
+
+/**
+ * Configure GitHub integration for a group (Process 2.6)
+ * @param {string} groupId - The group ID
+ * @param {object} payload
+ * @param {string} payload.pat - GitHub Personal Access Token
+ * @param {string} payload.org_name - GitHub organization name
+ * @param {string} payload.repo_name - Repository name
+ * @param {string} [payload.visibility] - Visibility setting (private, public, internal); default: 'private'
+ * @returns {Promise<{repo_url, status, org_data}>}
+ */
+export const configureGitHub = async (groupId, { pat, org_name, repo_name, visibility = 'private' }) => {
+  try {
+    const response = await apiClient.post(`/groups/${groupId}/github`, {
+      pat,
+      org_name,
+      repo_name,
+      visibility,
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error configuring GitHub:', error);
+    throw error;
+  }
+};

--- a/frontend/src/components/GitHubSetupForm.css
+++ b/frontend/src/components/GitHubSetupForm.css
@@ -1,0 +1,297 @@
+.github-setup-form-container {
+  padding: 1.5rem;
+  border-radius: 8px;
+  background-color: #f6f8fa;
+  border: 1px solid #d0d7de;
+}
+
+.github-setup-form-notice {
+  padding: 1rem;
+  border-radius: 6px;
+  background-color: #fff8c5;
+  border: 1px solid #d4a574;
+  color: #3d2817;
+}
+
+.github-setup-form-notice p {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+/* Toggle Button */
+.github-setup-toggle {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.github-setup-toggle:hover:not(:disabled) {
+  background-color: #238636;
+  border-color: #238636;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(35, 134, 54, 0.2);
+}
+
+.github-setup-toggle:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Form */
+.github-setup-form {
+  background-color: #ffffff;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  padding: 1.5rem;
+}
+
+.form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.form-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0d1117;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #57606a;
+  padding: 0.25rem;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.btn-close:hover:not(:disabled) {
+  color: #0d1117;
+}
+
+.btn-close:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Form Groups */
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: #0d1117;
+}
+
+.required {
+  color: #d1242f;
+}
+
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.form-input,
+.form-select {
+  width: 100%;
+  padding: 0.75rem;
+  font-size: 0.95rem;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  background-color: #ffffff;
+  color: #0d1117;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+}
+
+.form-input:focus,
+.form-select:focus {
+  outline: none;
+  border-color: #1f6feb;
+  box-shadow: 0 0 0 3px rgba(31, 111, 235, 0.1);
+}
+
+.form-input:disabled,
+.form-select:disabled {
+  background-color: #f6f8fa;
+  color: #57606a;
+  cursor: not-allowed;
+}
+
+.input-wrapper .form-input {
+  padding-right: 2.5rem;
+}
+
+.btn-icon {
+  position: absolute;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
+  font-size: 1rem;
+  color: #57606a;
+  transition: color 0.2s ease;
+}
+
+.btn-icon:hover:not(:disabled) {
+  color: #0d1117;
+}
+
+.btn-icon:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-help {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: #57606a;
+  line-height: 1.4;
+}
+
+.form-help a {
+  color: #1f6feb;
+  text-decoration: none;
+  margin-left: 0.3rem;
+}
+
+.form-help a:hover {
+  text-decoration: underline;
+}
+
+/* Form Actions */
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid #e5e7eb;
+}
+
+.btn {
+  padding: 0.75rem 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  border: 1px solid;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background-color: #1f6feb;
+  color: #ffffff;
+  border-color: #1f6feb;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #1860d9;
+  border-color: #1860d9;
+}
+
+.btn-secondary {
+  background-color: #f6f8fa;
+  color: #24292f;
+  border-color: #d0d7de;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #eaeef2;
+  border-color: #c9cef5;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loading-spinner {
+  display: inline-block;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+/* Alerts */
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.alert-icon {
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.alert-success {
+  background-color: #dafbe1;
+  border: 1px solid #34d399;
+  color: #065f46;
+}
+
+.alert-error {
+  background-color: #fee2e2;
+  border: 1px solid #f87171;
+  color: #7f1d1d;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .github-setup-form {
+    padding: 1rem;
+  }
+
+  .form-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .btn-close {
+    align-self: flex-end;
+  }
+
+  .form-actions {
+    flex-direction: column;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/GitHubSetupForm.js
+++ b/frontend/src/components/GitHubSetupForm.js
@@ -1,0 +1,309 @@
+import React, { useState } from 'react';
+import { configureGitHub } from '../api/groupService';
+import './GitHubSetupForm.css';
+
+/**
+ * GitHub Integration Setup Form Component
+ * Allows the group leader to submit GitHub PAT, organization, repository, and visibility settings
+ * 
+ * Process 2.6: Setup GitHub Integration
+ * DFD flows: f10 (Team Leader → 2.6), f11 (2.6 → GitHub API), f12 (GitHub API → 2.6)
+ */
+const GitHubSetupForm = ({ groupId, onSuccess, onError, isLeader }) => {
+  const [formData, setFormData] = useState({
+    pat: '',
+    org_name: '',
+    repo_name: '',
+    visibility: 'private',
+  });
+  const [loading, setLoading] = useState(false);
+  const [successMsg, setSuccessMsg] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
+  const [showForm, setShowForm] = useState(false);
+  const [patVisible, setPatVisible] = useState(false);
+
+  const handleInputChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+    // Clear error message when user starts typing
+    if (errorMsg) {
+      setErrorMsg('');
+    }
+  };
+
+  const validateForm = () => {
+    const errors = [];
+    
+    if (!formData.pat.trim()) {
+      errors.push('Personal Access Token is required');
+    }
+    if (!formData.org_name.trim()) {
+      errors.push('Organization name is required');
+    }
+    if (!formData.repo_name.trim()) {
+      errors.push('Repository name is required');
+    }
+    if (!['private', 'public', 'internal'].includes(formData.visibility)) {
+      errors.push('Invalid visibility setting');
+    }
+
+    return errors;
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    // Validation
+    const errors = validateForm();
+    if (errors.length > 0) {
+      setErrorMsg(errors.join(', '));
+      return;
+    }
+
+    setLoading(true);
+    setErrorMsg('');
+    setSuccessMsg('');
+
+    try {
+      const response = await configureGitHub(groupId, formData);
+      
+      setSuccessMsg('GitHub integration configured successfully!');
+      
+      // Reset form
+      setFormData({
+        pat: '',
+        org_name: '',
+        repo_name: '',
+        visibility: 'private',
+      });
+      setShowForm(false);
+
+      // Call onSuccess callback if provided
+      if (onSuccess) {
+        onSuccess(response);
+      }
+
+      // Auto-clear success message after 5 seconds
+      setTimeout(() => {
+        setSuccessMsg('');
+      }, 5000);
+    } catch (error) {
+      const errorCode = error.response?.data?.code;
+      const errorMessage = error.response?.data?.message || 'Failed to configure GitHub';
+      
+      let userFriendlyError = errorMessage;
+
+      // Handle specific error codes
+      if (errorCode === 'INVALID_PAT') {
+        userFriendlyError = 'The GitHub PAT is invalid or has insufficient permissions. Please check your token.';
+      } else if (errorCode === 'ORG_NOT_FOUND') {
+        userFriendlyError = 'The GitHub organization was not found or your token lacks access to it.';
+      } else if (errorCode === 'GITHUB_API_UNAVAILABLE') {
+        userFriendlyError = 'GitHub API is currently unavailable. Please try again later.';
+      } else if (errorCode === 'MISSING_PAT') {
+        userFriendlyError = 'Personal Access Token is required.';
+      } else if (errorCode === 'MISSING_ORG') {
+        userFriendlyError = 'Organization name is required.';
+      } else if (errorCode === 'MISSING_REPO') {
+        userFriendlyError = 'Repository name is required.';
+      } else if (error.response?.status === 403) {
+        userFriendlyError = 'You do not have permission to configure GitHub for this group. Only the group leader can do this.';
+      } else if (error.response?.status === 404) {
+        userFriendlyError = 'Group not found.';
+      }
+
+      setErrorMsg(userFriendlyError);
+
+      // Call onError callback if provided
+      if (onError) {
+        onError(error);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!isLeader) {
+    return (
+      <div className="github-setup-form-notice">
+        <p>Only the group leader can configure GitHub integration.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="github-setup-form-container">
+      {successMsg && (
+        <div className="alert alert-success">
+          <svg className="alert-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 11-1.06-1.06l7.25-7.25a.75.75 0 011.06 0z" />
+            <path d="M2.22 8.78l2.5-2.5a.75.75 0 011.06 1.06l-2.5 2.5a.75.75 0 11-1.06-1.06z" />
+          </svg>
+          {successMsg}
+        </div>
+      )}
+
+      {errorMsg && (
+        <div className="alert alert-error">
+          <svg className="alert-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z" />
+          </svg>
+          {errorMsg}
+        </div>
+      )}
+
+      {!showForm ? (
+        <button
+          className="btn btn-primary github-setup-toggle"
+          onClick={() => setShowForm(true)}
+          disabled={loading}
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+          </svg>
+          Setup GitHub Integration
+        </button>
+      ) : (
+        <form onSubmit={handleSubmit} className="github-setup-form">
+          <div className="form-header">
+            <h3>GitHub Integration Setup</h3>
+            <button
+              type="button"
+              className="btn-close"
+              onClick={() => setShowForm(false)}
+              disabled={loading}
+              aria-label="Close form"
+            >
+              ✕
+            </button>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="pat" className="form-label">
+              Personal Access Token <span className="required">*</span>
+            </label>
+            <div className="input-wrapper">
+              <input
+                type={patVisible ? 'text' : 'password'}
+                id="pat"
+                name="pat"
+                value={formData.pat}
+                onChange={handleInputChange}
+                placeholder="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+                className="form-input"
+                disabled={loading}
+                autoComplete="off"
+              />
+              <button
+                type="button"
+                className="btn-icon"
+                onClick={() => setPatVisible(!patVisible)}
+                disabled={loading}
+                aria-label={patVisible ? 'Hide PAT' : 'Show PAT'}
+              >
+                {patVisible ? '👁️' : '👁️‍🗨️'}
+              </button>
+            </div>
+            <small className="form-help">
+              Your GitHub Personal Access Token. It will be securely stored and used for API calls.
+              <a href="https://github.com/settings/tokens" target="_blank" rel="noopener noreferrer">
+                Create a token
+              </a>
+            </small>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="org_name" className="form-label">
+              Organization Name <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              id="org_name"
+              name="org_name"
+              value={formData.org_name}
+              onChange={handleInputChange}
+              placeholder="e.g., my-organization"
+              className="form-input"
+              disabled={loading}
+              autoComplete="off"
+            />
+            <small className="form-help">
+              The GitHub organization where the repository will be created.
+            </small>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="repo_name" className="form-label">
+              Repository Name <span className="required">*</span>
+            </label>
+            <input
+              type="text"
+              id="repo_name"
+              name="repo_name"
+              value={formData.repo_name}
+              onChange={handleInputChange}
+              placeholder="e.g., senior-project"
+              className="form-input"
+              disabled={loading}
+              autoComplete="off"
+            />
+            <small className="form-help">
+              The name of the repository to create or use for this project.
+            </small>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="visibility" className="form-label">
+              Repository Visibility <span className="required">*</span>
+            </label>
+            <select
+              id="visibility"
+              name="visibility"
+              value={formData.visibility}
+              onChange={handleInputChange}
+              className="form-select"
+              disabled={loading}
+            >
+              <option value="private">Private</option>
+              <option value="public">Public</option>
+              <option value="internal">Internal</option>
+            </select>
+            <small className="form-help">
+              Determine who can access your repository. Default is private for security.
+            </small>
+          </div>
+
+          <div className="form-actions">
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={loading}
+            >
+              {loading ? (
+                <>
+                  <span className="loading-spinner">⌛</span>
+                  Validating...
+                </>
+              ) : (
+                'Configure GitHub'
+              )}
+            </button>
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={() => setShowForm(false)}
+              disabled={loading}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+};
+
+export default GitHubSetupForm;

--- a/frontend/src/components/GroupDashboard.css
+++ b/frontend/src/components/GroupDashboard.css
@@ -636,3 +636,16 @@
     text-align: center;
   }
 }
+
+/* ─── Integration Section ──────────────────────────── */
+.integration-section {
+  margin-bottom: 32px;
+}
+
+.integration-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #1a1a2e;
+  margin-bottom: 16px;
+  margin-top: 32px;
+}

--- a/frontend/src/components/GroupDashboard.js
+++ b/frontend/src/components/GroupDashboard.js
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useGroupStore from '../store/groupStore';
 import useAuthStore from '../store/authStore';
 import GitHubStatusCard from './GitHubStatusCard';
+import GitHubSetupForm from './GitHubSetupForm';
 import JiraStatusCard from './JiraStatusCard';
 import GroupMemberList from './GroupMemberList';
 import AddMemberForm from './AddMemberForm';
@@ -240,6 +241,24 @@ const GroupDashboard = () => {
             isLoading={isLoading}
             groupLeaderId={groupData?.leaderId}
           />
+
+          {/* GitHub Integration Setup — Team Leader only (Process 2.6) */}
+          {isLeader && (
+            <div className="integration-section">
+              <h2 className="integration-title">GitHub Integration Setup</h2>
+              <GitHubSetupForm
+                groupId={groupId}
+                onSuccess={() => {
+                  // Refresh dashboard to show updated GitHub configuration
+                  fetchGroupDashboard(groupId);
+                }}
+                onError={(error) => {
+                  console.error('GitHub setup error:', error);
+                }}
+                isLeader={isLeader}
+              />
+            </div>
+          )}
 
           {/* Add Member — Team Leader only (Process 2.3) */}
           {isLeader && (


### PR DESCRIPTION
# GitHub Integration Setup - PAT Validation & Repo Configuration

## Summary
Implements GitHub integration setup for group leaders. Users can now submit a PAT, organization name, repository name, and visibility settings. The system validates the PAT and org against GitHub API and stores the approved configuration.

## What's New

### Backend
- `Group` model: Added `githubRepoName` and `githubVisibility` fields
- `POST /groups/{groupId}/github`: Enhanced with repo config, full GitHub API validation, retry logic
- New migration: `005_add_github_fields_to_groups.js`

### Frontend
- New component: `GitHubSetupForm.js` - Complete setup form with validation
- New service: `configureGitHub()` in `groupService.js`
- Updated: `GroupDashboard.js` - Integrated setup form (leader-only)

### Tests
- Updated all GitHub integration tests to match new request/response format

## Key Features
✅ PAT validation via GitHub API
✅ Organization lookup and data extraction
✅ 3-retry logic with exponential backoff
✅ Comprehensive error handling (400/403/404/422/503)
✅ Audit logging and sync error tracking
✅ User-friendly form with validation
✅ Leader-only access control

## Testing
1. Create group as student
2. Navigate to Group Dashboard (as leader)
3. Fill GitHub Setup Form with valid PAT and organization
4. Verify repo URL and org data in response
5. Check MongoDB that all fields are stored

## Files Changed
- backend: `Group.js`, `groupIntegrations.js`, migrations, tests
- frontend: `groupService.js`, `GroupDashboard.js`, new GitHubSetupForm component

## Related Issue
Closes #38 - FS: GitHub Integration Setup (PAT Validation + Repo Config)