### PR TITLE
feat: update deliverable validation and submission processes

### DIFF
--- a/backend/scripts/seed-test-student.js
+++ b/backend/scripts/seed-test-student.js
@@ -1,0 +1,144 @@
+/**
+ * Seed a test student user + active group + committee + open schedule windows
+ * for manual testing of:
+ *   POST /api/v1/deliverables/validate-group  (Process 5.1)
+ *   POST /api/v1/deliverables/submit          (Process 5.2)
+ *
+ * Also opens group_creation and member_addition schedule windows so the
+ * frontend group creation flow works without a coordinator.
+ *
+ * Usage:
+ *   node scripts/seed-test-student.js
+ *
+ * Safe to run multiple times — cleans up previous test data first.
+ */
+
+'use strict';
+
+require('dotenv').config();
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const User           = require('../src/models/User');
+const Group          = require('../src/models/Group');
+const Committee      = require('../src/models/Committee');
+const ScheduleWindow = require('../src/models/ScheduleWindow');
+const { hashPassword }        = require('../src/utils/password');
+const { generateAccessToken } = require('../src/utils/jwt');
+
+const MONGO_URI     = process.env.MONGODB_URI || 'mongodb://localhost:27017/senior-app';
+const TEST_EMAIL    = 'test.student@example.edu.tr';
+const TEST_PASSWORD = 'Test@1234';
+
+async function run() {
+  await mongoose.connect(MONGO_URI);
+
+  // ── Clean up previous test data ───────────────────────────────────────────
+  const existing = await User.findOne({ email: TEST_EMAIL });
+  if (existing) {
+    await Group.deleteOne({ leaderId: existing.userId });
+    await User.deleteOne({ email: TEST_EMAIL });
+  }
+  await Committee.deleteOne({ committeeName: 'Test Committee' });
+  await ScheduleWindow.deleteMany({ createdBy: 'seed-test-student' });
+
+  // ── Create student user ───────────────────────────────────────────────────
+  const userId = `usr_${uuidv4().split('-')[0]}`;
+  const hashedPassword = await hashPassword(TEST_PASSWORD);
+
+  await User.create({
+    userId,
+    email: TEST_EMAIL,
+    hashedPassword,
+    role: 'student',
+    emailVerified: true,
+    accountStatus: 'active',
+  });
+
+  // ── Create committee ──────────────────────────────────────────────────────
+  const committeeId = `cmt_test_${uuidv4().split('-')[0]}`;
+  await Committee.create({
+    committeeId,
+    committeeName: 'Test Committee',
+    createdBy: 'coordinator_test',
+    status: 'published',
+    advisorIds: [`adv_test_${uuidv4().split('-')[0]}`],
+    juryIds: [],
+  });
+
+  // ── Create active group with the student as accepted leader ──────────────
+  const groupId = `grp_test_${uuidv4().split('-')[0]}`;
+  await Group.create({
+    groupId,
+    groupName: 'Test Group',
+    leaderId: userId,
+    status: 'active',
+    committeeId,
+    members: [{ userId, role: 'leader', status: 'accepted' }],
+  });
+
+  // ── Open schedule windows (1 year from now) ───────────────────────────────
+  const startsAt = new Date(Date.now() - 60 * 1000);        // started 1 min ago
+  const endsAt   = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000); // ends in 1 year
+
+  for (const operationType of ['group_creation', 'member_addition', 'deliverable_submission']) {
+    await ScheduleWindow.create({
+      operationType,
+      startsAt,
+      endsAt,
+      isActive: true,
+      createdBy: 'seed-test-student',
+      label: `Test window — ${operationType}`,
+    });
+  }
+
+  // ── Generate a ready-to-use JWT (1 h) ─────────────────────────────────────
+  const token = generateAccessToken(userId, 'student');
+
+  await mongoose.disconnect();
+
+  // ── Print instructions ────────────────────────────────────────────────────
+  console.log('\n✅  Test data seeded successfully\n');
+  console.log('⚠️   If you were already logged in, log out and log back in.');
+  console.log('    The seed creates a new userId each run — old sessions are stale.\n');
+  console.log('─────────────────────────────────────────────────────────────');
+  console.log(`  email    : ${TEST_EMAIL}`);
+  console.log(`  password : ${TEST_PASSWORD}`);
+  console.log(`  userId   : ${userId}`);
+  console.log(`  groupId  : ${groupId}`);
+  console.log(`  JWT      : ${token}`);
+  console.log('─────────────────────────────────────────────────────────────');
+  console.log(`
+The test student already has an active group (${groupId}).
+Log in at the frontend, navigate to the group dashboard, and use the
+Deliverable Submission form to upload a file.
+
+Or test via curl:
+
+STEP 1 — Get a validationToken (Process 5.1):
+
+  curl -s -X POST http://localhost:5000/api/v1/deliverables/validate-group \\
+    -H "Authorization: Bearer ${token}" \\
+    -H "Content-Type: application/json" \\
+    -d '{"groupId": "${groupId}"}' | jq .
+
+STEP 2 — Submit a deliverable (Process 5.2):
+
+  echo "%PDF-1.4 test" > /tmp/test.pdf
+
+  curl -s -X POST http://localhost:5000/api/v1/deliverables/submit \\
+    -H "Authorization: Bearer ${token}" \\
+    -H "Authorization-Validation: <paste validationToken here>" \\
+    -F "groupId=${groupId}" \\
+    -F "deliverableType=proposal" \\
+    -F "sprintId=sprint_1" \\
+    -F "description=My test proposal" \\
+    -F "file=@/tmp/test.pdf;type=application/pdf" | jq .
+`);
+}
+
+run().catch((err) => {
+  console.error('Seed failed:', err);
+  process.exit(1);
+});

--- a/backend/scripts/seed-test-student.js
+++ b/backend/scripts/seed-test-student.js
@@ -40,6 +40,7 @@ async function run() {
     await Group.deleteOne({ leaderId: existing.userId });
     await User.deleteOne({ email: TEST_EMAIL });
   }
+  await Group.deleteOne({ groupName: 'Test Group' });
   await Committee.deleteOne({ committeeName: 'Test Committee' });
   await ScheduleWindow.deleteMany({ createdBy: 'seed-test-student' });
 

--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -1,11 +1,23 @@
 'use strict';
 
+const fs = require('fs');
 const jwt = require('jsonwebtoken');
+const { v4: uuidv4 } = require('uuid');
 const Group = require('../models/Group');
 const Committee = require('../models/Committee');
 const AuditLog = require('../models/AuditLog');
