### PR TITLE
feat: add review routes and comments functionality with authorization middleware

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -13,6 +13,7 @@ const committeeRoutes = require('./routes/committees');       // From main
 const scheduleWindowRoutes = require('./routes/scheduleWindow');
 const auditLogRoutes = require('./routes/auditLogs');
 const deliverableRoutes = require('./routes/deliverables');
+const reviewRoutes = require('./routes/reviews');
 const { errorHandler } = require('./middleware/auth');
 
 const app = express();
@@ -64,6 +65,7 @@ app.use('/api/v1/committees', committeeRoutes);           // From main
 app.use('/api/v1/schedule-window', scheduleWindowRoutes);
 app.use('/api/v1/audit-logs', auditLogRoutes);
 app.use('/api/v1/deliverables', deliverableRoutes);
+app.use('/api/v1/reviews', reviewRoutes);
 
 // 404 Handler
 app.use((req, res) => {

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -69,4 +69,30 @@ router.delete(
   }
 );
 
+/**
+ * POST /api/v1/deliverables/:deliverableId/comments
+ * Process 6 — Initiate a review comment on a deliverable.
+ * Accessible by committee_member and coordinator. Students may NOT initiate comments.
+ */
+router.post(
+  '/:deliverableId/comments',
+  roleMiddleware(['committee_member', 'coordinator']),
+  (_req, res) => {
+    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Comment endpoint not yet implemented' });
+  }
+);
+
+/**
+ * POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply
+ * Process 6 — Reply to an existing review comment.
+ * Accessible by committee_member, coordinator, and student.
+ */
+router.post(
+  '/:deliverableId/comments/:commentId/reply',
+  roleMiddleware(['committee_member', 'coordinator', 'student']),
+  (_req, res) => {
+    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Comment reply endpoint not yet implemented' });
+  }
+);
+
 module.exports = router;

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+
+const { deliverableAuthMiddleware, roleMiddleware } = require('../middleware/auth');
+
+// All review routes require a valid JWT; req.user = { userId, role, groupId }
+router.use(deliverableAuthMiddleware);
+
+/**
+ * POST /api/v1/reviews/assign
+ * Process 6 — Assign a reviewer to a deliverable submission.
+ * Restricted to coordinator role only.
+ */
+router.post(
+  '/assign',
+  roleMiddleware(['coordinator']),
+  (_req, res) => {
+    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Assign review endpoint not yet implemented' });
+  }
+);
+
+/**
+ * GET /api/v1/reviews/status
+ * Process 6 — Get current review status for deliverable submissions.
+ * Restricted to coordinator role only.
+ */
+router.get(
+  '/status',
+  roleMiddleware(['coordinator']),
+  (_req, res) => {
+    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Review status endpoint not yet implemented' });
+  }
+);
+
+module.exports = router;

--- a/backend/tests/reviews-auth-middleware.smoke.test.js
+++ b/backend/tests/reviews-auth-middleware.smoke.test.js
@@ -1,0 +1,372 @@
+/**
+ * Smoke tests — Process 6 auth middleware for review and deliverable comment routes
+ *
+ * Covers:
+ *   /api/v1/reviews/assign        → JWT required; coordinator only (403 for others)
+ *   /api/v1/reviews/status        → JWT required; coordinator only (403 for others)
+ *   /api/v1/deliverables/:id/comments
+ *     → JWT required; committee_member + coordinator allowed; student 403
+ *   /api/v1/deliverables/:id/comments/:commentId/reply
+ *     → JWT required; committee_member + coordinator + student allowed
+ *   req.user shape                → { userId, role, groupId } available in controllers
+ *
+ * Run:
+ *   npm test -- reviews-auth-middleware.smoke.test.js
+ */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'reviews-smoke-test-secret';
+
+const mongoose = require('mongoose');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { generateAccessToken } = require('../src/utils/jwt');
+const Group = require('../src/models/Group');
+
+let mongod;
+let app;
+
+const unique = (prefix) =>
+  `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+
+function makeToken(userId, role) {
+  return generateAccessToken(userId, role);
+}
+
+/** Seed a Group with one accepted student member and return { groupId, studentId }. */
+async function seedGroupWithStudent() {
+  const studentId = unique('stu');
+  const groupId = unique('grp');
+  await Group.create({
+    groupId,
+    groupName: unique('Group'),
+    leaderId: studentId,
+    status: 'active',
+    members: [{ userId: studentId, role: 'leader', status: 'accepted' }],
+  });
+  return { groupId, studentId };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  app = require('../src/index');
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+afterEach(async () => {
+  const { collections } = mongoose.connection;
+  await Promise.all(Object.values(collections).map((c) => c.deleteMany({})));
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/reviews/assign
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/reviews/assign', () => {
+  const ENDPOINT = '/api/v1/reviews/assign';
+
+  it('401 — no Authorization header', async () => {
+    const res = await request(app).post(ENDPOINT).send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('401 — malformed / invalid token', async () => {
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', 'Bearer not.a.real.token')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('403 — student cannot assign a review', async () => {
+    const { studentId } = await seedGroupWithStudent();
+    const token = makeToken(studentId, 'student');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — committee_member cannot assign a review', async () => {
+    const token = makeToken(unique('cm'), 'committee_member');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — advisor cannot assign a review', async () => {
+    const token = makeToken(unique('adv'), 'advisor');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it('501 — coordinator reaches stub (auth + role passed)', async () => {
+    const token = makeToken(unique('coord'), 'coordinator');
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/reviews/status
+// ---------------------------------------------------------------------------
+describe('GET /api/v1/reviews/status', () => {
+  const ENDPOINT = '/api/v1/reviews/status';
+
+  it('401 — no Authorization header', async () => {
+    const res = await request(app).get(ENDPOINT);
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('401 — malformed / invalid token', async () => {
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', 'Bearer not.a.real.token');
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('403 — student cannot view review status', async () => {
+    const { studentId } = await seedGroupWithStudent();
+    const token = makeToken(studentId, 'student');
+
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — committee_member cannot view review status', async () => {
+    const token = makeToken(unique('cm'), 'committee_member');
+
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('501 — coordinator reaches stub (auth + role passed)', async () => {
+    const token = makeToken(unique('coord'), 'coordinator');
+
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/deliverables/:deliverableId/comments  (initiate comment)
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/deliverables/:deliverableId/comments', () => {
+  const endpoint = (id) => `/api/v1/deliverables/${id}/comments`;
+
+  it('401 — no Authorization header', async () => {
+    const res = await request(app).post(endpoint('del-1')).send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('401 — malformed token', async () => {
+    const res = await request(app)
+      .post(endpoint('del-1'))
+      .set('Authorization', 'Bearer bad.token.here')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('403 — student cannot initiate a comment', async () => {
+    const { studentId } = await seedGroupWithStudent();
+    const token = makeToken(studentId, 'student');
+
+    const res = await request(app)
+      .post(endpoint('del-1'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — advisor cannot initiate a comment', async () => {
+    const token = makeToken(unique('adv'), 'advisor');
+
+    const res = await request(app)
+      .post(endpoint('del-1'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it('501 — committee_member reaches stub (auth + role passed)', async () => {
+    const token = makeToken(unique('cm'), 'committee_member');
+
+    const res = await request(app)
+      .post(endpoint('del-abc'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+
+  it('501 — coordinator reaches stub (auth + role passed)', async () => {
+    const token = makeToken(unique('coord'), 'coordinator');
+
+    const res = await request(app)
+      .post(endpoint('del-abc'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply  (reply)
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply', () => {
+  const endpoint = (delId, commentId) =>
+    `/api/v1/deliverables/${delId}/comments/${commentId}/reply`;
+
+  it('401 — no Authorization header', async () => {
+    const res = await request(app).post(endpoint('del-1', 'cmt-1')).send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('401 — malformed token', async () => {
+    const res = await request(app)
+      .post(endpoint('del-1', 'cmt-1'))
+      .set('Authorization', 'Bearer bad.token.here')
+      .send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('403 — advisor cannot reply to a comment', async () => {
+    const token = makeToken(unique('adv'), 'advisor');
+
+    const res = await request(app)
+      .post(endpoint('del-1', 'cmt-1'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(403);
+  });
+
+  it('501 — student reaches stub (students may reply)', async () => {
+    const { studentId } = await seedGroupWithStudent();
+    const token = makeToken(studentId, 'student');
+
+    const res = await request(app)
+      .post(endpoint('del-abc', 'cmt-abc'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+
+  it('501 — committee_member reaches stub', async () => {
+    const token = makeToken(unique('cm'), 'committee_member');
+
+    const res = await request(app)
+      .post(endpoint('del-abc', 'cmt-abc'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+
+  it('501 — coordinator reaches stub', async () => {
+    const token = makeToken(unique('coord'), 'coordinator');
+
+    const res = await request(app)
+      .post(endpoint('del-abc', 'cmt-abc'))
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// req.user shape — { userId, role, groupId } is populated on all review routes
+// ---------------------------------------------------------------------------
+describe('req.user shape on review routes', () => {
+  it('coordinator req.user has userId and role set (groupId null when not in group)', async () => {
+    // We verify indirectly: a valid coordinator token reaches the 501 stub,
+    // confirming deliverableAuthMiddleware ran and set req.user without error.
+    const coordId = unique('coord');
+    const token = makeToken(coordId, 'coordinator');
+
+    const res = await request(app)
+      .post('/api/v1/reviews/assign')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    // 501 means auth passed and req.user was set correctly
+    expect(res.status).toBe(501);
+  });
+
+  it('student req.user.groupId is populated when student belongs to a group', async () => {
+    // Student can reach reply endpoint — confirms groupId lookup ran successfully
+    const { studentId } = await seedGroupWithStudent();
+    const token = makeToken(studentId, 'student');
+
+    const res = await request(app)
+      .post('/api/v1/deliverables/del-x/comments/cmt-x/reply')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(501);
+  });
+});


### PR DESCRIPTION
## Summary

- Created `backend/src/routes/reviews.js` and mounted it at `/api/v1/reviews`. All routes are protected by `deliverableAuthMiddleware`, which validates the Bearer JWT and enriches `req.user = { userId, role, groupId }`. `POST /assign` and `GET /status` are restricted to the` coordinator` role; any other role receives `403`.

- Added two comment sub-routes to `backend/src/routes/deliverables.js`: `POST /:deliverableId/comments` (accessible by `committee_member` and `coordinator`) and `POST /:deliverableId/comments/:commentId/reply` (accessible by `committee_member`, `coordinator`, and `student`). Both inherit the `deliverableAuthMiddleware` already applied router-wide. Students are blocked from initiating comments but may reply.

- Both new route handlers return `501 NOT_IMPLEMENTED` stubs, ready for controller wiring in the next issue.