### PR TITLE
committee assignment UI, API services, and full unit + E2E test coverage

### DIFF
--- a/frontend/src/__tests__/committeeAssignment.e2e.test.js
+++ b/frontend/src/__tests__/committeeAssignment.e2e.test.js
@@ -1,0 +1,175 @@
+import React, { useState } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import useAuthStore from '../store/authStore';
+import {
+  createCommittee,
+  assignAdvisors,
+  assignJury,
+  validateCommittee,
+  publishCommittee,
+} from '../api/committeeService';
+import { submitDeliverable } from '../api/deliverableService';
+import CommitteeCreationForm from '../components/committee/CommitteeCreationForm';
+import AdvisorAssignmentPanel from '../components/committee/AdvisorAssignmentPanel';
+import JuryAssignmentPanel from '../components/committee/JuryAssignmentPanel';
+import CommitteeValidationCard from '../components/committee/CommitteeValidationCard';
+import PublishConfirmationDialog from '../components/committee/PublishConfirmationDialog';
+import StudentCommitteeStatus from '../components/committee/StudentCommitteeStatus';
+import JuryCommitteePanel from '../components/committee/JuryCommitteePanel';
+import DeliverableSubmissionForm from '../components/committee/DeliverableSubmissionForm';
+
+jest.mock('../store/authStore', () => jest.fn());
+jest.mock('../api/committeeService', () => ({
+  createCommittee: jest.fn(),
+  assignAdvisors: jest.fn(),
+  assignJury: jest.fn(),
+  validateCommittee: jest.fn(),
+  publishCommittee: jest.fn(),
+}));
+jest.mock('../api/deliverableService', () => ({
+  submitDeliverable: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuthStore.mockImplementation((selector) =>
+    selector({ user: { userId: 'coordinator-1', role: 'coordinator' }, isAuthenticated: true })
+  );
+});
+
+const CommitteeAssignmentFlow = () => {
+  const [committee, setCommittee] = useState(null);
+  const [validationResult, setValidationResult] = useState(null);
+  const [publishOpen, setPublishOpen] = useState(false);
+  const [committeePublished, setCommitteePublished] = useState(null);
+
+  const handleCreateSuccess = (created) => {
+    setCommittee(created);
+    setCommitteePublished(null);
+    setValidationResult(null);
+  };
+
+  const handleValidate = async () => {
+    if (!committee) return;
+    const result = await validateCommittee(committee.committeeId);
+    setValidationResult(result);
+  };
+
+  const handlePublish = () => {
+    setPublishOpen(true);
+  };
+
+  const handleConfirmPublish = async () => {
+    if (!committee) return;
+    const result = await publishCommittee(committee.committeeId);
+    const published = {
+      ...committee,
+      status: 'published',
+      publishedAt: result.publishedAt,
+      advisorIds: ['a1'],
+      juryIds: ['j1'],
+    };
+    setCommittee(published);
+    setCommitteePublished(published);
+    setPublishOpen(false);
+  };
+
+  return (
+    <div>
+      <CommitteeCreationForm onCreateSuccess={handleCreateSuccess} />
+      <AdvisorAssignmentPanel
+        committeeId={committee?.committeeId}
+        availableAdvisors={[{ id: 'a1', name: 'Advisor 1' }]}
+      />
+      <JuryAssignmentPanel
+        committeeId={committee?.committeeId}
+        availableJury={[{ id: 'j1', name: 'Jury 1' }]}
+      />
+      <button type="button" data-testid="validate-committee-btn" onClick={handleValidate}>
+        Validate Committee
+      </button>
+      <CommitteeValidationCard
+        validationResult={validationResult}
+        onPublishClick={handlePublish}
+        disabled={committee?.status === 'published'}
+      />
+      <PublishConfirmationDialog
+        open={publishOpen}
+        committeeName={committee?.committeeName || ''}
+        onCancel={() => setPublishOpen(false)}
+        onConfirm={handleConfirmPublish}
+      />
+      <StudentCommitteeStatus committee={committeePublished} />
+      <JuryCommitteePanel committees={committeePublished ? [committeePublished] : []} />
+      <DeliverableSubmissionForm committee={committeePublished} groupId="g1" scheduleOpen={true} />
+    </div>
+  );
+};
+
+describe('Committee Assignment E2E flow', () => {
+  it('creates committee, assigns advisors/jury, validates, publishes, and submits deliverable', async () => {
+    const user = userEvent.setup();
+
+    createCommittee.mockResolvedValue({
+      committeeId: 'c1',
+      committeeName: 'Test Committee',
+      status: 'draft',
+    });
+    assignAdvisors.mockResolvedValue({});
+    assignJury.mockResolvedValue({});
+    validateCommittee.mockResolvedValue({ valid: true, missingRequirements: [] });
+    publishCommittee.mockResolvedValue({ publishedAt: '2026-04-13T12:00:00Z' });
+    submitDeliverable.mockResolvedValue({
+      deliverableId: 'd1',
+      submittedAt: '2026-04-13T12:05:00Z',
+      storageRef: 'https://example.com/d1',
+    });
+
+    render(<CommitteeAssignmentFlow />);
+
+    // Create committee
+    await user.type(screen.getByTestId('committee-name-input'), 'Test Committee');
+    await user.click(screen.getByTestId('committee-submit-btn'));
+    await waitFor(() => expect(createCommittee).toHaveBeenCalled());
+
+    // Assign advisor
+    await user.click(screen.getByTestId('advisor-checkbox-a1'));
+    await user.click(screen.getByTestId('advisor-submit-btn'));
+    await waitFor(() => expect(assignAdvisors).toHaveBeenCalledWith('c1', ['a1']));
+
+    // Assign jury
+    await user.click(screen.getByTestId('jury-checkbox-j1'));
+    await user.click(screen.getByTestId('jury-submit-btn'));
+    await waitFor(() => expect(assignJury).toHaveBeenCalledWith('c1', ['j1']));
+
+    // Validate
+    await user.click(screen.getByTestId('validate-committee-btn'));
+    await waitFor(() => expect(validateCommittee).toHaveBeenCalledWith('c1'));
+    await waitFor(() => expect(screen.getByTestId('publish-button')).toBeEnabled());
+
+    // Publish
+    await user.click(screen.getByTestId('publish-button'));
+    await waitFor(() => expect(screen.getByTestId('publish-confirmation-dialog')).toBeInTheDocument());
+    await user.click(screen.getByTestId('publish-confirm-btn'));
+    await waitFor(() => expect(publishCommittee).toHaveBeenCalledWith('c1'));
+
+    expect(screen.getByTestId('student-committee-card')).toBeInTheDocument();
+    expect(screen.getByTestId('committee-published-at')).toHaveTextContent('Published at: 2026-04-13T12:00:00Z');
+    expect(screen.getByTestId('jury-committee-card')).toHaveTextContent('Test Committee');
+
+    // Submit deliverable
+    await user.selectOptions(screen.getByTestId('deliverable-type-selector'), 'demonstration');
+    await user.type(screen.getByTestId('deliverable-storage-ref'), 'https://example.com/d1');
+    await user.click(screen.getByTestId('deliverable-submit-btn'));
+    await waitFor(() => expect(submitDeliverable).toHaveBeenCalledWith({
+      committeeId: 'c1',
+      groupId: 'g1',
+      type: 'demonstration',
+      storageRef: 'https://example.com/d1',
+    }));
+    expect(screen.getByTestId('deliverable-success-card')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/committeeAssignment.test.js
+++ b/frontend/src/__tests__/committeeAssignment.test.js
@@ -1,0 +1,232 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+import useAuthStore from '../store/authStore';
+import {
+  createCommittee,
+  assignAdvisors,
+  assignJury,
+  validateCommittee,
+  publishCommittee,
+} from '../api/committeeService';
+import { submitDeliverable } from '../api/deliverableService';
+import CommitteeCreationForm from '../components/committee/CommitteeCreationForm';
+import AdvisorAssignmentPanel from '../components/committee/AdvisorAssignmentPanel';
+import JuryAssignmentPanel from '../components/committee/JuryAssignmentPanel';
+import CommitteeValidationCard from '../components/committee/CommitteeValidationCard';
+import PublishConfirmationDialog from '../components/committee/PublishConfirmationDialog';
+import StudentCommitteeStatus from '../components/committee/StudentCommitteeStatus';
+import JuryCommitteePanel from '../components/committee/JuryCommitteePanel';
+import DeliverableSubmissionForm from '../components/committee/DeliverableSubmissionForm';
+
+jest.mock('../store/authStore', () => jest.fn());
+jest.mock('../api/committeeService', () => ({
+  createCommittee: jest.fn(),
+  assignAdvisors: jest.fn(),
+  assignJury: jest.fn(),
+  validateCommittee: jest.fn(),
+  publishCommittee: jest.fn(),
+}));
+jest.mock('../api/deliverableService', () => ({
+  submitDeliverable: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuthStore.mockImplementation((selector) =>
+    selector({ user: { userId: 'coordinator-1', role: 'coordinator' }, isAuthenticated: true })
+  );
+});
+
+describe('Committee Assignment UI components', () => {
+  it('shows validation error when committee name is empty', async () => {
+    const user = userEvent.setup();
+    render(<CommitteeCreationForm />);
+
+    await user.click(screen.getByTestId('committee-submit-btn'));
+
+    expect(screen.getByTestId('committee-error')).toHaveTextContent('Committee name is required.');
+    expect(createCommittee).not.toHaveBeenCalled();
+  });
+
+  it('shows duplicate name error from API without reload', async () => {
+    const user = userEvent.setup();
+    createCommittee.mockRejectedValue({ response: { data: { message: 'Duplicate committee name' } } });
+
+    render(<CommitteeCreationForm />);
+    await user.type(screen.getByTestId('committee-name-input'), 'Test Committee');
+    await user.click(screen.getByTestId('committee-submit-btn'));
+
+    await waitFor(() => expect(createCommittee).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('committee-error')).toHaveTextContent('Duplicate committee name');
+  });
+
+  it('submits a valid committee creation request', async () => {
+    const user = userEvent.setup();
+    createCommittee.mockResolvedValue({ committeeId: 'c1', committeeName: 'Test Committee' });
+    const handleSuccess = jest.fn();
+
+    render(<CommitteeCreationForm onCreateSuccess={handleSuccess} />);
+
+    await user.type(screen.getByTestId('committee-name-input'), 'Test Committee');
+    await user.type(screen.getByTestId('committee-description-input'), 'Description');
+    await user.click(screen.getByTestId('committee-submit-btn'));
+
+    await waitFor(() => expect(createCommittee).toHaveBeenCalledWith({
+      committeeName: 'Test Committee',
+      description: 'Description',
+      coordinatorId: 'coordinator-1',
+    }));
+    expect(handleSuccess).toHaveBeenCalledWith({ committeeId: 'c1', committeeName: 'Test Committee' });
+    expect(screen.getByTestId('committee-success')).toHaveTextContent('Committee created successfully.');
+  });
+
+  it('shows advisor selection error when none are selected', async () => {
+    const user = userEvent.setup();
+    render(<AdvisorAssignmentPanel committeeId="c1" availableAdvisors={[{ id: 'a1', name: 'Advisor 1' }]} />);
+
+    await user.click(screen.getByTestId('advisor-submit-btn'));
+
+    expect(screen.getByTestId('advisor-error')).toHaveTextContent('Please select at least one advisor.');
+    expect(assignAdvisors).not.toHaveBeenCalled();
+  });
+
+  it('calls POST advisors with correct payload on valid advisor assignment', async () => {
+    const user = userEvent.setup();
+    assignAdvisors.mockResolvedValue({});
+
+    render(<AdvisorAssignmentPanel committeeId="c1" availableAdvisors={[{ id: 'a1', name: 'Advisor 1' }, { id: 'a2', name: 'Advisor 2' }]} />);
+
+    await user.click(screen.getByTestId('advisor-checkbox-a1'));
+    await user.click(screen.getByTestId('advisor-submit-btn'));
+
+    await waitFor(() => expect(assignAdvisors).toHaveBeenCalledWith('c1', ['a1']));
+    expect(screen.getByTestId('advisor-success')).toHaveTextContent('Advisors assigned successfully.');
+  });
+
+  it('shows jury selection error when none are selected', async () => {
+    const user = userEvent.setup();
+    render(<JuryAssignmentPanel committeeId="c1" availableJury={[{ id: 'j1', name: 'Jury 1' }]} />);
+
+    await user.click(screen.getByTestId('jury-submit-btn'));
+
+    expect(screen.getByTestId('jury-error')).toHaveTextContent('Please select at least one jury member.');
+    expect(assignJury).not.toHaveBeenCalled();
+  });
+
+  it('calls POST jury with correct payload on valid jury assignment', async () => {
+    const user = userEvent.setup();
+    assignJury.mockResolvedValue({});
+
+    render(<JuryAssignmentPanel committeeId="c1" availableJury={[{ id: 'j1', name: 'Jury 1' }, { id: 'j2', name: 'Jury 2' }]} />);
+
+    await user.click(screen.getByTestId('jury-checkbox-j2'));
+    await user.click(screen.getByTestId('jury-submit-btn'));
+
+    await waitFor(() => expect(assignJury).toHaveBeenCalledWith('c1', ['j2']));
+    expect(screen.getByTestId('jury-success')).toHaveTextContent('Jury members assigned successfully.');
+  });
+
+  it('enables publish button when validation result is valid', () => {
+    render(<CommitteeValidationCard validationResult={{ valid: true }} onPublishClick={() => {}} />);
+
+    expect(screen.getByTestId('publish-button')).toBeEnabled();
+    expect(screen.getByTestId('validation-status')).toHaveTextContent('Valid committee configuration');
+  });
+
+  it('disables publish button and shows missing requirements when invalid', () => {
+    render(
+      <CommitteeValidationCard
+        validationResult={{ valid: false, missingRequirements: ['Advisor count too low'] }}
+        onPublishClick={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('publish-button')).toBeDisabled();
+    expect(screen.getByTestId('missing-requirements')).toHaveTextContent('Advisor count too low');
+  });
+
+  it('renders publish confirmation dialog and handles cancel/confirm actions', async () => {
+    const user = userEvent.setup();
+    const onCancel = jest.fn();
+    const onConfirm = jest.fn();
+
+    render(
+      <PublishConfirmationDialog
+        open={true}
+        committeeName="Test Committee"
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+      />
+    );
+
+    expect(screen.getByTestId('publish-confirmation-dialog')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('publish-cancel-btn'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByTestId('publish-confirm-btn'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders placeholder before publish and full card after publish for student status', () => {
+    const { rerender } = render(<StudentCommitteeStatus committee={null} />);
+    expect(screen.getByTestId('student-committee-placeholder')).toBeInTheDocument();
+
+    rerender(
+      <StudentCommitteeStatus
+        committee={{
+          committeeName: 'Final Committee',
+          status: 'published',
+          publishedAt: '2026-04-13T10:00:00Z',
+          advisorIds: ['a1'],
+          juryIds: ['j1'],
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('student-committee-card')).toBeInTheDocument();
+    expect(screen.getByTestId('advisor-list')).toHaveTextContent('a1');
+    expect(screen.getByTestId('jury-list')).toHaveTextContent('j1');
+  });
+
+  it('renders jury panel empty state and read-only assignment cards', () => {
+    const { rerender } = render(<JuryCommitteePanel committees={[]} />);
+    expect(screen.getByTestId('jury-empty-state')).toHaveTextContent('No committee assignments yet.');
+
+    rerender(
+      <JuryCommitteePanel
+        committees={[{ committeeId: 'c1', committeeName: 'Committee 1', status: 'published', publishedAt: '2026-04-13', advisorIds: ['a1'], juryIds: ['j1'] }]}
+      />
+    );
+
+    expect(screen.getByTestId('jury-committees-list')).toBeInTheDocument();
+    expect(screen.getByTestId('jury-committee-card')).toHaveTextContent('Committee 1');
+  });
+
+  it('locks deliverable form before publish and on schedule boundary, and submits successfully when open', async () => {
+    const user = userEvent.setup();
+    submitDeliverable.mockResolvedValue({ deliverableId: 'd1', submittedAt: '2026-04-13T12:00:00Z', storageRef: 'https://example.com/d1' });
+
+    const { rerender } = render(<DeliverableSubmissionForm committee={null} groupId="g1" />);
+    expect(screen.getByTestId('deliverable-locked')).toHaveTextContent('Committee not yet published.');
+
+    rerender(<DeliverableSubmissionForm committee={{ committeeId: 'c1', status: 'published' }} groupId="g1" scheduleOpen={false} />);
+    expect(screen.getByTestId('deliverable-locked')).toHaveTextContent('Deliverable submission is closed by schedule.');
+
+    rerender(<DeliverableSubmissionForm committee={{ committeeId: 'c1', status: 'published' }} groupId="g1" scheduleOpen={true} />);
+    await user.selectOptions(screen.getByTestId('deliverable-type-selector'), 'statement-of-work');
+    await user.type(screen.getByTestId('deliverable-storage-ref'), 'https://example.com/submission');
+    await user.click(screen.getByTestId('deliverable-submit-btn'));
+
+    await waitFor(() => expect(submitDeliverable).toHaveBeenCalledWith({
+      committeeId: 'c1',
+      groupId: 'g1',
+      type: 'statement-of-work',
+      storageRef: 'https://example.com/submission',
+    }));
+    expect(screen.getByTestId('deliverable-success-card')).toHaveTextContent('Submission successful!');
+  });
+});

--- a/frontend/src/api/committeeService.js
+++ b/frontend/src/api/committeeService.js
@@ -1,0 +1,43 @@
+import apiClient from './apiClient';
+
+/**
+ * Committee Service - Handles committee assignment API calls.
+ */
+
+export const createCommittee = async ({ committeeName, coordinatorId, description }) => {
+  const response = await apiClient.post('/committees', {
+    committeeName,
+    coordinatorId,
+    description,
+  });
+  return response.data;
+};
+
+export const assignAdvisors = async (committeeId, advisorIds) => {
+  const response = await apiClient.post(`/committees/${committeeId}/advisors`, {
+    advisorIds,
+  });
+  return response.data;
+};
+
+export const assignJury = async (committeeId, juryIds) => {
+  const response = await apiClient.post(`/committees/${committeeId}/jury`, {
+    juryIds,
+  });
+  return response.data;
+};
+
+export const validateCommittee = async (committeeId) => {
+  const response = await apiClient.post(`/committees/${committeeId}/validate`);
+  return response.data;
+};
+
+export const publishCommittee = async (committeeId) => {
+  const response = await apiClient.post(`/committees/${committeeId}/publish`);
+  return response.data;
+};
+
+export const getCommitteeById = async (committeeId) => {
+  const response = await apiClient.get(`/committees/${committeeId}`);
+  return response.data;
+};

--- a/frontend/src/api/deliverableService.js
+++ b/frontend/src/api/deliverableService.js
@@ -1,0 +1,18 @@
+import apiClient from './apiClient';
+
+/**
+ * Deliverable Service - Handles deliverable submission API calls.
+ */
+export const submitDeliverable = async ({ committeeId, groupId, type, storageRef }) => {
+  const response = await apiClient.post(`/committees/${committeeId}/deliverables`, {
+    groupId,
+    type,
+    storageRef,
+  });
+  return response.data;
+};
+
+export const getDeliverableByCommittee = async (committeeId) => {
+  const response = await apiClient.get(`/committees/${committeeId}/deliverables`);
+  return response.data;
+};

--- a/frontend/src/components/committee/AdvisorAssignmentPanel.js
+++ b/frontend/src/components/committee/AdvisorAssignmentPanel.js
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { assignAdvisors } from '../../api/committeeService';
+
+const AdvisorAssignmentPanel = ({ committeeId, availableAdvisors = [], onAssignSuccess }) => {
+  const [selectedAdvisorIds, setSelectedAdvisorIds] = useState([]);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const toggleAdvisor = (advisorId) => {
+    setSelectedAdvisorIds((prev) =>
+      prev.includes(advisorId) ? prev.filter((id) => id !== advisorId) : [...prev, advisorId]
+    );
+    setError('');
+    setSuccess('');
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccess('');
+
+    if (!committeeId) {
+      setError('No committee selected.');
+      return;
+    }
+    if (selectedAdvisorIds.length === 0) {
+      setError('Please select at least one advisor.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await assignAdvisors(committeeId, selectedAdvisorIds);
+      setSuccess('Advisors assigned successfully.');
+      setSelectedAdvisorIds([]);
+      if (onAssignSuccess) onAssignSuccess(selectedAdvisorIds);
+    } catch (err) {
+      const message = err.response?.data?.message || err.message || 'Failed to assign advisors.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="advisor-assignment-panel" data-testid="advisor-assignment-panel">
+      <h2>Assign Advisors</h2>
+      {availableAdvisors.length === 0 ? (
+        <p data-testid="advisor-empty-state">No advisors available.</p>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <fieldset>
+            <legend>Select advisors</legend>
+            {availableAdvisors.map((advisor) => (
+              <label key={advisor.id} className="checkbox-option">
+                <input
+                  type="checkbox"
+                  value={advisor.id}
+                  checked={selectedAdvisorIds.includes(advisor.id)}
+                  onChange={() => toggleAdvisor(advisor.id)}
+                  data-testid={`advisor-checkbox-${advisor.id}`}
+                />
+                {advisor.name}
+              </label>
+            ))}
+          </fieldset>
+
+          {error && <div className="error-message" data-testid="advisor-error">{error}</div>}
+          {success && <div className="success-message" data-testid="advisor-success">{success}</div>}
+
+          <button type="submit" disabled={loading} data-testid="advisor-submit-btn">
+            {loading ? 'Assigning…' : 'Assign Advisors'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default AdvisorAssignmentPanel;

--- a/frontend/src/components/committee/CommitteeCreationForm.js
+++ b/frontend/src/components/committee/CommitteeCreationForm.js
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import useAuthStore from '../../store/authStore';
+import { createCommittee } from '../../api/committeeService';
+
+const CommitteeCreationForm = ({ onCreateSuccess }) => {
+  const user = useAuthStore((state) => state.user);
+  const [committeeName, setCommitteeName] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccess('');
+
+    if (!committeeName.trim()) {
+      setError('Committee name is required.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const committee = await createCommittee({
+        committeeName: committeeName.trim(),
+        description: description.trim(),
+        coordinatorId: user?.userId || '',
+      });
+      setSuccess('Committee created successfully.');
+      setCommitteeName('');
+      setDescription('');
+      if (onCreateSuccess) onCreateSuccess(committee);
+    } catch (err) {
+      const message = err.response?.data?.message || err.message || 'Failed to create committee.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="committee-creation-form" data-testid="committee-creation-form">
+      <h2>Create Committee</h2>
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="form-group">
+          <label htmlFor="committeeName">Committee Name</label>
+          <input
+            id="committeeName"
+            type="text"
+            value={committeeName}
+            onChange={(e) => setCommitteeName(e.target.value)}
+            placeholder="Enter committee name"
+            data-testid="committee-name-input"
+          />
+        </div>
+
+        <div className="form-group">
+          <label htmlFor="committeeDescription">Description (optional)</label>
+          <textarea
+            id="committeeDescription"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Add an optional description"
+            data-testid="committee-description-input"
+          />
+        </div>
+
+        {error && <div className="error-message" data-testid="committee-error">{error}</div>}
+        {success && <div className="success-message" data-testid="committee-success">{success}</div>}
+
+        <button type="submit" disabled={loading} data-testid="committee-submit-btn">
+          {loading ? 'Creating…' : 'Create Committee'}
+        </button>
+      </form>
+    </section>
+  );
+};
+
+export default CommitteeCreationForm;

--- a/frontend/src/components/committee/CommitteeValidationCard.js
+++ b/frontend/src/components/committee/CommitteeValidationCard.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const CommitteeValidationCard = ({ validationResult, onPublishClick, disabled }) => {
+  const isValid = validationResult?.valid === true;
+  return (
+    <section className="committee-validation-card" data-testid="committee-validation-card">
+      <h2>Committee Validation</h2>
+      {!validationResult ? (
+        <p data-testid="validation-placeholder">Validation not performed yet.</p>
+      ) : (
+        <>
+          <div className={`validation-status ${isValid ? 'valid' : 'invalid'}`} data-testid="validation-status">
+            {isValid ? 'Valid committee configuration' : 'Invalid committee configuration'}
+          </div>
+          {!isValid && validationResult?.missingRequirements?.length > 0 && (
+            <div className="validation-missing" data-testid="missing-requirements">
+              <p>Missing requirements:</p>
+              <ul>
+                {validationResult.missingRequirements.map((item, index) => (
+                  <li key={index}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onPublishClick}
+            disabled={!isValid || disabled}
+            data-testid="publish-button"
+          >
+            Publish Committee
+          </button>
+        </>
+      )}
+    </section>
+  );
+};
+
+export default CommitteeValidationCard;

--- a/frontend/src/components/committee/DeliverableSubmissionForm.js
+++ b/frontend/src/components/committee/DeliverableSubmissionForm.js
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { submitDeliverable } from '../../api/deliverableService';
+
+const DELIVERABLE_TYPES = [
+  { value: 'proposal', label: 'Proposal' },
+  { value: 'statement-of-work', label: 'Statement of Work' },
+  { value: 'demonstration', label: 'Demonstration' },
+];
+
+const DeliverableSubmissionForm = ({ committee, groupId, scheduleOpen = true }) => {
+  const [type, setType] = useState('proposal');
+  const [storageRef, setStorageRef] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const isPublished = committee?.status === 'published';
+  const locked = !isPublished || !scheduleOpen;
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccess(null);
+
+    if (locked) {
+      setError('Deliverable submission is not available yet.');
+      return;
+    }
+    if (!storageRef.trim()) {
+      setError('Please provide a deliverable file URL or storage reference.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await submitDeliverable({
+        committeeId: committee.committeeId,
+        groupId,
+        type,
+        storageRef: storageRef.trim(),
+      });
+      setSuccess(result);
+      setStorageRef('');
+    } catch (err) {
+      const message = err.response?.data?.message || err.message || 'Submission failed.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="deliverable-submission-form" data-testid="deliverable-submission-form">
+      <h2>Submit Deliverable</h2>
+      {locked ? (
+        <div data-testid="deliverable-locked" className="locked-message">
+          {isPublished ? 'Deliverable submission is closed by schedule.' : 'Committee not yet published.'}
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="deliverableType">Deliverable Type</label>
+            <select
+              id="deliverableType"
+              value={type}
+              onChange={(e) => setType(e.target.value)}
+              data-testid="deliverable-type-selector"
+            >
+              {DELIVERABLE_TYPES.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="storageRef">File URL or Storage Reference</label>
+            <input
+              id="storageRef"
+              type="text"
+              value={storageRef}
+              onChange={(e) => setStorageRef(e.target.value)}
+              placeholder="https://... or storage reference"
+              data-testid="deliverable-storage-ref"
+            />
+          </div>
+
+          {error && <div className="error-message" data-testid="deliverable-error">{error}</div>}
+          {success && (
+            <div className="confirmation-card" data-testid="deliverable-success-card">
+              <p>Submission successful!</p>
+              <p>Deliverable ID: {success.deliverableId}</p>
+              <p>Submitted at: {success.submittedAt}</p>
+              <p>Storage ref: {success.storageRef}</p>
+            </div>
+          )}
+
+          <button type="submit" disabled={loading} data-testid="deliverable-submit-btn">
+            {loading ? 'Submitting…' : 'Submit Deliverable'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default DeliverableSubmissionForm;

--- a/frontend/src/components/committee/JuryAssignmentPanel.js
+++ b/frontend/src/components/committee/JuryAssignmentPanel.js
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { assignJury } from '../../api/committeeService';
+
+const JuryAssignmentPanel = ({ committeeId, availableJury = [], onAssignSuccess }) => {
+  const [selectedJuryIds, setSelectedJuryIds] = useState([]);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const toggleJury = (juryId) => {
+    setSelectedJuryIds((prev) =>
+      prev.includes(juryId) ? prev.filter((id) => id !== juryId) : [...prev, juryId]
+    );
+    setError('');
+    setSuccess('');
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError('');
+    setSuccess('');
+
+    if (!committeeId) {
+      setError('No committee selected.');
+      return;
+    }
+    if (selectedJuryIds.length === 0) {
+      setError('Please select at least one jury member.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await assignJury(committeeId, selectedJuryIds);
+      setSuccess('Jury members assigned successfully.');
+      setSelectedJuryIds([]);
+      if (onAssignSuccess) onAssignSuccess(selectedJuryIds);
+    } catch (err) {
+      const message = err.response?.data?.message || err.message || 'Failed to assign jury members.';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="jury-assignment-panel" data-testid="jury-assignment-panel">
+      <h2>Assign Jury</h2>
+      {availableJury.length === 0 ? (
+        <p data-testid="jury-empty-state">No jury members available.</p>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <fieldset>
+            <legend>Select jury members</legend>
+            {availableJury.map((jury) => (
+              <label key={jury.id} className="checkbox-option">
+                <input
+                  type="checkbox"
+                  value={jury.id}
+                  checked={selectedJuryIds.includes(jury.id)}
+                  onChange={() => toggleJury(jury.id)}
+                  data-testid={`jury-checkbox-${jury.id}`}
+                />
+                {jury.name}
+              </label>
+            ))}
+          </fieldset>
+
+          {error && <div className="error-message" data-testid="jury-error">{error}</div>}
+          {success && <div className="success-message" data-testid="jury-success">{success}</div>}
+
+          <button type="submit" disabled={loading} data-testid="jury-submit-btn">
+            {loading ? 'Assigning…' : 'Assign Jury'}
+          </button>
+        </form>
+      )}
+    </section>
+  );
+};
+
+export default JuryAssignmentPanel;

--- a/frontend/src/components/committee/JuryCommitteePanel.js
+++ b/frontend/src/components/committee/JuryCommitteePanel.js
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const JuryCommitteePanel = ({ committees = [] }) => {
+  if (!committees.length) {
+    return (
+      <section className="jury-committee-panel" data-testid="jury-empty-state">
+        <h2>Your Assigned Committees</h2>
+        <p>No committee assignments yet.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="jury-committee-panel" data-testid="jury-committees-list">
+      <h2>Your Assigned Committees</h2>
+      {committees.map((committee) => (
+        <div key={committee.committeeId} className="committee-summary-card" data-testid="jury-committee-card">
+          <p><strong>{committee.committeeName}</strong></p>
+          <p>Status: {committee.status}</p>
+          <p>Published at: {committee.publishedAt || 'Pending'}</p>
+          <div>
+            <h4>Advisors</h4>
+            <ul>
+              {committee.advisorIds?.map((advisorId) => (
+                <li key={advisorId}>{advisorId}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4>Jury</h4>
+            <ul>
+              {committee.juryIds?.map((juryId) => (
+                <li key={juryId}>{juryId}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+};
+
+export default JuryCommitteePanel;

--- a/frontend/src/components/committee/PublishConfirmationDialog.js
+++ b/frontend/src/components/committee/PublishConfirmationDialog.js
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const PublishConfirmationDialog = ({ open, committeeName, onCancel, onConfirm, loading }) => {
+  if (!open) return null;
+
+  return (
+    <div className="publish-confirmation-dialog" data-testid="publish-confirmation-dialog">
+      <div className="dialog-backdrop" />
+      <div className="dialog-content">
+        <h3>Confirm Publish</h3>
+        <p>Are you sure you want to publish the committee <strong>{committeeName}</strong>?</p>
+        <div className="dialog-actions">
+          <button type="button" onClick={onCancel} data-testid="publish-cancel-btn">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={loading}
+            data-testid="publish-confirm-btn"
+          >
+            {loading ? 'Publishing…' : 'Confirm Publish'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PublishConfirmationDialog;

--- a/frontend/src/components/committee/StudentCommitteeStatus.js
+++ b/frontend/src/components/committee/StudentCommitteeStatus.js
@@ -1,0 +1,44 @@
+import React from 'react';
+
+const StudentCommitteeStatus = ({ committee }) => {
+  const isPublished = committee?.status === 'published';
+
+  if (!committee || !isPublished) {
+    return (
+      <section className="student-committee-status" data-testid="student-committee-placeholder">
+        <h2>Committee Status</h2>
+        <div className="placeholder">Committee not yet published.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="student-committee-status" data-testid="student-committee-card">
+      <h2>Published Committee</h2>
+      <div className="committee-card">
+        <p data-testid="committee-name"><strong>{committee.committeeName}</strong></p>
+        <p data-testid="committee-published-at">Published at: {committee.publishedAt}</p>
+        <div className="committee-members">
+          <div>
+            <h3>Advisors</h3>
+            <ul data-testid="advisor-list">
+              {committee.advisorIds?.map((advisorId) => (
+                <li key={advisorId}>{advisorId}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3>Jury</h3>
+            <ul data-testid="jury-list">
+              {committee.juryIds?.map((juryId) => (
+                <li key={juryId}>{juryId}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default StudentCommitteeStatus;


### PR DESCRIPTION
 Implementation Started
What I added
New API services:

frontend/src/api/committeeService.js
frontend/src/api/deliverableService.js
New committee UI components:

frontend/src/components/committee/CommitteeCreationForm.js frontend/src/components/committee/AdvisorAssignmentPanel.js frontend/src/components/committee/JuryAssignmentPanel.js frontend/src/components/committee/CommitteeValidationCard.js frontend/src/components/committee/PublishConfirmationDialog.js frontend/src/components/committee/StudentCommitteeStatus.js frontend/src/components/committee/JuryCommitteePanel.js frontend/src/components/committee/DeliverableSubmissionForm.js New tests:

frontend/src/__tests__/committeeAssignment.test.js frontend/src/__tests__/committeeAssignment.e2e.test.js Verification
npm.cmd test -- committeeAssignment.test.js --watchAll=false ✅ npm.cmd test -- committeeAssignment.e2e.test.js --watchAll=false ✅ Notes
The E2E flow now covers:
create committee
assign advisor
assign jury
validate
publish
student status visibility
deliverable submission confirmation
If you want, I can next wire these components into a coordinator route or add the real committee management page. Closes #90