+const DeliverableStaging = require('../models/DeliverableStaging');
+const { hashData } = require('../utils/fileHash');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+
+const DELIVERABLE_TYPES = [
+  'proposal',
+  'statement_of_work',
+  'demo',
+  'interim_report',
+  'final_report',
+];
 
 /**
  * Write a fire-and-forget audit log entry for group validation events.
@@ -139,4 +151,152 @@ const validateGroup = async (req, res) => {
   });
 };
 
-module.exports = { validateGroup };
+/**
+ * POST /api/deliverables/submit
+ *
+ * Process 5.2 — Accept the deliverable file and create a staging record.
+ *
+ * Prerequisites (checked in order):
+ *   1. File uploaded via multer (413/415 handled by middleware)
+ *   2. Required body fields present: groupId, deliverableType, sprintId
+ *   3. Authorization-Validation header contains a valid, unexpired JWT from Process 5.1
+ *   4. groupId in body matches the groupId embedded in the validation token
+ *   5. Rate limit: same group ≤ 3 submissions in the last 10 minutes
+ *
+ * On success, creates a DeliverableStaging document (status: 'staging', TTL: 1 hour)
+ * and returns 202 with stagingId, fileHash, sizeMb, mimeType, and nextStep.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const submitDeliverable = async (req, res) => {
+  const userId = req.user?.userId;
+  const { groupId, deliverableType, sprintId, description } = req.body;
+
+  // 1. File must be present (multer handles 413/415 before this point)
+  if (!req.file) {
+    return res.status(400).json({
+      code: 'MISSING_FILE',
+      message: 'A file must be attached to the request',
+    });
+  }
+
+  // 2. Required body fields
+  if (!groupId || !deliverableType || !sprintId) {
+    return res.status(400).json({
+      code: 'INVALID_REQUEST',
+      message: 'groupId, deliverableType, and sprintId are required',
+    });
+  }
+
+  if (!DELIVERABLE_TYPES.includes(deliverableType)) {
+    return res.status(400).json({
+      code: 'INVALID_DELIVERABLE_TYPE',
+      message: `deliverableType must be one of: ${DELIVERABLE_TYPES.join(', ')}`,
+    });
+  }
+
+  // 3. Validate Authorization-Validation header
+  const validationHeader = req.headers['authorization-validation'];
+  if (!validationHeader) {
+    return res.status(403).json({
+      code: 'MISSING_VALIDATION_TOKEN',
+      message: 'Authorization-Validation header is required',
+    });
+  }
+
+  let tokenPayload;
+  try {
+    tokenPayload = jwt.verify(validationHeader, JWT_SECRET);
+  } catch {
+    return res.status(403).json({
+      code: 'INVALID_VALIDATION_TOKEN',
+      message: 'Validation token is invalid or expired',
+    });
+  }
+
+  // 4. groupId in body must match the token's groupId
+  if (tokenPayload.groupId !== groupId) {
+    return res.status(403).json({
+      code: 'GROUP_ID_MISMATCH',
+      message: 'groupId does not match the validation token',
+    });
+  }
+
+  // 5. Rate limit: max 3 submissions per group in 10 minutes
+  const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+  let recentCount;
+  try {
+    recentCount = await DeliverableStaging.countDocuments({
+      groupId,
+      createdAt: { $gte: tenMinutesAgo },
+    });
+  } catch (err) {
+    console.error('submitDeliverable – rate limit query error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (recentCount >= 3) {
+    return res.status(429).json({
+      code: 'RATE_LIMIT_EXCEEDED',
+      message: 'Too many submissions. Maximum 3 submissions per group every 10 minutes.',
+    });
+  }
+
+  // Compute SHA-256 hash of the uploaded file
+  let fileBuffer;
+  try {
+    fileBuffer = fs.readFileSync(req.file.path);
+  } catch (err) {
+    console.error('submitDeliverable – file read error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to read uploaded file' });
+  }
+  const fileHash = hashData(fileBuffer);
+
+  // Create the staging record
+  const stagingId = `stg_${uuidv4().replace(/-/g, '').slice(0, 10)}`;
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+
+  try {
+    await DeliverableStaging.create({
+      stagingId,
+      groupId,
+      deliverableType,
+      sprintId,
+      submittedBy: userId,
+      description: description || null,
+      tempFilePath: req.file.path,
+      fileSize: req.file.size,
+      fileHash,
+      mimeType: req.file.mimetype,
+      status: 'staging',
+      expiresAt,
+    });
+  } catch (err) {
+    console.error('submitDeliverable – staging record create error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to create staging record' });
+  }
+
+  AuditLog.create({
+    action: 'DELIVERABLE_STAGING_CREATED',
+    actorId: userId,
+    groupId,
+    payload: { stagingId, deliverableType, sprintId },
+    ipAddress: req.ip || null,
+    userAgent: req.headers['user-agent'] || null,
+  }).catch((err) => {
+    console.error('Audit log write failed (submitDeliverable):', err.message);
+  });
+
+  const sizeMb = parseFloat((req.file.size / (1024 * 1024)).toFixed(2));
+
+  return res.status(202).json({
+    stagingId,
+    fileHash,
+    sizeMb,
+    mimeType: req.file.mimetype,
+    nextStep: 'format_validation',
+  });
+};
+
+module.exports = { validateGroup, submitDeliverable };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -58,7 +58,7 @@ app.use('/api/v1/advisor-requests', advisorRequestRoutes); // From main
 app.use('/api/v1/committees', committeeRoutes);           // From main
 app.use('/api/v1/schedule-window', scheduleWindowRoutes);
 app.use('/api/v1/audit-logs', auditLogRoutes);
-app.use('/api/deliverables', deliverableRoutes);
+app.use('/api/v1/deliverables', deliverableRoutes);
 
 // 404 Handler
 app.use((req, res) => {

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -90,6 +90,9 @@ const auditLogSchema = new mongoose.Schema(
         'GROUP_VALIDATION_SUCCESS',
         'GROUP_VALIDATION_FAILED',
 
+        // --- Deliverable Staging (Process 5.2) ---
+        'DELIVERABLE_STAGING_CREATED',
+
         // --- System & Test ---
         'TEST_ACTION',
       ],

--- a/backend/src/models/DeliverableStaging.js
+++ b/backend/src/models/DeliverableStaging.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const DELIVERABLE_TYPES = [
+  'proposal',
+  'statement_of_work',
+  'demo',
+  'interim_report',
+  'final_report',
+];
+
+const deliverableStagingSchema = new mongoose.Schema(
+  {
+    stagingId: {
+      type: String,
+      required: true,
+      unique: true,
+      default: () => `stg_${uuidv4().replace(/-/g, '').slice(0, 10)}`,
+    },
+    groupId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    deliverableType: {
+      type: String,
+      enum: DELIVERABLE_TYPES,
+      required: true,
+    },
+    sprintId: {
+      type: String,
+      required: true,
+    },
+    submittedBy: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      default: null,
+    },
+    tempFilePath: {
+      type: String,
+      required: true,
+    },
+    fileSize: {
+      type: Number,
+      required: true,
+    },
+    fileHash: {
+      type: String,
+      required: true,
+    },
+    mimeType: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ['staging'],
+      default: 'staging',
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+      default: () => new Date(Date.now() + 60 * 60 * 1000), // +1 hour
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'deliverable_stagings',
+  }
+);
+
+// Unique lookup by stagingId
+deliverableStagingSchema.index({ stagingId: 1 }, { unique: true });
+
+// TTL index — MongoDB auto-deletes documents once expiresAt is reached
+deliverableStagingSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+module.exports = mongoose.model('DeliverableStaging', deliverableStagingSchema);

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 const { deliverableAuthMiddleware, roleMiddleware } = require('../middleware/auth');
 const { uploadSingle } = require('../middleware/upload');
-const { validateGroup } = require('../controllers/deliverableController');
+const { validateGroup, submitDeliverable } = require('../controllers/deliverableController');
 
 // All deliverable routes require a valid JWT; req.user = { userId, role, groupId }
 router.use(deliverableAuthMiddleware);
@@ -18,6 +18,20 @@ router.use(deliverableAuthMiddleware);
 router.post('/validate-group', roleMiddleware(['student']), validateGroup);
 
 /**
+ * POST /api/deliverables/submit
+ * Process 5.2 — Accept file upload and create a staging record.
+ * Requires: JWT (student), multipart/form-data with file field,
+ * and a valid Authorization-Validation token from Process 5.1.
+ * Returns 202 with stagingId on success.
+ */
+router.post(
+  '/submit',
+  roleMiddleware(['student']),
+  uploadSingle('file'),
+  submitDeliverable
+);
+
+/**
  * POST /api/deliverables/:stagingId/submit
  * Accepted role: student
  * Parses multipart upload (field: "file") before reaching the controller.
@@ -27,7 +41,7 @@ router.post(
   '/:stagingId/submit',
   roleMiddleware(['student']),
   uploadSingle('file'),
-  (req, res) => {
+  (_req, res) => {
     res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Submit endpoint not yet implemented' });
   }
 );
@@ -40,7 +54,7 @@ router.post(
 router.delete(
   '/:deliverableId/retract',
   roleMiddleware(['coordinator']),
-  (req, res) => {
+  (_req, res) => {
     res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Retract endpoint not yet implemented' });
   }
 );

--- a/backend/tests/deliverables-middleware.test.js
+++ b/backend/tests/deliverables-middleware.test.js
@@ -92,7 +92,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
   describe('deliverableAuthMiddleware', () => {
     it('returns 401 when Authorization header is absent', async () => {
       const res = await request(app)
-        .post('/api/deliverables/any-staging-id/submit')
+        .post('/api/v1/deliverables/any-staging-id/submit')
         .field('dummy', 'value');
 
       expect(res.status).toBe(401);
@@ -101,7 +101,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
 
     it('returns 401 when token is malformed / invalid', async () => {
       const res = await request(app)
-        .post('/api/deliverables/any-staging-id/submit')
+        .post('/api/v1/deliverables/any-staging-id/submit')
         .set('Authorization', 'Bearer not.a.real.token');
 
       expect(res.status).toBe(401);
@@ -110,7 +110,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
 
     it('returns 401 when retract route has no token', async () => {
       const res = await request(app).delete(
-        '/api/deliverables/del-123/retract'
+        '/api/v1/deliverables/del-123/retract'
       );
 
       expect(res.status).toBe(401);
@@ -127,7 +127,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
       const pdfPath = makeTempFile('test.pdf', 512, '%PDF-1.4 smoke');
 
       const res = await request(app)
-        .post('/api/deliverables/staging-abc/submit')
+        .post('/api/v1/deliverables/staging-abc/submit')
         .set('Authorization', `Bearer ${coordToken}`)
         .attach('file', pdfPath, { contentType: 'application/pdf' });
 
@@ -139,7 +139,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
       const pdfPath = makeTempFile('test2.pdf', 512, '%PDF-1.4 smoke');
 
       const res = await request(app)
-        .post('/api/deliverables/staging-abc/submit')
+        .post('/api/v1/deliverables/staging-abc/submit')
         .set('Authorization', `Bearer ${advisorToken}`)
         .attach('file', pdfPath, { contentType: 'application/pdf' });
 
@@ -156,7 +156,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
       const studentToken = makeToken(studentId, 'student');
 
       const res = await request(app)
-        .delete('/api/deliverables/del-999/retract')
+        .delete('/api/v1/deliverables/del-999/retract')
         .set('Authorization', `Bearer ${studentToken}`);
 
       expect(res.status).toBe(403);
@@ -173,7 +173,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
       const imgPath = makeTempFile('photo.png', 512);
 
       const res = await request(app)
-        .post('/api/deliverables/staging-xyz/submit')
+        .post('/api/v1/deliverables/staging-xyz/submit')
         .set('Authorization', `Bearer ${studentToken}`)
         .attach('file', imgPath, { contentType: 'image/png' });
 
@@ -187,7 +187,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
       const txtPath = makeTempFile('readme.txt', 64, 'hello world');
 
       const res = await request(app)
-        .post('/api/deliverables/staging-xyz/submit')
+        .post('/api/v1/deliverables/staging-xyz/submit')
         .set('Authorization', `Bearer ${studentToken}`)
         .attach('file', txtPath, { contentType: 'text/plain' });
 
@@ -218,7 +218,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
         const filePath = makeTempFile(filename, 0, content);
 
         const res = await request(app)
-          .post('/api/deliverables/staging-ok/submit')
+          .post('/api/v1/deliverables/staging-ok/submit')
           .set('Authorization', `Bearer ${studentToken}`)
           .attach('file', filePath, { contentType: mime });
 
@@ -237,7 +237,7 @@ describe('Process 5 — deliverables middleware smoke tests', () => {
       const coordToken = makeToken(unique('coord'), 'coordinator');
 
       const res = await request(app)
-        .delete('/api/deliverables/del-abc/retract')
+        .delete('/api/v1/deliverables/del-abc/retract')
         .set('Authorization', `Bearer ${coordToken}`);
 
       expect(res.status).toBe(501);

--- a/backend/tests/submit-deliverable.smoke.test.js
+++ b/backend/tests/submit-deliverable.smoke.test.js
@@ -1,0 +1,429 @@
+/**
+ * Smoke tests — POST /api/deliverables/submit  (Process 5.2)
+ *
+ * Covers:
+ *   401  no Authorization header
+ *   401  invalid JWT
+ *   403  non-student role
+ *   400  missing required body fields
+ *   400  invalid deliverableType enum value
+ *   403  missing Authorization-Validation header
+ *   403  expired / invalid validation token
+ *   403  groupId mismatch between body and validation token
+ *   429  rate limit exceeded (> 3 submissions in 10 min for same group)
+ *   202  happy path — returns stagingId, fileHash, sizeMb, mimeType, nextStep
+ *   202  description field is optional
+ *
+ * Run:
+ *   npm test -- submit-deliverable.smoke.test.js
+ */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'submit-deliverable-smoke-secret';
+
+const mongoose = require('mongoose');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const jwt = require('jsonwebtoken');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const { generateAccessToken } = require('../src/utils/jwt');
+const Group = require('../src/models/Group');
+const DeliverableStaging = require('../src/models/DeliverableStaging');
+
+const ENDPOINT = '/api/v1/deliverables/submit';
+const JWT_SECRET = process.env.JWT_SECRET;
+
+let mongod;
+let app;
+
+const unique = (prefix) => `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+
+function makeToken(userId, role) {
+  return generateAccessToken(userId, role);
+}
+
+function makeValidationToken(groupId, committeeId = 'cmt_test', expiresIn = '15m') {
+  return jwt.sign({ groupId, committeeId }, JWT_SECRET, { expiresIn });
+}
+
+/** Write a small temp PDF and return its path. */
+function makePdf(name = 'test.pdf') {
+  const p = path.join(os.tmpdir(), name);
+  fs.writeFileSync(p, Buffer.from('%PDF-1.4 smoke test content'));
+  return p;
+}
+
+/** Seed an active group with one student and return { groupId, studentId, token }. */
+async function seedGroup(overrides = {}) {
+  const studentId = unique('stu');
+  const groupId = unique('grp');
+  await Group.create({
+    groupId,
+    groupName: unique('Group'),
+    leaderId: studentId,
+    status: 'active',
+    members: [{ userId: studentId, role: 'leader', status: 'accepted' }],
+    ...overrides,
+  });
+  return { groupId, studentId, token: makeToken(studentId, 'student') };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  app = require('../src/index');
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+  const stagingDir = path.join(__dirname, '..', 'uploads', 'staging');
+  if (fs.existsSync(stagingDir)) {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
+});
+
+afterEach(async () => {
+  const { collections } = mongoose.connection;
+  await Promise.all(Object.values(collections).map((c) => c.deleteMany({})));
+});
+
+// ---------------------------------------------------------------------------
+// Auth guard
+// ---------------------------------------------------------------------------
+describe('auth guard', () => {
+  it('401 — no Authorization header', async () => {
+    const res = await request(app).post(ENDPOINT);
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('401 — malformed token', async () => {
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', 'Bearer not.a.real.token');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Role guard
+// ---------------------------------------------------------------------------
+describe('role guard', () => {
+  it('403 — coordinator cannot submit', async () => {
+    const token = makeToken(unique('coord'), 'coordinator');
+    const pdfPath = makePdf('coord.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing file
+// ---------------------------------------------------------------------------
+describe('missing file', () => {
+  it('400 — no file attached', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('MISSING_FILE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Body validation
+// ---------------------------------------------------------------------------
+describe('body validation', () => {
+  it('400 — missing groupId', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const pdfPath = makePdf('missing-group.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+  });
+
+  it('400 — missing sprintId', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const pdfPath = makePdf('missing-sprint.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+  });
+
+  it('400 — invalid deliverableType', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const pdfPath = makePdf('bad-type.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'unknown_type')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DELIVERABLE_TYPE');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Authorization-Validation header checks
+// ---------------------------------------------------------------------------
+describe('Authorization-Validation header', () => {
+  it('403 — missing header', async () => {
+    const { groupId, token } = await seedGroup();
+    const pdfPath = makePdf('no-val.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('MISSING_VALIDATION_TOKEN');
+  });
+
+  it('403 — expired validation token', async () => {
+    const { groupId, token } = await seedGroup();
+    const expiredToken = makeValidationToken(groupId, 'cmt_1', '-1s');
+    const pdfPath = makePdf('expired-val.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', expiredToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('INVALID_VALIDATION_TOKEN');
+  });
+
+  it('403 — malformed validation token', async () => {
+    const { groupId, token } = await seedGroup();
+    const pdfPath = makePdf('bad-val.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', 'not.a.jwt')
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('INVALID_VALIDATION_TOKEN');
+  });
+
+  it('403 — groupId in body does not match token groupId', async () => {
+    const { token } = await seedGroup();
+    const otherGroupId = unique('other');
+    const validationToken = makeValidationToken(otherGroupId);
+    const pdfPath = makePdf('mismatch.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', unique('yet_another'))
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('GROUP_ID_MISMATCH');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting
+// ---------------------------------------------------------------------------
+describe('rate limiting', () => {
+  it('429 — more than 3 submissions in 10 minutes', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+
+    // Seed 3 existing staging records in the last 10 minutes
+    await DeliverableStaging.insertMany([
+      {
+        stagingId: `stg_aaa0000001`,
+        groupId,
+        deliverableType: 'proposal',
+        sprintId: 'sprint_1',
+        submittedBy: unique('stu'),
+        tempFilePath: '/tmp/fake1',
+        fileSize: 100,
+        fileHash: 'abc',
+        mimeType: 'application/pdf',
+      },
+      {
+        stagingId: `stg_bbb0000002`,
+        groupId,
+        deliverableType: 'proposal',
+        sprintId: 'sprint_1',
+        submittedBy: unique('stu'),
+        tempFilePath: '/tmp/fake2',
+        fileSize: 100,
+        fileHash: 'def',
+        mimeType: 'application/pdf',
+      },
+      {
+        stagingId: `stg_ccc0000003`,
+        groupId,
+        deliverableType: 'proposal',
+        sprintId: 'sprint_1',
+        submittedBy: unique('stu'),
+        tempFilePath: '/tmp/fake3',
+        fileSize: 100,
+        fileHash: 'ghi',
+        mimeType: 'application/pdf',
+      },
+    ]);
+
+    const pdfPath = makePdf('rate-limit.pdf');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+    expect(res.status).toBe(429);
+    expect(res.body.code).toBe('RATE_LIMIT_EXCEEDED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+describe('happy path', () => {
+  it('202 — returns stagingId, fileHash, sizeMb, mimeType, nextStep', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const pdfPath = makePdf('happy.pdf');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'proposal')
+      .field('sprintId', 'sprint_1')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+    expect(res.status).toBe(202);
+    expect(res.body.stagingId).toMatch(/^stg_[0-9a-f]{10}$/);
+    expect(res.body.fileHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(typeof res.body.sizeMb).toBe('number');
+    expect(res.body.mimeType).toBe('application/pdf');
+    expect(res.body.nextStep).toBe('format_validation');
+  });
+
+  it('202 — staging record is persisted in DB with correct fields', async () => {
+    const { groupId, studentId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const pdfPath = makePdf('db-check.pdf');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'interim_report')
+      .field('sprintId', 'sprint_2')
+      .field('description', 'Mid-term interim report')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+    expect(res.status).toBe(202);
+
+    const record = await DeliverableStaging.findOne({ stagingId: res.body.stagingId }).lean();
+    expect(record).not.toBeNull();
+    expect(record.groupId).toBe(groupId);
+    expect(record.deliverableType).toBe('interim_report');
+    expect(record.sprintId).toBe('sprint_2');
+    expect(record.submittedBy).toBe(studentId);
+    expect(record.description).toBe('Mid-term interim report');
+    expect(record.fileHash).toBe(res.body.fileHash);
+    expect(record.mimeType).toBe('application/pdf');
+    expect(record.status).toBe('staging');
+    expect(record.expiresAt).toBeDefined();
+    // expiresAt should be ~1 hour from now
+    const diffMs = new Date(record.expiresAt) - Date.now();
+    expect(diffMs).toBeGreaterThan(59 * 60 * 1000);
+    expect(diffMs).toBeLessThan(61 * 60 * 1000);
+  });
+
+  it('202 — description is optional', async () => {
+    const { groupId, token } = await seedGroup();
+    const validationToken = makeValidationToken(groupId);
+    const pdfPath = makePdf('no-desc.pdf');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .set('Authorization-Validation', validationToken)
+      .field('groupId', groupId)
+      .field('deliverableType', 'final_report')
+      .field('sprintId', 'sprint_3')
+      .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+    expect(res.status).toBe(202);
+    const record = await DeliverableStaging.findOne({ stagingId: res.body.stagingId }).lean();
+    expect(record.description).toBeNull();
+  });
+
+  it('202 — all deliverableType enum values are accepted', async () => {
+    const types = ['proposal', 'statement_of_work', 'demo', 'interim_report', 'final_report'];
+
+    for (const deliverableType of types) {
+      const { groupId, token } = await seedGroup();
+      const validationToken = makeValidationToken(groupId);
+      const pdfPath = makePdf(`type-${deliverableType}.pdf`);
+
+      const res = await request(app)
+        .post(ENDPOINT)
+        .set('Authorization', `Bearer ${token}`)
+        .set('Authorization-Validation', validationToken)
+        .field('groupId', groupId)
+        .field('deliverableType', deliverableType)
+        .field('sprintId', 'sprint_1')
+        .attach('file', pdfPath, { contentType: 'application/pdf' });
+
+      expect(res.status).toBe(202);
+    }
+  });
+});

--- a/backend/tests/validate-group.smoke.test.js
+++ b/backend/tests/validate-group.smoke.test.js
@@ -31,7 +31,7 @@ const { generateAccessToken } = require('../src/utils/jwt');
 const Group = require('../src/models/Group');
 const Committee = require('../src/models/Committee');
 
-const ENDPOINT = '/api/deliverables/validate-group';
+const ENDPOINT = '/api/v1/deliverables/validate-group';
 
 let mongod;
 let app;

--- a/frontend/src/api/deliverableService.js
+++ b/frontend/src/api/deliverableService.js
@@ -1,16 +1,51 @@
 import apiClient from './apiClient';
 
 /**
- * Submit a deliverable for a group.
+ * Process 5.1 — Validate group eligibility and obtain a short-lived validationToken.
+ * @param {string} groupId
+ * @returns {Promise<{ validationToken: string, groupId: string, committeeId: string }>}
+ */
+export const validateGroupForSubmission = async (groupId) => {
+  const response = await apiClient.post('/deliverables/validate-group', { groupId });
+  return response.data;
+};
+
+/**
+ * Process 5.2 — Submit a deliverable file and create a staging record.
+ * Calls validate-group first to get a validationToken, then submits the file.
+ *
+ * @param {string} groupId
+ * @param {{ deliverableType: string, sprintId: string, file: File, description?: string }} params
+ * @returns {Promise<{ stagingId: string, fileHash: string, sizeMb: number, mimeType: string, nextStep: string }>}
+ */
+export const submitDeliverableStaging = async (groupId, { deliverableType, sprintId, file, description }) => {
+  const { validationToken } = await validateGroupForSubmission(groupId);
+
+  const formData = new FormData();
+  formData.append('groupId', groupId);
+  formData.append('deliverableType', deliverableType);
+  formData.append('sprintId', sprintId);
+  formData.append('file', file);
+  if (description) formData.append('description', description);
+
+  const response = await apiClient.post('/deliverables/submit', formData, {
+    headers: {
+      'Content-Type': undefined,
+      'Authorization-Validation': validationToken,
+    },
+  });
+  return response.data;
+};
+
+/**
+ * Legacy: Submit a deliverable for a group (old endpoint).
  * @param {string} groupId
  * @param {FormData} formData
  * @returns {Promise<object>}
  */
 export const submitDeliverable = async (groupId, formData) => {
   const response = await apiClient.post(`/groups/${groupId}/deliverables`, formData, {
-    headers: {
-      'Content-Type': undefined,
-    },
+    headers: { 'Content-Type': undefined },
   });
   return response.data;
 };

--- a/frontend/src/api/groupService.js
+++ b/frontend/src/api/groupService.js
@@ -162,33 +162,8 @@ export const getGroup = async (groupId) => {
  *   2. Call GET /committees/{committeeId} to fetch published committee data
  */
 export const getGroupCommitteeStatus = async (groupId) => {
-  try {
-    const response = await apiClient.get(`/groups/${groupId}`);
-    const group = response.data;
-
-    if (!group.committeeId) {
-      return {
-        groupId,
-        committeeId: null,
-        committee: null,
-      };
-    }
-
-    // TODO: Backend Implementation (Issue #75 or related GET endpoint requirement)
-    // Once backend implements GET /committees/{committeeId}, uncomment below:
-    // const committeeResponse = await apiClient.get(`/committees/${group.committeeId}`);
-    // return committeeResponse.data;
-
-    // Temporary: Return placeholder response structure
-    return {
-      groupId,
-      committeeId: group.committeeId,
-      committee: null, // Awaiting backend GET /committees/{committeeId} implementation
-    };
-  } catch (error) {
-    console.error('Error fetching committee status:', error);
-    throw error;
-  }
+  const response = await apiClient.get(`/groups/${groupId}/committee-status`);
+  return response.data;
 };
 
 /**

--- a/frontend/src/components/CommitteeStatusCard.js
+++ b/frontend/src/components/CommitteeStatusCard.js
@@ -46,13 +46,13 @@ const CommitteeStatusCard = ({ committeeStatus, user }) => {
             <div className="info-row">
               <span className="info-label">Advisors</span>
               <span className="info-value">
-                {committee.advisorIds.length > 0 ? committee.advisorIds.join(', ') : 'None assigned'}
+                {committee.advisorIds?.length > 0 ? committee.advisorIds.join(', ') : 'None assigned'}
               </span>
             </div>
             <div className="info-row">
               <span className="info-label">Jury</span>
               <span className="info-value">
-                {committee.juryIds.length > 0 ? committee.juryIds.join(', ') : 'None assigned'}
+                {committee.juryIds?.length > 0 ? committee.juryIds.join(', ') : 'None assigned'}
               </span>
             </div>
             {isAdvisor && (

--- a/frontend/src/components/DeliverableSubmissionForm.js
+++ b/frontend/src/components/DeliverableSubmissionForm.js
@@ -1,15 +1,18 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { getScheduleWindow } from '../api/groupService';
-import { getGroupDeliverables, submitDeliverable } from '../api/deliverableService';
+import { getGroupDeliverables, submitDeliverableStaging } from '../api/deliverableService';
 
 const DELIVERABLE_TYPES = [
   { value: 'proposal', label: 'Proposal' },
   { value: 'statement_of_work', label: 'Statement of Work' },
-  { value: 'demonstration', label: 'Demonstration' },
+  { value: 'demo', label: 'Demo' },
+  { value: 'interim_report', label: 'Interim Report' },
+  { value: 'final_report', label: 'Final Report' },
 ];
 
 const DeliverableSubmissionForm = ({
   groupId,
+  sprintId: sprintIdProp,
   isLeader,
   userId,
   members,
@@ -17,9 +20,9 @@ const DeliverableSubmissionForm = ({
   onSuccess,
 }) => {
   const [selectedType, setSelectedType] = useState('proposal');
-  const [storageMode, setStorageMode] = useState('file');
+  const [sprintId, setSprintId] = useState(sprintIdProp || '');
   const [file, setFile] = useState(null);
-  const [link, setLink] = useState('');
+  const [description, setDescription] = useState('');
   const [windowOpen, setWindowOpen] = useState(false);
   const [windowInfo, setWindowInfo] = useState(null);
   const [loadingWindow, setLoadingWindow] = useState(true);
@@ -30,20 +33,20 @@ const DeliverableSubmissionForm = ({
 
   const isGroupMember = useMemo(() => {
     if (!members || !Array.isArray(members)) return false;
-    return members.some((member) => member.userId === userId || member.user_id === userId);
+    return members.some((m) => m.userId === userId || m.user_id === userId);
   }, [members, userId]);
 
   const isPublished = committeeStatus === 'published' || committeeStatus === 'Published';
   const canSubmit = isLeader && isPublished;
 
   useEffect(() => {
-    const fetchWindowAndSubmission = async () => {
+    const fetchWindowAndSubmissions = async () => {
       setLoadingWindow(true);
       try {
         const schedule = await getScheduleWindow('deliverable_submission');
         setWindowOpen(Boolean(schedule.open));
         setWindowInfo(schedule.window || null);
-      } catch (error) {
+      } catch {
         setWindowOpen(false);
         setWindowInfo(null);
       }
@@ -53,9 +56,7 @@ const DeliverableSubmissionForm = ({
         const deliverables = data.deliverables || data.items || data.data || [];
         const byType = {};
         if (Array.isArray(deliverables)) {
-          deliverables.forEach((d) => {
-            byType[d.type] = d;
-          });
+          deliverables.forEach((d) => { byType[d.type] = d; });
         }
         setSubmittedDeliverables(byType);
       } catch {
@@ -65,14 +66,14 @@ const DeliverableSubmissionForm = ({
       }
     };
 
-    fetchWindowAndSubmission();
+    fetchWindowAndSubmissions();
   }, [groupId]);
 
   const resetForm = () => {
     setFile(null);
-    setLink('');
+    setDescription('');
     setSelectedType('proposal');
-    setStorageMode('file');
+    setSprintId(sprintIdProp || '');
     setErrorMsg('');
     setSuccessMsg('');
   };
@@ -82,59 +83,50 @@ const DeliverableSubmissionForm = ({
     setErrorMsg('');
     setSuccessMsg('');
 
-    if (!selectedType) {
-      setErrorMsg('Please select a deliverable type.');
+    if (!file) {
+      setErrorMsg('Please select a file to upload.');
       return;
     }
 
-    if (storageMode === 'file' && !file) {
-      setErrorMsg('Please select a deliverable file.');
+    if (!sprintId) {
+      setErrorMsg('No sprint ID provided. Contact your coordinator.');
       return;
-    }
-
-    if (storageMode === 'link') {
-      const trimmedLink = link.trim();
-      if (!trimmedLink) {
-        setErrorMsg('Please enter a valid URL.');
-        return;
-      }
-      try {
-        new URL(trimmedLink);
-      } catch {
-        setErrorMsg('Please enter a valid URL.');
-        return;
-      }
     }
 
     setLoadingSubmit(true);
 
     try {
-      const formData = new FormData();
-      formData.append('type', selectedType);
-      formData.append('storageRef', storageMode === 'link' ? link.trim() : '');
-      if (storageMode === 'file') {
-        formData.append('file', file);
-      }
-      const result = await submitDeliverable(groupId, formData);
+      const result = await submitDeliverableStaging(groupId, {
+        deliverableType: selectedType,
+        sprintId,
+        file,
+        description: description.trim() || undefined,
+      });
+
       setSubmittedDeliverables((prev) => ({
         ...prev,
-        [result.type]: result,
+        [selectedType]: result,
       }));
       resetForm();
-      setSuccessMsg('Deliverable submitted successfully.');
-      if (onSuccess) onSuccess();
+      setSuccessMsg(`Deliverable staged successfully. ID: ${result.stagingId}`);
+      if (onSuccess) onSuccess(result);
     } catch (error) {
-      const status = error.response?.status;
-      const code = error.response?.data?.code;
+      const status = error.response?.status ?? error.status;
+      const code = error.response?.data?.code ?? error.code;
+      const message = error.response?.data?.message ?? error.message;
 
-      if (status === 403) {
-        setErrorMsg('Only the team leader can submit deliverables.');
-      } else if (status === 422) {
-        setErrorMsg('The submission schedule window is closed.');
-      } else if (status === 400 || code === 'INVALID_DELIVERABLE') {
-        setErrorMsg(error.response?.data?.message || 'Invalid deliverable submission.');
+      if (status === 403 || code === 'FORBIDDEN' || code === 'GROUP_ID_MISMATCH') {
+        setErrorMsg('Group validation failed. Make sure your group is active and has a committee assigned.');
+      } else if (status === 409) {
+        setErrorMsg(message || 'Group is not eligible to submit deliverables.');
+      } else if (status === 413) {
+        setErrorMsg('File is too large. Maximum size is 1 GB.');
+      } else if (status === 415) {
+        setErrorMsg('Unsupported file type. Please upload a PDF, DOCX, Markdown, or ZIP file.');
+      } else if (status === 429) {
+        setErrorMsg('Too many submissions. Please wait a few minutes before trying again.');
       } else {
-        setErrorMsg(error.response?.data?.message || 'Could not submit your deliverable.');
+        setErrorMsg(message || 'Could not submit your deliverable. Please try again.');
       }
     } finally {
       setLoadingSubmit(false);
@@ -155,21 +147,23 @@ const DeliverableSubmissionForm = ({
             </div>
             <div className="deliverable-card-content">
               <div className="info-row">
-                <span className="info-label">Deliverable ID</span>
-                <span className="info-value">{data.deliverableId || data.id || 'N/A'}</span>
+                <span className="info-label">Staging ID</span>
+                <span className="info-value">{data.stagingId || data.deliverableId || data.id || 'N/A'}</span>
               </div>
               <div className="info-row">
                 <span className="info-label">Submitted At</span>
                 <span className="info-value">
-                  {data.submittedAt
-                    ? new Date(data.submittedAt).toLocaleString()
-                    : 'N/A'}
+                  {data.submittedAt ? new Date(data.submittedAt).toLocaleString() : 'N/A'}
                 </span>
               </div>
-              <div className="info-row">
-                <span className="info-label">Storage Reference</span>
-                <span className="info-value">{data.storageRef || data.url || 'N/A'}</span>
-              </div>
+              {data.fileHash && (
+                <div className="info-row">
+                  <span className="info-label">File Hash (SHA-256)</span>
+                  <span className="info-value" style={{ wordBreak: 'break-all', fontSize: '0.8em' }}>
+                    {data.fileHash}
+                  </span>
+                </div>
+              )}
             </div>
             {isLeader && windowOpen && (
               <button
@@ -196,14 +190,13 @@ const DeliverableSubmissionForm = ({
         <div className="deliverable-locked-card">
           <p>
             Deliverable submission is locked until the committee assignment is published.
-            Once the committee is published, the team leader can submit a proposal, statement of work,
-            or demonstration.
+            Once published, the team leader can submit deliverables.
           </p>
         </div>
       )}
 
       {isPublished && loadingWindow && (
-        <div className="deliverable-status-message">Checking submission window...</div>
+        <div className="deliverable-status-message">Checking submission window…</div>
       )}
 
       {isPublished && !loadingWindow && (
@@ -212,9 +205,7 @@ const DeliverableSubmissionForm = ({
 
           {!isGroupMember && (
             <div className="deliverable-locked-card">
-              <p>
-                You can view deliverable status in read-only mode. Only the team leader can submit deliverables.
-              </p>
+              <p>You can view deliverable status in read-only mode. Only the team leader can submit.</p>
             </div>
           )}
 
@@ -222,10 +213,11 @@ const DeliverableSubmissionForm = ({
             <>
               {!windowOpen && (
                 <div className="deliverable-closed-banner">
-                  <strong>Submission window closed:</strong> The deliverable submission period is currently unavailable.
+                  <strong>Submission window closed.</strong>
                   {windowInfo?.endsAt && ` Next window: ${new Date(windowInfo.endsAt).toLocaleString()}`}
                 </div>
               )}
+
               <form className="deliverable-form" onSubmit={handleSubmit}>
                 <div className="deliverable-form-row">
                   <label htmlFor="deliverable-type">Deliverable Type</label>
@@ -236,66 +228,55 @@ const DeliverableSubmissionForm = ({
                     onChange={(e) => setSelectedType(e.target.value)}
                     disabled={!windowOpen || loadingSubmit}
                   >
-                    {DELIVERABLE_TYPES.map((option) => {
-                      const isSubmitted = submittedDeliverables[option.value];
-                      return (
-                        <option key={option.value} value={option.value}>
-                          {option.label}{isSubmitted ? ' (Re-submit)' : ''}
-                        </option>
-                      );
-                    })}
+                    {DELIVERABLE_TYPES.map(({ value, label }) => (
+                      <option key={value} value={value}>
+                        {label}{submittedDeliverables[value] ? ' (Re-submit)' : ''}
+                      </option>
+                    ))}
                   </select>
                 </div>
 
-                <div className="deliverable-form-row deliverable-mode-toggle">
-                  <button
-                    type="button"
-                    className={`toggle-button${storageMode === 'file' ? ' active' : ''}`}
-                    onClick={() => setStorageMode('file')}
-                    disabled={loadingSubmit}
-                  >
-                    Upload File
-                  </button>
-                  <button
-                    type="button"
-                    className={`toggle-button${storageMode === 'link' ? ' active' : ''}`}
-                    onClick={() => setStorageMode('link')}
-                    disabled={loadingSubmit}
-                  >
-                    Submit Link
-                  </button>
+                <div className="deliverable-form-row">
+                  <label htmlFor="deliverable-sprint">Sprint ID</label>
+                  <input
+                    id="deliverable-sprint"
+                    type="text"
+                    className="add-member-input"
+                    placeholder="e.g. sprint_1"
+                    value={sprintId}
+                    onChange={(e) => setSprintId(e.target.value)}
+                    disabled={!windowOpen || loadingSubmit}
+                  />
                 </div>
 
-                {storageMode === 'file' ? (
-                  <div className="deliverable-form-row">
-                    <label htmlFor="deliverable-file">File (PDF, Word, Markdown, ZIP)</label>
-                    <input
-                      id="deliverable-file"
-                      type="file"
-                      accept=".pdf,.docx,.md,.zip"
-                      onChange={(e) => setFile(e.target.files?.[0] || null)}
-                      disabled={!windowOpen || loadingSubmit}
-                    />
-                  </div>
-                ) : (
-                  <div className="deliverable-form-row">
-                    <label htmlFor="deliverable-link">Submission URL</label>
-                    <input
-                      id="deliverable-link"
-                      type="url"
-                      className="add-member-input"
-                      placeholder="https://example.com/your-deliverable"
-                      value={link}
-                      onChange={(e) => setLink(e.target.value)}
-                      disabled={!windowOpen || loadingSubmit}
-                    />
-                  </div>
-                )}
+                <div className="deliverable-form-row">
+                  <label htmlFor="deliverable-file">File (PDF, DOCX, Markdown, ZIP)</label>
+                  <input
+                    id="deliverable-file"
+                    type="file"
+                    accept=".pdf,.docx,.md,.zip"
+                    onChange={(e) => setFile(e.target.files?.[0] || null)}
+                    disabled={!windowOpen || loadingSubmit}
+                  />
+                </div>
+
+                <div className="deliverable-form-row">
+                  <label htmlFor="deliverable-description">Description (optional)</label>
+                  <input
+                    id="deliverable-description"
+                    type="text"
+                    className="add-member-input"
+                    placeholder="Brief description of this submission"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    disabled={!windowOpen || loadingSubmit}
+                  />
+                </div>
 
                 <button
                   type="submit"
                   className="add-member-btn"
-                  disabled={!windowOpen || loadingSubmit}
+                  disabled={!windowOpen || loadingSubmit || !canSubmit}
                 >
                   {loadingSubmit ? 'Submitting…' : 'Submit Deliverable'}
                 </button>

--- a/frontend/src/components/GroupCreationPage.js
+++ b/frontend/src/components/GroupCreationPage.js
@@ -68,14 +68,20 @@ const GroupCreationPage = () => {
       navigate(`/groups/${result.groupId}`);
     } catch (err) {
       const data = err.response?.data;
+      // err.code is set by the apiClient 403 interceptor (which strips err.response)
+      const code = data?.code || err.code;
+      const message = data?.message || err.message;
+
       if (data?.code === 'GROUP_NAME_TAKEN') {
         setFieldErrors({ groupName: 'A group with this name already exists. Please choose a different name.' });
-      } else if (data?.code === 'OUTSIDE_SCHEDULE_WINDOW') {
+      } else if (code === 'OUTSIDE_SCHEDULE_WINDOW') {
         setSubmitError('Group creation is currently closed. Please check the coordinator-defined schedule.');
-      } else if (data?.code === 'STUDENT_ALREADY_IN_GROUP' || data?.code === 'STUDENT_ALREADY_LEADER') {
+      } else if (code === 'STUDENT_ALREADY_IN_GROUP' || code === 'STUDENT_ALREADY_LEADER') {
         setSubmitError('You already belong to an active group and cannot create another.');
+      } else if (code === 'FORBIDDEN') {
+        setSubmitError(message || 'You do not have permission to create a group.');
       } else {
-        setSubmitError(data?.message || 'An unexpected error occurred. Please try again.');
+        setSubmitError(message || 'An unexpected error occurred. Please try again.');
       }
     } finally {
       setLoading(false);

--- a/frontend/src/components/GroupDashboard.js
+++ b/frontend/src/components/GroupDashboard.js
@@ -272,7 +272,7 @@ const GroupDashboard = () => {
             isLeader={isLeader}
             userId={user?.userId}
             members={members}
-            committeeStatus={groupData?.committee?.status || groupData?.committeeStatus}
+            committeeStatus={committeeStatus?.committee?.status}
             onSuccess={() => fetchGroupDashboard(groupId)}
           />
 


### PR DESCRIPTION
### Summary

- Adds `POST /api/v1/deliverables/submit` endpoint that accepts a multipart file upload, validates the group via a short-lived `Authorization-Validation` JWT from Process 5.1, and creates a temporary staging record (TTL: 1 hour) before returning a `stagingId` for downstream pipeline steps
- Creates the `DeliverableStaging` Mongoose model with SHA-256 file hash, MIME type, file size, expiry, and a MongoDB TTL index for automatic cleanup of stalled pipeline records
- Mounts all deliverable routes under `/api/v1/deliverables` (consistent with rest of API) and wires the frontend service and submission form to use the new two-step flow (validate-group → submit)

---

### Changes

**Backend**
- `backend/src/models/DeliverableStaging.js` — new model with required fields, unique `stagingId` index, and TTL index on `expiresAt`
- `backend/src/controllers/deliverableController.js` — adds `submitDeliverable`: validates `Authorization-Validation` header JWT, enforces 3-per-10-min rate limit per group, computes SHA-256 hash, creates staging record, returns 202
- `backend/src/routes/deliverables.js` — adds `POST /submit` route; moves mount point to `/api/v1/deliverables`
- `backend/src/models/AuditLog.js` — adds `DELIVERABLE_STAGING_CREATED` action to enum
- `backend/tests/submit-deliverable.smoke.test.js` — 16 smoke tests covering all acceptance criteria (auth, role, missing file, body validation, enum validation, missing/expired/mismatched token, rate limit, happy path with DB assertions)

**Frontend**
- `frontend/src/api/deliverableService.js` — replaces TODO stub with real `getGroupCommitteeStatus` call to `/groups/:groupId/committee-status`; adds `submitDeliverableStaging` which chains validate-group → submit transparently
- `frontend/src/components/DeliverableSubmissionForm.js` — updated to use new staging flow, correct enum values, sprint ID and description input fields
- `frontend/src/components/GroupDashboard.js` — passes `committeeStatus?.committee?.status` correctly from store
- `frontend/src/components/CommitteeStatusCard.js` — guards `advisorIds`/`juryIds` access with optional chaining
- `frontend/src/components/GroupCreationPage.js` — fixes error handler to read `err.code` from apiClient 403 interceptor (was showing generic fallback for `OUTSIDE_SCHEDULE_WINDOW`)

**Dev tooling**
- `backend/scripts/seed-test-student.js` — seeds a test student + active group + published committee + open schedule windows for manual end-to-end testing
