### PR TITLE
feat: implement Process 5.3 deliverable format and size validation  -…

### DIFF
--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -8,6 +8,7 @@ const Committee = require('../models/Committee');
 const AuditLog = require('../models/AuditLog');
 const DeliverableStaging = require('../models/DeliverableStaging');
 const { hashData } = require('../utils/fileHash');
+const { runFormatValidation } = require('../services/deliverableValidationService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 
@@ -299,4 +300,20 @@ const submitDeliverable = async (req, res) => {
   });
 };
 
-module.exports = { validateGroup, submitDeliverable };
+/**
+ * POST /api/deliverables/:stagingId/validate-format
+ *
+ * Process 5.3 — Validate the staged file's format and size.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const validateFormatHandler = async (req, res) => {
+  const { stagingId } = req.params;
+  const actorId = req.user?.userId;
+
+  const { status, body } = await runFormatValidation(stagingId, actorId);
+  return res.status(status).json(body);
+};
+
+module.exports = { validateGroup, submitDeliverable, validateFormatHandler };

--- a/backend/src/models/DeliverableStaging.js
+++ b/backend/src/models/DeliverableStaging.js
@@ -59,7 +59,7 @@ const deliverableStagingSchema = new mongoose.Schema(
     },
     status: {
       type: String,
-      enum: ['staging'],
+      enum: ['staging', 'format_validated', 'validation_failed'],
       default: 'staging',
     },
     expiresAt: {

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -5,7 +5,7 @@ const router = express.Router();
 
 const { deliverableAuthMiddleware, roleMiddleware } = require('../middleware/auth');
 const { uploadSingle } = require('../middleware/upload');
-const { validateGroup, submitDeliverable } = require('../controllers/deliverableController');
+const { validateGroup, submitDeliverable, validateFormatHandler } = require('../controllers/deliverableController');
 
 // All deliverable routes require a valid JWT; req.user = { userId, role, groupId }
 router.use(deliverableAuthMiddleware);
@@ -29,6 +29,16 @@ router.post(
   roleMiddleware(['student']),
   uploadSingle('file'),
   submitDeliverable
+);
+
+/**
+ * POST /api/deliverables/:stagingId/validate-format
+ * Process 5.3 — Validate staged file format and size.
+ */
+router.post(
+  '/:stagingId/validate-format',
+  roleMiddleware(['student']),
+  validateFormatHandler
 );
 
 /**

--- a/backend/src/services/deliverableValidationService.js
+++ b/backend/src/services/deliverableValidationService.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const DeliverableStaging = require('../models/DeliverableStaging');
+const User = require('../models/User');
+const AuditLog = require('../models/AuditLog');
+const { validateFormat, validateFileSize } = require('../utils/fileValidator');
+
+/**
+ * Fire-and-forget audit log. Swallows errors so logging never blocks response.
+ */
+const writeAudit = (action, actorId, groupId, payload) => {
+  AuditLog.create({ action, actorId, groupId, payload }).catch((err) => {
+    console.error(`[deliverableValidationService] Audit log failed (${action}):`, err.message);
+  });
+};
+
+/**
+ * Async notification to student on validation failure (flow f13).
+ * Logs to console in dev mode; does not block the response.
+ *
+ * @param {string} submittedBy - userId of the student
+ * @param {string} stagingId
+ * @param {string} reason - human-readable failure reason
+ */
+const notifyValidationFailure = async (submittedBy, stagingId, reason) => {
+  try {
+    const user = await User.findOne({ userId: submittedBy }).select('email firstName').lean();
+    if (!user) return;
+
+    // In production this would call an email/push service.
+    // Dev mode logs to console — same pattern used by emailService.js.
+    console.log(
+      `[NOTIFICATION f13] Deliverable validation failed\n` +
+      `  To     : ${user.email}\n` +
+      `  staging: ${stagingId}\n` +
+      `  Reason : ${reason}`
+    );
+  } catch (err) {
+    console.error('[deliverableValidationService] f13 notification error:', err.message);
+  }
+};
+
+/**
+ * Process 5.3 — Validate staged file format and size.
+ *
+ * Steps:
+ *  1. Look up staging record; return 404 if missing or expired.
+ *  2. Run validateFormat() and validateFileSize().
+ *  3. On any failure: set status = 'validation_failed', return failure payload,
+ *     trigger async f13 notification.
+ *  4. On success: set status = 'format_validated', return success payload.
+ *
+ * @param {string} stagingId
+ * @param {string} actorId - userId performing the request
+ * @returns {{ status: number, body: object }}
+ */
+const runFormatValidation = async (stagingId, actorId) => {
+  // 1. Look up staging record
+  let staging;
+  try {
+    staging = await DeliverableStaging.findOne({ stagingId });
+  } catch (err) {
+    console.error('[deliverableValidationService] DB lookup error:', err);
+    return { status: 500, body: { code: 'INTERNAL_ERROR', message: 'Database query failed' } };
+  }
+
+  if (!staging) {
+    return {
+      status: 404,
+      body: { code: 'STAGING_NOT_FOUND', message: 'Staging record not found' },
+    };
+  }
+
+  if (staging.expiresAt < new Date()) {
+    return {
+      status: 404,
+      body: { code: 'STAGING_EXPIRED', message: 'Staging record has expired' },
+    };
+  }
+
+  // 2. Run format and size checks
+  const formatResult = validateFormat(
+    staging.tempFilePath,
+    staging.mimeType,
+    staging.deliverableType
+  );
+
+  const sizeResult = validateFileSize(staging.fileSize, staging.deliverableType);
+
+  const allValid = formatResult.valid && sizeResult.withinLimit;
+
+  if (!allValid) {
+    // 3. Failure path
+    const errors = [];
+    if (!formatResult.valid) errors.push(formatResult.error);
+    if (!sizeResult.withinLimit) {
+      errors.push(
+        `File size ${sizeResult.actualMb} MB exceeds the ${sizeResult.maxAllowedMb} MB limit ` +
+        `for deliverable type '${staging.deliverableType}'`
+      );
+    }
+
+    try {
+      await DeliverableStaging.updateOne({ stagingId }, { $set: { status: 'validation_failed' } });
+    } catch (err) {
+      console.error('[deliverableValidationService] status update error (failed):', err.message);
+    }
+
+    writeAudit('DELIVERABLE_FORMAT_VALIDATION_FAILED', actorId, staging.groupId, {
+      stagingId,
+      errors,
+    });
+
+    // Async f13 notification — does not block response
+    notifyValidationFailure(staging.submittedBy, stagingId, errors.join('; '));
+
+    return {
+      status: 400,
+      body: {
+        code: 'VALIDATION_FAILED',
+        stagingId,
+        errors,
+        checks: {
+          formatValid: formatResult.valid,
+          sizeValid: sizeResult.withinLimit,
+          virusScanPassed: null,
+        },
+      },
+    };
+  }
+
+  // 4. Success path
+  try {
+    await DeliverableStaging.updateOne({ stagingId }, { $set: { status: 'format_validated' } });
+  } catch (err) {
+    console.error('[deliverableValidationService] status update error (success):', err.message);
+    return { status: 500, body: { code: 'INTERNAL_ERROR', message: 'Failed to update staging record' } };
+  }
+
+  writeAudit('DELIVERABLE_FORMAT_VALIDATION_SUCCESS', actorId, staging.groupId, { stagingId });
+
+  return {
+    status: 200,
+    body: {
+      stagingId,
+      valid: true,
+      format: formatResult.format,
+      checks: {
+        formatValid: true,
+        sizeValid: true,
+        virusScanPassed: null,
+      },
+      nextStep: 'deadline_validation',
+    },
+  };
+};
+
+module.exports = { runFormatValidation };

