### PR TITLE
CommitteeManagementTab API usage, add validation/error handling, and …

### DIFF
--- a/frontend/src/__tests__/CommitteeCreationForm.test.js
+++ b/frontend/src/__tests__/CommitteeCreationForm.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import CommitteeCreationForm from '../components/CommitteeCreationForm';
+import * as committeeService from '../api/committeeService';
+import useAuthStore from '../store/authStore';
+
+jest.mock('../store/authStore');
+jest.mock('../api/committeeService');
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+
+describe('CommitteeCreationForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.mockImplementation((selector) =>
+      selector({
+        user: { userId: 'usr_coordinator', role: 'coordinator' },
+        isAuthenticated: true,
+      })
+    );
+    require('react-router-dom').useNavigate.mockReturnValue(mockNavigate);
+  });
+
+  it('blocks empty committee name and shows validation error', async () => {
+    render(<CommitteeCreationForm />);
+
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    expect(await screen.findByText(/Committee name is required/i)).toBeInTheDocument();
+    expect(committeeService.createCommittee).not.toHaveBeenCalled();
+  });
+
+  it('renders duplicate name error when API returns 409', async () => {
+    committeeService.createCommittee.mockRejectedValue({
+      response: {
+        data: {
+          code: 'DUPLICATE_COMMITTEE_NAME',
+          message: 'A committee with this name already exists.',
+        },
+      },
+    });
+
+    render(<CommitteeCreationForm />);
+
+    await userEvent.type(screen.getByLabelText(/Committee name/i), 'Test Committee');
+    await userEvent.type(screen.getByLabelText(/Description/i), 'A new committee draft');
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    expect(await screen.findByText(/A committee with this name already exists/i)).toBeInTheDocument();
+    expect(committeeService.createCommittee).toHaveBeenCalledWith({
+      committeeName: 'Test Committee',
+      coordinatorId: 'usr_coordinator',
+      description: 'A new committee draft',
+    });
+  });
+
+  it('navigates to coordinator page after successful committee creation', async () => {
+    committeeService.createCommittee.mockResolvedValue({
+      committeeId: 'c1',
+      committeeName: 'Working Committee',
+    });
+
+    render(<CommitteeCreationForm />);
+
+    await userEvent.type(screen.getByLabelText(/Committee name/i), 'Working Committee');
+    fireEvent.click(screen.getByRole('button', { name: /create draft/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/coordinator');
+    });
+  });
+});

