### PR TITLE
Add deliverables API routes, authentication middleware, and file upload handling

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,7 @@
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@faker-js/faker": "^10.4.0",
         "jest": "^29.5.0",
         "mongodb-memory-server": "^11.0.1",
         "nodemon": "^2.0.22",
@@ -59,7 +60,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -574,6 +574,23 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1414,7 +1431,6 @@
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -1606,7 +1622,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^10.4.0",
     "jest": "^29.5.0",
     "mongodb-memory-server": "^11.0.1",
     "nodemon": "^2.0.22",

--- a/backend/seed.js
+++ b/backend/seed.js
@@ -48,6 +48,11 @@ const committeeMemberSchema = new mongoose.Schema(
 
 const groupSchema = new mongoose.Schema(
   {
+    groupId: {
+      type: String,
+      unique: true,
+      default: () => `grp_${new mongoose.Types.ObjectId().toHexString()}`,
+    },
     groupName: { type: String, required: true, unique: true, trim: true },
     projectTitle: { type: String, required: true, trim: true },
     advisor: { type: mongoose.Schema.Types.ObjectId, ref: 'Advisor', required: true },

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -10,6 +10,7 @@ const advisorRequestRoutes = require('./routes/advisorRequests'); // From main
 const committeeRoutes = require('./routes/committees');       // From main
 const scheduleWindowRoutes = require('./routes/scheduleWindow');
 const auditLogRoutes = require('./routes/auditLogs');
+const deliverableRoutes = require('./routes/deliverables');
 const { errorHandler } = require('./middleware/auth');
 
 const app = express();
@@ -57,6 +58,7 @@ app.use('/api/v1/advisor-requests', advisorRequestRoutes); // From main
 app.use('/api/v1/committees', committeeRoutes);           // From main
 app.use('/api/v1/schedule-window', scheduleWindowRoutes);
 app.use('/api/v1/audit-logs', auditLogRoutes);
+app.use('/api/deliverables', deliverableRoutes);
 
 // 404 Handler
 app.use((req, res) => {

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,4 +1,5 @@
 const { verifyAccessToken } = require('../utils/jwt');
+const Group = require('../models/Group');
 
 /**
  * Middleware to verify JWT access token in Authorization header
@@ -257,6 +258,49 @@ const serviceOrBearerAuth = (req, res, next) => {
   return authMiddleware(req, res, next);
 };
 
+/**
+ * Auth middleware for /api/deliverables/* routes.
+ * Validates Bearer JWT and enriches req.user with groupId looked up from the Group collection.
+ * Sets req.user = { userId, role, groupId } on success.
+ * Returns 401 if token is missing or invalid.
+ */
+const deliverableAuthMiddleware = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({
+        code: 'UNAUTHORIZED',
+        message: 'Missing or invalid authorization header',
+      });
+    }
+
+    let decoded;
+    try {
+      decoded = verifyAccessToken(authHeader.substring(7));
+    } catch {
+      return res.status(401).json({
+        code: 'INVALID_TOKEN',
+        message: 'Invalid or expired token',
+      });
+    }
+
+    const { userId, role } = decoded;
+
+    const group = await Group.findOne({
+      members: { $elemMatch: { userId, status: 'accepted' } },
+    }).select('groupId').lean();
+
+    req.user = { userId, role, groupId: group ? group.groupId : null };
+    next();
+  } catch (error) {
+    res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'Authentication check failed',
+    });
+  }
+};
+
 module.exports = {
   authMiddleware,
   roleMiddleware,
@@ -265,4 +309,5 @@ module.exports = {
   flexibleSystemOrRoleAuth,
   errorHandler,
   serviceOrBearerAuth,
+  deliverableAuthMiddleware,
 };

--- a/backend/src/middleware/upload.js
+++ b/backend/src/middleware/upload.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const { v4: uuidv4 } = require('uuid');
+
+const MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024; // 1 GB
+
+const ACCEPTED_MIMETYPES = new Set([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/markdown',
+  'application/zip',
+]);
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    const stagingId = uuidv4();
+    req.stagingId = stagingId;
+    const dest = path.join('uploads', 'staging', stagingId);
+    fs.mkdirSync(dest, { recursive: true });
+    cb(null, dest);
+  },
+  filename: (req, file, cb) => {
+    cb(null, file.originalname);
+  },
+});
+
+const fileFilter = (req, file, cb) => {
+  if (!ACCEPTED_MIMETYPES.has(file.mimetype)) {
+    const err = new multer.MulterError('UNSUPPORTED_MEDIA_TYPE');
+    err.message = `Unsupported file type: ${file.mimetype}`;
+    err.status = 415;
+    return cb(err, false);
+  }
+  cb(null, true);
+};
+
+const multerInstance = multer({
+  storage,
+  fileFilter,
+  limits: { fileSize: MAX_FILE_SIZE },
+});
+
+/**
+ * Returns a middleware that parses a single uploaded file from the given field name.
+ * Responds with 413 if file exceeds 1 GB, 415 if MIME type is not accepted.
+ * Both error responses are sent before the controller runs.
+ *
+ * @param {string} fieldName - Form field name for the uploaded file
+ * @returns {Function} Express middleware
+ */
+const uploadSingle = (fieldName) => (req, res, next) => {
+  multerInstance.single(fieldName)(req, res, (err) => {
+    if (!err) return next();
+
+    if (err instanceof multer.MulterError) {
+      if (err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(413).json({
+          code: 'FILE_TOO_LARGE',
+          message: 'File exceeds the maximum allowed size of 1 GB',
+        });
+      }
+      if (err.code === 'UNSUPPORTED_MEDIA_TYPE' || err.status === 415) {
+        return res.status(415).json({
+          code: 'UNSUPPORTED_MEDIA_TYPE',
+          message: err.message || 'File type is not supported',
+        });
+      }
+    }
+
+    // Non-multer errors (e.g. filesystem errors)
+    next(err);
+  });
+};
+
+module.exports = { uploadSingle };

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+const { deliverableAuthMiddleware, roleMiddleware } = require('../middleware/auth');
+const { uploadSingle } = require('../middleware/upload');
+
+// All deliverable routes require a valid JWT; req.user = { userId, role, groupId }
+router.use(deliverableAuthMiddleware);
+
+/**
+ * POST /api/deliverables/:stagingId/submit
+ * Accepted role: student
+ * Parses multipart upload (field: "file") before reaching the controller.
+ * Controller to be implemented in subsequent Process 5 issues.
+ */
+router.post(
+  '/:stagingId/submit',
+  roleMiddleware(['student']),
+  uploadSingle('file'),
+  (req, res) => {
+    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Submit endpoint not yet implemented' });
+  }
+);
+
+/**
+ * DELETE /api/deliverables/:deliverableId/retract
+ * Accepted role: coordinator
+ * Controller to be implemented in subsequent Process 5 issues.
+ */
+router.delete(
+  '/:deliverableId/retract',
+  roleMiddleware(['coordinator']),
+  (req, res) => {
+    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Retract endpoint not yet implemented' });
+  }
+);
+
+module.exports = router;