--- a/backend/src/utils/fileValidator.js
+++ b/backend/src/utils/fileValidator.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const fs = require('fs');
+
+/**
+ * Magic byte signatures for accepted file types.
+ * Read from the first 4 bytes of the file to detect real format
+ * regardless of the extension or MIME type reported by the client.
+ */
+const MAGIC_BYTES = {
+  pdf:  [0x25, 0x50, 0x44, 0x46], // %PDF
+  zip:  [0x50, 0x4b, 0x03, 0x04], // PK\x03\x04  (also covers .docx)
+};
+
+/** Max file sizes in bytes per deliverable type */
+const SIZE_LIMITS_MB = {
+  proposal:         50,
+  statement_of_work: 50,
+  demo:             500,
+  interim_report:   100,
+  final_report:     500,
+};
+
+/**
+ * Read the first N bytes of a file from disk.
+ * Returns a Buffer, or null if the file cannot be read.
+ *
+ * @param {string} filePath
+ * @param {number} byteCount
+ * @returns {Buffer|null}
+ */
+const readMagicBytes = (filePath, byteCount = 4) => {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, 'r');
+    const buf = Buffer.alloc(byteCount);
+    fs.readSync(fd, buf, 0, byteCount, 0);
+    return buf;
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+};
+
+/**
+ * Check whether a Buffer starts with an expected byte sequence.
+ *
+ * @param {Buffer} buf
+ * @param {number[]} signature
+ * @returns {boolean}
+ */
+const startsWith = (buf, signature) =>
+  buf && signature.every((byte, i) => buf[i] === byte);
+
+/**
+ * Derive the canonical format name from file path and MIME type,
+ * then verify the file's actual magic bytes match.
+ *
+ * Accepted: .pdf, .docx, .md, .zip
+ *
+ * @param {string} filePath   - Absolute path to the file on disk
+ * @param {string} mimeType   - MIME type reported by multer / client
+ * @param {string} _deliverableType - Reserved for future per-type rules
+ * @returns {{ valid: boolean, format?: string, error?: string }}
+ */
+const validateFormat = (filePath, mimeType, _deliverableType) => {
+  const ext = (filePath.split('.').pop() || '').toLowerCase();
+
+  // ── Markdown ──────────────────────────────────────────────────────────────
+  // No reliable magic bytes; accept by extension + text/plain MIME.
+  if (ext === 'md') {
+    const validMime = mimeType === 'text/plain' || mimeType === 'text/markdown';
+    if (!validMime) {
+      return {
+        valid: false,
+        error: `Markdown file must have MIME type text/plain or text/markdown, got '${mimeType}'`,
+      };
+    }
+    return { valid: true, format: 'md' };
+  }
+
+  // ── PDF ───────────────────────────────────────────────────────────────────
+  if (ext === 'pdf') {
+    const buf = readMagicBytes(filePath);
+    if (!buf) {
+      return { valid: false, error: 'Could not read file from disk' };
+    }
+    if (!startsWith(buf, MAGIC_BYTES.pdf)) {
+      return { valid: false, error: 'File content does not match PDF format (bad magic bytes)' };
+    }
+    return { valid: true, format: 'pdf' };
+  }
+
+  // ── DOCX ──────────────────────────────────────────────────────────────────
+  // DOCX is a ZIP archive; magic bytes are identical to .zip.
+  if (ext === 'docx') {
+    const buf = readMagicBytes(filePath);
+    if (!buf) {
+      return { valid: false, error: 'Could not read file from disk' };
+    }
+    if (!startsWith(buf, MAGIC_BYTES.zip)) {
+      return { valid: false, error: 'File content does not match DOCX format (bad magic bytes)' };
+    }
+    return { valid: true, format: 'docx' };
+  }
+
+  // ── ZIP ───────────────────────────────────────────────────────────────────
+  if (ext === 'zip') {
+    const buf = readMagicBytes(filePath);
+    if (!buf) {
+      return { valid: false, error: 'Could not read file from disk' };
+    }
+    if (!startsWith(buf, MAGIC_BYTES.zip)) {
+      return { valid: false, error: 'File content does not match ZIP format (bad magic bytes)' };
+    }
+    return { valid: true, format: 'zip' };
+  }
+
+  // ── Unknown extension ─────────────────────────────────────────────────────
+  return {
+    valid: false,
+    error: `Unsupported file extension '.${ext}'. Accepted: .pdf, .docx, .md, .zip`,
+  };
+};
+
+/**
+ * Check whether a file size is within the allowed limit for the given
+ * deliverable type.
+ *
+ * @param {number} fileSizeBytes
+ * @param {string} deliverableType
+ * @returns {{ withinLimit: boolean, maxAllowedMb: number, actualMb: number }}
+ */
+const validateFileSize = (fileSizeBytes, deliverableType) => {
+  const maxMb = SIZE_LIMITS_MB[deliverableType] ?? 50;
+  const maxBytes = maxMb * 1024 * 1024;
+  const actualMb = parseFloat((fileSizeBytes / (1024 * 1024)).toFixed(2));
+
+  return {
+    withinLimit: fileSizeBytes <= maxBytes,
+    maxAllowedMb: maxMb,
+    actualMb,
+  };
+};
+
+module.exports = { validateFormat, validateFileSize };


### PR DESCRIPTION
- Add POST /api/deliverables/:stagingId/validate-format endpoint (student role)
- Validate file format via magic bytes: PDF (25504446), DOCX/ZIP (504B0304), Markdown (MIME check)
- Enforce per-type size limits: proposal/sow ≤ 50MB, interim ≤ 100MB, demo/final ≤ 500MB
- On failure: set staging status to validation_failed, return 400, trigger async f13 notification
- On success: set staging status to format_validated, return 200 with format and nextStep
- Expand DeliverableStaging status enum with format_validated and validation_failed