--- a/frontend/src/__tests__/CommitteeCreationForm.test.js
+++ b/frontend/src/__tests__/CommitteeCreationForm.test.js
@@ -39,6 +39,7 @@ describe('CommitteeCreationForm', () => {
   it('renders duplicate name error when API returns 409', async () => {
     committeeService.createCommittee.mockRejectedValue({
       response: {
+        status: 409,
         data: {
           code: 'DUPLICATE_COMMITTEE_NAME',
           message: 'A committee with this name already exists.',

--- a/frontend/src/__tests__/CommitteeE2EFlow.test.js
+++ b/frontend/src/__tests__/CommitteeE2EFlow.test.js
@@ -1,0 +1,205 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import CommitteeManagementTab from '../components/CommitteeManagementTab';
+import JuryCommittees from '../components/JuryCommittees';
+import DeliverableSubmissionForm from '../components/DeliverableSubmissionForm';
+import * as committeeService from '../api/committeeService';
+import * as groupService from '../api/groupService';
+import * as deliverableService from '../api/deliverableService';
+import useAuthStore from '../store/authStore';
+
+jest.mock('../store/authStore');
+jest.mock('../api/committeeService');
+jest.mock('../api/groupService', () => ({
+  getScheduleWindow: jest.fn(),
+  getJuryCommittees: jest.fn(),
+}));
+jest.mock('../api/deliverableService', () => ({
+  getGroupDeliverables: jest.fn(),
+  submitDeliverable: jest.fn(),
+}));
+
+describe('Issue #90 — Committee E2E-style flows (RTL)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.mockImplementation((selector) =>
+      selector({ user: { userId: 'usr_coordinator', role: 'coordinator' } })
+    );
+  });
+
+  describe('E2E Journey 1: Coordinator full flow', () => {
+    let committeesState;
+
+    beforeEach(() => {
+      committeesState = [];
+
+      committeeService.listCommittees.mockImplementation(() =>
+        Promise.resolve({ committees: [...committeesState] })
+      );
+
+      committeeService.listCommitteeCandidates.mockResolvedValue({
+        professors: [
+          { userId: 'adv1', email: 'advisor1@test.edu' },
+          { userId: 'jury1', email: 'jury1@test.edu' },
+        ],
+      });
+
+      committeeService.createCommittee.mockImplementation(async (payload) => {
+        const committeeId = 'c-e2e-flow';
+        committeesState = [
+          {
+            committeeId,
+            committeeName: payload.committeeName,
+            description: payload.description || '',
+            status: 'draft',
+            advisorIds: [],
+            juryIds: [],
+            createdAt: '2026-04-13T00:00:00Z',
+          },
+        ];
+        return { committeeId, committeeName: payload.committeeName };
+      });
+
+      committeeService.assignCommitteeAdvisors.mockImplementation(async (committeeId, advisorIds) => {
+        const c = committeesState.find((x) => x.committeeId === committeeId);
+        if (c) c.advisorIds = [...advisorIds];
+        return {};
+      });
+
+      committeeService.addJuryMembers.mockImplementation(async (committeeId, juryIds) => {
+        const c = committeesState.find((x) => x.committeeId === committeeId);
+        if (c) c.juryIds = [...juryIds];
+        return {};
+      });
+
+      committeeService.validateCommitteeSetup.mockResolvedValue({
+        valid: true,
+        missingRequirements: [],
+      });
+
+      committeeService.publishCommittee.mockImplementation(async (committeeId) => {
+        const c = committeesState.find((x) => x.committeeId === committeeId);
+        if (c) c.status = 'published';
+        return { committeeId, status: 'published' };
+      });
+    });
+
+    it('creates, assigns, validates, publishes, and calls publishCommittee with the committee id', async () => {
+      const user = userEvent.setup();
+      jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+      render(<CommitteeManagementTab />);
+
+      await screen.findByPlaceholderText(/enter committee name/i);
+
+      await user.type(screen.getByPlaceholderText(/enter committee name/i), 'E2E Flow Committee');
+      await user.click(screen.getByRole('button', { name: /create committee draft/i }));
+
+      await screen.findByText(/Committee "E2E Flow Committee" created successfully/i);
+
+      const multiSelects = document.querySelectorAll('select[multiple]');
+      expect(multiSelects.length).toBeGreaterThanOrEqual(2);
+
+      await user.selectOptions(multiSelects[0], 'adv1');
+      await user.click(screen.getByRole('button', { name: /save advisors/i }));
+
+      await waitFor(() => {
+        expect(committeeService.assignCommitteeAdvisors).toHaveBeenCalledWith('c-e2e-flow', ['adv1']);
+      });
+
+      const multiSelectsAfterAdvisor = document.querySelectorAll('select[multiple]');
+      await user.selectOptions(multiSelectsAfterAdvisor[1], 'jury1');
+      await user.click(screen.getByRole('button', { name: /save jury/i }));
+
+      await waitFor(() => {
+        expect(committeeService.addJuryMembers).toHaveBeenCalledWith('c-e2e-flow', ['jury1']);
+      });
+
+      await user.click(screen.getByRole('button', { name: /validate committee/i }));
+
+      await screen.findByText(/Validation: Valid/i);
+
+      await user.click(screen.getByRole('button', { name: /publish committee/i }));
+
+      await waitFor(() => {
+        expect(committeeService.publishCommittee).toHaveBeenCalledWith('c-e2e-flow');
+      });
+
+      window.confirm.mockRestore();
+    });
+  });
+
+  describe('E2E Journey 2: Jury read-only view', () => {
+    const publishedCommittee = {
+      committeeId: 'c-jury-e2e',
+      committeeName: 'Jury Visible Committee',
+      status: 'published',
+      publishedAt: '2026-04-13T00:00:00Z',
+      advisorIds: ['adv1'],
+      juryIds: ['jury1'],
+    };
+
+    it('shows committee details without coordinator management controls', async () => {
+      groupService.getJuryCommittees.mockResolvedValue({ committees: [publishedCommittee] });
+
+      render(<JuryCommittees />);
+
+      expect(await screen.findByText('Jury Visible Committee')).toBeInTheDocument();
+      expect(screen.getByText('c-jury-e2e')).toBeInTheDocument();
+
+      expect(screen.queryByRole('button', { name: /publish/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /validate/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /assign/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /create committee draft/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('E2E Journey 3: Student deliverable submission', () => {
+    beforeEach(() => {
+      groupService.getScheduleWindow.mockResolvedValue({
+        open: true,
+        window: { endsAt: '2026-04-20T00:00:00Z' },
+      });
+      deliverableService.getGroupDeliverables.mockResolvedValue({ deliverables: [] });
+      deliverableService.submitDeliverable.mockResolvedValue({
+        type: 'proposal',
+        deliverableId: 'del-e2e-1',
+        submittedAt: '2026-04-13T12:00:00Z',
+        storageRef: 'https://example.com/proposal.pdf',
+      });
+    });
+
+    it('submits a proposal file and shows success when committee is published', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <DeliverableSubmissionForm
+          groupId="g-e2e"
+          isLeader={true}
+          userId="usr_student"
+          members={[{ userId: 'usr_student' }]}
+          committeeStatus="published"
+        />
+      );
+
+      await screen.findByLabelText(/deliverable type/i);
+
+      await user.selectOptions(screen.getByLabelText(/deliverable type/i), 'proposal');
+
+      const fileInput = screen.getByLabelText(/file \(pdf/i);
+      const file = new File(['proposal'], 'proposal.pdf', { type: 'application/pdf' });
+      await user.upload(fileInput, file);
+
+      await user.click(screen.getByRole('button', { name: /submit deliverable/i }));
+
+      await waitFor(() => {
+        expect(deliverableService.submitDeliverable).toHaveBeenCalled();
+      });
+
+      expect(await screen.findByText(/deliverable submitted successfully/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/CommitteeManagementTab.test.js
+++ b/frontend/src/__tests__/CommitteeManagementTab.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import CommitteeManagementTab from '../components/CommitteeManagementTab';
+import * as committeeService from '../api/committeeService';
+import useAuthStore from '../store/authStore';
+
+jest.mock('../store/authStore');
+jest.mock('../api/committeeService');
+
+describe('CommitteeManagementTab', () => {
+  const committees = [
+    {
+      committeeId: 'c1',
+      committeeName: 'Alpha Committee',
+      description: 'A test committee',
+      status: 'draft',
+      advisorIds: [],
+      juryIds: [],
+      createdAt: '2026-04-13T00:00:00Z',
+    },
+  ];
+
+  const candidates = [
+    { userId: 'adv1', email: 'advisor1@test.edu' },
+    { userId: 'jury1', email: 'jury1@test.edu' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAuthStore.mockImplementation((selector) =>
+      selector({ user: { userId: 'usr_coordinator', role: 'coordinator' } })
+    );
+    committeeService.listCommittees.mockResolvedValue({ committees });
+    committeeService.listCommitteeCandidates.mockResolvedValue({ professors: candidates });
+    committeeService.assignCommitteeAdvisors.mockResolvedValue({});
+    committeeService.addJuryMembers.mockResolvedValue({});
+    committeeService.validateCommitteeSetup.mockResolvedValue({ valid: true, missingRequirements: [] });
+    committeeService.publishCommittee.mockResolvedValue({ committeeId: 'c1', status: 'published' });
+  });
+
+  it('loads committee data and renders the selected committee', async () => {
+    render(<CommitteeManagementTab />);
+
+    await screen.findAllByText('Alpha Committee');
+
+    expect(committeeService.listCommittees).toHaveBeenCalled();
+    expect(screen.getAllByText('Alpha Committee').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Status:/i)).toBeInTheDocument();
+    expect(screen.getAllByText('draft').length).toBeGreaterThan(0);
+  });
+
+  it('shows an error when saving advisors with no selection', async () => {
+    render(<CommitteeManagementTab />);
+
+    await screen.findAllByText('Alpha Committee');
+
+    fireEvent.click(screen.getByRole('button', { name: /save advisors/i }));
+
+    expect(await screen.findByText(/Please select at least one advisor/i)).toBeInTheDocument();
+    expect(committeeService.assignCommitteeAdvisors).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when saving jury members with no selection', async () => {
+    render(<CommitteeManagementTab />);
+
+    await screen.findAllByText('Alpha Committee');
+
+    fireEvent.click(screen.getByRole('button', { name: /save jury/i }));
+
+    expect(await screen.findByText(/Please select at least one jury member/i)).toBeInTheDocument();
+    expect(committeeService.addJuryMembers).not.toHaveBeenCalled();
+  });
+
+  it('validates and publishes a committee when confirmed', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<CommitteeManagementTab />);
+
+    await screen.findAllByText('Alpha Committee');
+
+    fireEvent.click(screen.getByRole('button', { name: /validate committee/i }));
+
+    expect(await screen.findByText(/Validation: Valid/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /publish committee/i }));
+
+    await waitFor(() => {
+      expect(committeeService.publishCommittee).toHaveBeenCalledWith('c1');
+      expect(screen.getByText(/Committee published successfully/i)).toBeInTheDocument();
+    });
+
+    window.confirm.mockRestore();
+  });
+});

--- a/frontend/src/__tests__/CommitteeManagementTab.test.js
+++ b/frontend/src/__tests__/CommitteeManagementTab.test.js
@@ -73,6 +73,24 @@ describe('CommitteeManagementTab', () => {
     expect(committeeService.addJuryMembers).not.toHaveBeenCalled();
   });
 
+  it('disables publish when validation returns invalid', async () => {
+    committeeService.validateCommitteeSetup.mockResolvedValue({
+      valid: false,
+      missingRequirements: ['At least one advisor', 'At least one jury member'],
+    });
+
+    render(<CommitteeManagementTab />);
+
+    await screen.findAllByText('Alpha Committee');
+
+    fireEvent.click(screen.getByRole('button', { name: /validate committee/i }));
+
+    expect(await screen.findByText(/Validation: Invalid/i)).toBeInTheDocument();
+    expect(screen.getByText(/At least one advisor/i)).toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: /publish committee/i })).toBeDisabled();
+  });
+
   it('validates and publishes a committee when confirmed', async () => {
     jest.spyOn(window, 'confirm').mockReturnValue(true);
 

--- a/frontend/src/__tests__/CommitteeStatusCard.test.js
+++ b/frontend/src/__tests__/CommitteeStatusCard.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CommitteeStatusCard from '../components/CommitteeStatusCard';
+
+describe('CommitteeStatusCard', () => {
+  it('renders a placeholder before the committee is published', () => {
+    render(
+      <CommitteeStatusCard
+        committeeStatus={{ committeeId: null, committee: null }}
+        user={{ userId: 'usr_student' }}
+      />
+    );
+
+    expect(screen.getByText(/Committee not yet published/i)).toBeInTheDocument();
+    expect(screen.getByText(/When published, the committee name/i)).toBeInTheDocument();
+  });
+
+  it('renders published committee details with advisors and jury members', () => {
+    render(
+      <CommitteeStatusCard
+        committeeStatus={{
+          committeeId: 'c1',
+          committee: {
+            committeeName: 'Beta Committee',
+            status: 'published',
+            publishedAt: '2026-04-13T00:00:00Z',
+            advisorIds: ['adv1'],
+            juryIds: ['jury1'],
+          },
+        }}
+        user={{ userId: 'adv1' }}
+      />
+    );
+
+    expect(screen.getByText('Beta Committee')).toBeInTheDocument();
+    expect(screen.getByText(/Published At/i)).toBeInTheDocument();
+    expect(screen.getByText(/adv1/i)).toBeInTheDocument();
+    expect(screen.getByText(/jury1/i)).toBeInTheDocument();
+    expect(screen.getByText(/You are assigned to this committee as an advisor/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/DeliverableSubmissionForm.test.js
+++ b/frontend/src/__tests__/DeliverableSubmissionForm.test.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import * as groupService from '../api/groupService';
+import * as deliverableService from '../api/deliverableService';
+import DeliverableSubmissionForm from '../components/DeliverableSubmissionForm';
+
+jest.mock('../api/groupService', () => ({
+  getScheduleWindow: jest.fn(),
+  getGroupDeliverables: jest.fn(),
+}));
+jest.mock('../api/deliverableService', () => ({
+  getGroupDeliverables: jest.fn(),
+  submitDeliverable: jest.fn(),
+}));
+
+describe('DeliverableSubmissionForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('locks the form before the committee is published', () => {
+    render(
+      <DeliverableSubmissionForm
+        groupId="g1"
+        isLeader={true}
+        userId="usr_student"
+        members={[{ userId: 'usr_student' }]}
+        committeeStatus="draft"
+      />
+    );
+
+    expect(screen.getByText(/Deliverable submission is locked until the committee assignment is published/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Deliverable Type/i)).not.toBeInTheDocument();
+  });
+
+  it('renders type selector and submit controls when published and window open', async () => {
+    groupService.getScheduleWindow.mockResolvedValue({ open: true, window: { endsAt: '2026-04-20T00:00:00Z' } });
+    groupService.getGroupDeliverables.mockResolvedValue({ deliverables: [] });
+
+    render(
+      <DeliverableSubmissionForm
+        groupId="g1"
+        isLeader={true}
+        userId="usr_student"
+        members={[{ userId: 'usr_student' }]}
+        committeeStatus="published"
+      />
+    );
+
+    expect(await screen.findByLabelText(/Deliverable Type/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Submit Deliverable/i })).not.toBeDisabled();
+  });
+
+  it('shows submission success message after submitting a link', async () => {
+    groupService.getScheduleWindow.mockResolvedValue({ open: true, window: { endsAt: '2026-04-20T00:00:00Z' } });
+    groupService.getGroupDeliverables.mockResolvedValue({ deliverables: [] });
+    deliverableService.submitDeliverable.mockResolvedValue({
+      type: 'proposal',
+      deliverableId: 'd1',
+      submittedAt: '2026-04-13T00:00:00Z',
+      storageRef: 'https://example.com/proposal.pdf',
+    });
+
+    render(
+      <DeliverableSubmissionForm
+        groupId="g1"
+        isLeader={true}
+        userId="usr_student"
+        members={[{ userId: 'usr_student' }]}
+        committeeStatus="published"
+      />
+    );
+
+    await screen.findByLabelText(/Deliverable Type/i);
+
+    const fileInput = screen.getByLabelText(/File \(PDF, Word, Markdown, ZIP\)/i);
+    const file = new File(['dummy content'], 'proposal.pdf', { type: 'application/pdf' });
+    await userEvent.upload(fileInput, file);
+
+    fireEvent.click(screen.getByRole('button', { name: /Submit Deliverable/i }));
+
+    expect(await screen.findByText('d1')).toBeInTheDocument();
+    expect(screen.getByText('https://example.com/proposal.pdf')).toBeInTheDocument();
+    expect(deliverableService.submitDeliverable).toHaveBeenCalled();
+  });
+
+  it('disables submission when the schedule window is closed', async () => {
+    groupService.getScheduleWindow.mockResolvedValue({ open: false, window: { endsAt: '2026-04-20T00:00:00Z' } });
+    groupService.getGroupDeliverables.mockResolvedValue({ deliverables: [] });
+
+    render(
+      <DeliverableSubmissionForm
+        groupId="g1"
+        isLeader={true}
+        userId="usr_student"
+        members={[{ userId: 'usr_student' }]}
+        committeeStatus="published"
+      />
+    );
+
+    await screen.findByText(/Submission window closed/i);
+    expect(screen.getByRole('button', { name: /Submit Deliverable/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/__tests__/JuryCommittees.test.js
+++ b/frontend/src/__tests__/JuryCommittees.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import * as groupService from '../api/groupService';
+import JuryCommittees from '../components/JuryCommittees';
+
+jest.mock('../api/groupService');
+
+describe('JuryCommittees', () => {
+  const committee = {
+    committeeId: 'c1',
+    committeeName: 'Gamma Committee',
+    status: 'published',
+    publishedAt: '2026-04-13T00:00:00Z',
+    advisorIds: ['adv1'],
+    juryIds: ['jury1'],
+  };
+
+  it('renders an empty state when no jury committees exist', async () => {
+    groupService.getJuryCommittees.mockResolvedValue({ committees: [] });
+
+    render(<JuryCommittees />);
+
+    expect(screen.getByText(/Loading your assigned committees/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText(/You are not assigned to any jury committees yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders published jury committee cards in read-only mode', async () => {
+    groupService.getJuryCommittees.mockResolvedValue({ committees: [committee] });
+
+    render(<JuryCommittees />);
+
+    expect(await screen.findByText('Gamma Committee')).toBeInTheDocument();
+    expect(screen.getByText('c1')).toBeInTheDocument();
+    expect(screen.getByText(/adv1/i)).toBeInTheDocument();
+    expect(screen.getByText(/jury1/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/JuryCommittees.test.js
+++ b/frontend/src/__tests__/JuryCommittees.test.js
@@ -37,5 +37,10 @@ describe('JuryCommittees', () => {
     expect(screen.getByText('c1')).toBeInTheDocument();
     expect(screen.getByText(/adv1/i)).toBeInTheDocument();
     expect(screen.getByText(/jury1/i)).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: /publish/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /validate/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /edit/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /assign/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/CommitteeManagementTab.js
+++ b/frontend/src/components/CommitteeManagementTab.js
@@ -5,7 +5,7 @@ import {
   listCommittees,
   listCommitteeCandidates,
   assignCommitteeAdvisors,
-  addCommitteeJuryMembers,
+  addJuryMembers,
   validateCommitteeSetup,
   publishCommittee,
 } from '../api/committeeService';
@@ -143,6 +143,10 @@ const CommitteeManagementTab = () => {
 
   const handleAssignAdvisors = async () => {
     if (!selectedCommittee) return;
+    if (!advisorSelection.length) {
+      setAssignError('Please select at least one advisor.');
+      return;
+    }
     setAssignError('');
     setPublishError('');
     setSubmitting(true);
@@ -160,12 +164,16 @@ const CommitteeManagementTab = () => {
 
   const handleAssignJuryMembers = async () => {
     if (!selectedCommittee) return;
+    if (!jurySelection.length) {
+      setAssignError('Please select at least one jury member.');
+      return;
+    }
     setAssignError('');
     setPublishError('');
     setSubmitting(true);
 
     try {
-      await addCommitteeJuryMembers(selectedCommittee.committeeId, jurySelection);
+      await addJuryMembers(selectedCommittee.committeeId, jurySelection);
       setInfoMessage('Jury assignments updated. Please validate before publishing.');
       await refreshCommittees(selectedCommittee.committeeId);
     } catch (err) {
@@ -421,6 +429,10 @@ const CommitteeManagementTab = () => {
               </button>
             </div>
           </div>
+
+          {assignError && (
+            <div style={{ color: '#d73a49', marginBottom: '16px' }}>{assignError}</div>
+          )}
 
           <div style={{ display: 'grid', gap: '12px', marginBottom: '16px' }}>
             <h3 style={{ marginBottom: '12px' }}>Validation</h3>

--- a/frontend/src/components/DeliverableSubmissionForm.js
+++ b/frontend/src/components/DeliverableSubmissionForm.js
@@ -120,8 +120,8 @@ const DeliverableSubmissionForm = ({
         ...prev,
         [result.type]: result,
       }));
-      setSuccessMsg('Deliverable submitted successfully.');
       resetForm();
+      setSuccessMsg('Deliverable submitted successfully.');
       if (onSuccess) onSuccess();
     } catch (error) {
       const status = error.response?.status;


### PR DESCRIPTION
…implement comprehensive frontend unit tests for committee workflows.

Completed Implementation
✅ Code changes
Fixed frontend/src/components/CommitteeManagementTab.js corrected API import from addCommitteeJuryMembers to addJuryMembers added empty-selection validation for advisor and jury assignment made assignError render in the UI
✅ New tests added
frontend/src/__tests__/CommitteeCreationForm.test.js frontend/src/__tests__/CommitteeManagementTab.test.js frontend/src/__tests__/CommitteeStatusCard.test.js frontend/src/__tests__/JuryCommittees.test.js
frontend/src/__tests__/DeliverableSubmissionForm.test.js 🧪 Validation
Ran the new frontend tests in batch via react-scripts test Result: 5 passed, 5 total
🧹 Cleanup
Removed temporary test output files created during debugging If you want, I can continue by adding an end-to-end flow test covering committee creation → advisor/jury assignment → validation → publish → deliverable submission. Closes #90