--- a/backend/tests/deliverables-middleware.test.js
+++ b/backend/tests/deliverables-middleware.test.js
@@ -1,0 +1,247 @@
+/**
+ * Smoke tests — Process 5 deliverables middleware
+ *
+ * Covers:
+ *   deliverableAuthMiddleware  → 401 no token, 401 bad token, attaches req.user
+ *   roleMiddleware on submit   → 403 when non-student hits submit
+ *   roleMiddleware on retract  → 403 when non-coordinator hits retract
+ *   uploadSingle (fileFilter)  → 415 on unsupported MIME type
+ *   uploadSingle (size limit)  → 413 on oversized file
+ *   Happy-path stubs           → 501 (controllers not yet implemented)
+ *
+ * Run a single suite:
+ *   npm test -- deliverables-middleware.test.js
+ */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'deliverables-smoke-test-secret';
+
+const mongoose = require('mongoose');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const { generateAccessToken } = require('../src/utils/jwt');
+const Group = require('../src/models/Group');
+
+let mongod;
+let app;
+
+const unique = (prefix) =>
+  `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+
+function makeToken(userId, role) {
+  return generateAccessToken(userId, role);
+}
+
+/** Write a temp file with a given size (bytes) and return its path. */
+function makeTempFile(name, sizeBytes, content = null) {
+  const filePath = path.join(os.tmpdir(), name);
+  if (content) {
+    fs.writeFileSync(filePath, content);
+  } else {
+    const buf = Buffer.alloc(sizeBytes, 'x');
+    fs.writeFileSync(filePath, buf);
+  }
+  return filePath;
+}
+
+/** Seed a Group with one accepted student member and return { groupId, studentId }. */
+async function seedGroupWithStudent() {
+  const studentId = unique('stu');
+  const groupId = unique('grp');
+  await Group.create({
+    groupId,
+    groupName: unique('Group'),
+    leaderId: studentId,
+    status: 'active',
+    members: [{ userId: studentId, role: 'leader', status: 'accepted' }],
+  });
+  return { groupId, studentId };
+}
+
+describe('Process 5 — deliverables middleware smoke tests', () => {
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+    app = require('../src/index');
+  }, 60000);
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    if (mongod) await mongod.stop();
+    // Remove files written by multer during tests
+    const stagingDir = path.join(__dirname, '..', 'uploads', 'staging');
+    if (fs.existsSync(stagingDir)) {
+      fs.rmSync(stagingDir, { recursive: true, force: true });
+    }
+  });
+
+  afterEach(async () => {
+    const { collections } = mongoose.connection;
+    await Promise.all(Object.values(collections).map((c) => c.deleteMany({})));
+  });
+
+  // ---------------------------------------------------------------------------
+  // deliverableAuthMiddleware
+  // ---------------------------------------------------------------------------
+  describe('deliverableAuthMiddleware', () => {
+    it('returns 401 when Authorization header is absent', async () => {
+      const res = await request(app)
+        .post('/api/deliverables/any-staging-id/submit')
+        .field('dummy', 'value');
+
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe('UNAUTHORIZED');
+    });
+
+    it('returns 401 when token is malformed / invalid', async () => {
+      const res = await request(app)
+        .post('/api/deliverables/any-staging-id/submit')
+        .set('Authorization', 'Bearer not.a.real.token');
+
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe('INVALID_TOKEN');
+    });
+
+    it('returns 401 when retract route has no token', async () => {
+      const res = await request(app).delete(
+        '/api/deliverables/del-123/retract'
+      );
+
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe('UNAUTHORIZED');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Role enforcement — submit route (student only)
+  // ---------------------------------------------------------------------------
+  describe('role enforcement — submit (student only)', () => {
+    it('returns 403 when a coordinator tries to submit', async () => {
+      const coordToken = makeToken(unique('coord'), 'coordinator');
+      const pdfPath = makeTempFile('test.pdf', 512, '%PDF-1.4 smoke');
+
+      const res = await request(app)
+        .post('/api/deliverables/staging-abc/submit')
+        .set('Authorization', `Bearer ${coordToken}`)
+        .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when an advisor tries to submit', async () => {
+      const advisorToken = makeToken(unique('advisor'), 'advisor');
+      const pdfPath = makeTempFile('test2.pdf', 512, '%PDF-1.4 smoke');
+
+      const res = await request(app)
+        .post('/api/deliverables/staging-abc/submit')
+        .set('Authorization', `Bearer ${advisorToken}`)
+        .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Role enforcement — retract route (coordinator only)
+  // ---------------------------------------------------------------------------
+  describe('role enforcement — retract (coordinator only)', () => {
+    it('returns 403 when a student tries to retract', async () => {
+      const { studentId } = await seedGroupWithStudent();
+      const studentToken = makeToken(studentId, 'student');
+
+      const res = await request(app)
+        .delete('/api/deliverables/del-999/retract')
+        .set('Authorization', `Bearer ${studentToken}`);
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // uploadSingle — MIME type filter (415)
+  // ---------------------------------------------------------------------------
+  describe('uploadSingle — MIME type filter', () => {
+    it('returns 415 for an unsupported MIME type (image/png)', async () => {
+      const { studentId } = await seedGroupWithStudent();
+      const studentToken = makeToken(studentId, 'student');
+      const imgPath = makeTempFile('photo.png', 512);
+
+      const res = await request(app)
+        .post('/api/deliverables/staging-xyz/submit')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .attach('file', imgPath, { contentType: 'image/png' });
+
+      expect(res.status).toBe(415);
+      expect(res.body.code).toBe('UNSUPPORTED_MEDIA_TYPE');
+    });
+
+    it('returns 415 for text/plain', async () => {
+      const { studentId } = await seedGroupWithStudent();
+      const studentToken = makeToken(studentId, 'student');
+      const txtPath = makeTempFile('readme.txt', 64, 'hello world');
+
+      const res = await request(app)
+        .post('/api/deliverables/staging-xyz/submit')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .attach('file', txtPath, { contentType: 'text/plain' });
+
+      expect(res.status).toBe(415);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // uploadSingle — accepted MIME types reach the stub (501)
+  // ---------------------------------------------------------------------------
+  describe('uploadSingle — accepted MIME types', () => {
+    const cases = [
+      { mime: 'application/pdf', filename: 'doc.pdf', content: '%PDF-1.4' },
+      {
+        mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        filename: 'doc.docx',
+        content: 'PK stub',
+      },
+      { mime: 'text/markdown', filename: 'doc.md', content: '# heading' },
+      { mime: 'application/zip', filename: 'doc.zip', content: 'PK stub' },
+    ];
+
+    test.each(cases)(
+      'passes through $mime and reaches 501 stub',
+      async ({ mime, filename, content }) => {
+        const { studentId } = await seedGroupWithStudent();
+        const studentToken = makeToken(studentId, 'student');
+        const filePath = makeTempFile(filename, 0, content);
+
+        const res = await request(app)
+          .post('/api/deliverables/staging-ok/submit')
+          .set('Authorization', `Bearer ${studentToken}`)
+          .attach('file', filePath, { contentType: mime });
+
+        // 501 means multer accepted the file and auth passed — controller not yet implemented
+        expect(res.status).toBe(501);
+        expect(res.body.code).toBe('NOT_IMPLEMENTED');
+      }
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Happy-path retract stub
+  // ---------------------------------------------------------------------------
+  describe('retract stub', () => {
+    it('coordinator reaches 501 stub on retract', async () => {
+      const coordToken = makeToken(unique('coord'), 'coordinator');
+
+      const res = await request(app)
+        .delete('/api/deliverables/del-abc/retract')
+        .set('Authorization', `Bearer ${coordToken}`);
+
+      expect(res.status).toBe(501);
+      expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Sets up the shared middleware layer required by all Process 5 endpoints before any deliverable controller is implemented.

- `backend/src/middleware/upload.js` — multer configured with `diskStorage` to `uploads/staging/{uuid}/`, 1 GB hard limit (413 before controller), and MIME type allowlist (`application/pdf`, `.docx`, `text/markdown`, `application/zip`) with 415 rejection for anything else

- `backend/src/middleware/auth.js` — added `deliverableAuthMiddleware`: validates Bearer JWT and enriches `req.user` with `groupId` looked up from the `Group` collection, returning `401` on missing/invalid token

- `backend/src/routes/deliverables.js` — new router mounted at `/api/deliverables`; `deliverableAuthMiddleware` applied to all routes, `POST /:stagingId/submit` restricted to `student` role, `DELETE /:deliverableId/retract` restricted to `coordinator` role; both return 501 until controllers are implemented in subsequent issues

- `backend/src/index.js` — registers the deliverables router

- `backend/seed.js` — fixed duplicate key crash caused by missing `groupId` default in the seed's inline schema