### PR TITLE
feat(deliverables): implement GET list, GET detail

### DIFF
--- a/backend/scripts/seed-test-student.js
+++ b/backend/scripts/seed-test-student.js
@@ -27,6 +27,7 @@ const Group          = require('../src/models/Group');
 const Committee      = require('../src/models/Committee');
 const ScheduleWindow = require('../src/models/ScheduleWindow');
 const SprintConfig   = require('../src/models/SprintConfig');
+const Deliverable    = require('../src/models/Deliverable');
 const { hashPassword }        = require('../src/utils/password');
 const { generateAccessToken } = require('../src/utils/jwt');
 
@@ -47,6 +48,7 @@ async function run() {
   await Committee.deleteOne({ committeeName: 'Test Committee' });
   await ScheduleWindow.deleteMany({ createdBy: 'seed-test-student' });
   await SprintConfig.deleteMany({ sprintId: 'sprint_1' });
+  await Deliverable.deleteMany({ groupId: /^grp_test_/ });
 
   // ── Create student user ───────────────────────────────────────────────────
   const userId = `usr_${uuidv4().split('-')[0]}`;
@@ -107,6 +109,49 @@ async function run() {
     description: 'Test sprint — seeded for local dev',
   });
 
+  // ── Seed test Deliverable records (D4) for GET endpoints ─────────────────
+  const deliverableId1 = `DEL-test-${uuidv4().split('-')[0]}`;
+  const deliverableId2 = `DEL-test-${uuidv4().split('-')[0]}`;
+
+  await Deliverable.create([
+    {
+      deliverableId: deliverableId1,
+      committeeId,
+      groupId,
+      studentId: userId,
+      type: 'proposal',
+      sprintId: 'sprint_1',
+      version: 1,
+      storageRef: '/uploads/permanent/test-proposal.pdf',
+      status: 'accepted',
+      submittedAt: new Date(),
+      validationHistory: [
+        { step: 'format_validation',   passed: true,  checkedAt: new Date(), failureReasons: [] },
+        { step: 'deadline_validation', passed: true,  checkedAt: new Date(), failureReasons: [] },
+        { step: 'storage',             passed: true,  checkedAt: new Date(), failureReasons: [] },
+      ],
+    },
+    {
+      deliverableId: deliverableId2,
+      committeeId,
+      groupId,
+      studentId: userId,
+      type: 'proposal',
+      sprintId: 'sprint_1',
+      version: 2,
+      storageRef: '/uploads/permanent/test-proposal-v2.pdf',
+      status: 'submitted',
+      submittedAt: new Date(),
+      validationHistory: [
+        { step: 'format_validation',   passed: true,  checkedAt: new Date(), failureReasons: [] },
+        { step: 'deadline_validation', passed: true,  checkedAt: new Date(), failureReasons: [] },
+      ],
+    },
+  ]);
+
+  // ── Coordinator JWT for retract endpoint ──────────────────────────────────
+  const coordToken = generateAccessToken('coordinator_test', 'coordinator');
+
   // ── Generate a ready-to-use JWT (1 h) ─────────────────────────────────────
   const token = generateAccessToken(userId, 'student');
 
@@ -120,8 +165,11 @@ async function run() {
   console.log(`  email    : ${TEST_EMAIL}`);
   console.log(`  password : ${TEST_PASSWORD}`);
   console.log(`  userId   : ${userId}`);
-  console.log(`  groupId  : ${groupId}`);
-  console.log(`  JWT      : ${token}`);
+  console.log(`  groupId       : ${groupId}`);
+  console.log(`  deliverableId1: ${deliverableId1}  (status: accepted — use this to test retract)`);
+  console.log(`  deliverableId2: ${deliverableId2}  (status: submitted)`);
+  console.log(`  JWT (student) : ${token}`);
+  console.log(`  JWT (coord)   : ${coordToken}`);
   console.log('─────────────────────────────────────────────────────────────');
   console.log(`
 The test student already has an active group (${groupId}).

--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -7,6 +7,7 @@ const Group = require('../models/Group');
 const Committee = require('../models/Committee');
 const AuditLog = require('../models/AuditLog');
 const DeliverableStaging = require('../models/DeliverableStaging');
+const Deliverable = require('../models/Deliverable');
 const { hashData } = require('../utils/fileHash');
 const { runFormatValidation, runDeadlineValidation } = require('../services/deliverableValidationService');
 
@@ -341,4 +342,193 @@ const validateDeadlineHandler = async (req, res) => {
   return res.status(status).json(body);
 };
 
-module.exports = { validateGroup, submitDeliverable, validateFormatHandler, validateDeadlineHandler };
+/**
+ * GET /api/deliverables
+ *
+ * List deliverables for a group with optional filters and pagination.
+ * Students may only query their own group. Coordinators may query any group.
+ *
+ * Query params:
+ *   groupId   — required for coordinator; defaults to req.user.groupId for student
+ *   sprintId  — optional filter
+ *   status    — optional filter
+ *   page      — default 1
+ *   limit     — default 20, max 100
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const listDeliverablesHandler = async (req, res) => {
+  const { role, groupId: userGroupId } = req.user;
+
+  let { groupId, sprintId, status, page, limit } = req.query;
+
+  // Resolve groupId
+  if (!groupId) {
+    if (role === 'student') {
+      groupId = userGroupId;
+    } else {
+      return res.status(400).json({ code: 'INVALID_REQUEST', message: 'groupId query param is required' });
+    }
+  }
+
+  // Students can only query their own group
+  if (role === 'student' && groupId !== userGroupId) {
+    return res.status(403).json({ code: 'FORBIDDEN', message: 'Students can only view their own group deliverables' });
+  }
+
+  // Pagination
+  page = Math.max(1, parseInt(page, 10) || 1);
+  limit = Math.min(100, Math.max(1, parseInt(limit, 10) || 20));
+  const skip = (page - 1) * limit;
+
+  // Build filter
+  const filter = { groupId };
+  if (sprintId) filter.sprintId = sprintId;
+  if (status) filter.status = status;
+
+  let deliverables, total;
+  try {
+    [deliverables, total] = await Promise.all([
+      Deliverable.find(filter)
+        .select('deliverableId type sprintId status submittedAt version')
+        .sort({ submittedAt: -1 })
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Deliverable.countDocuments(filter),
+    ]);
+  } catch (err) {
+    console.error('[listDeliverablesHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  return res.status(200).json({
+    groupId,
+    total,
+    page,
+    limit,
+    deliverables: deliverables.map((d) => ({
+      deliverableId: d.deliverableId,
+      deliverableType: d.type,
+      sprintId: d.sprintId ?? null,
+      status: d.status,
+      submittedAt: d.submittedAt,
+      version: d.version ?? 1,
+    })),
+  });
+};
+
+/**
+ * GET /api/deliverables/:deliverableId
+ *
+ * Return full deliverable record including validationHistory.
+ * Students can only view deliverables belonging to their own group.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const getDeliverableHandler = async (req, res) => {
+  const { deliverableId } = req.params;
+  const { role, groupId: userGroupId } = req.user;
+
+  let deliverable;
+  try {
+    deliverable = await Deliverable.findOne({ deliverableId }).lean();
+  } catch (err) {
+    console.error('[getDeliverableHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!deliverable) {
+    return res.status(404).json({ code: 'DELIVERABLE_NOT_FOUND', message: 'Deliverable not found' });
+  }
+
+  // Students can only view their own group's deliverables
+  if (role === 'student' && deliverable.groupId !== userGroupId) {
+    return res.status(403).json({ code: 'FORBIDDEN', message: 'Students can only view their own group deliverables' });
+  }
+
+  return res.status(200).json({
+    deliverableId: deliverable.deliverableId,
+    groupId: deliverable.groupId,
+    committeeId: deliverable.committeeId,
+    deliverableType: deliverable.type,
+    sprintId: deliverable.sprintId ?? null,
+    version: deliverable.version ?? 1,
+    status: deliverable.status,
+    submittedAt: deliverable.submittedAt,
+    storageRef: deliverable.storageRef,
+    feedback: deliverable.feedback ?? null,
+    reviewedBy: deliverable.reviewedBy ?? null,
+    reviewedAt: deliverable.reviewedAt ?? null,
+    validationHistory: deliverable.validationHistory ?? [],
+  });
+};
+
+/**
+ * DELETE /api/deliverables/:deliverableId/retract
+ *
+ * Retract a submitted deliverable. Coordinator only.
+ * Only allowed if status === 'accepted' (not yet under review).
+ * Sets status = 'retracted'; does not delete the file from disk.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const retractDeliverableHandler = async (req, res) => {
+  const { deliverableId } = req.params;
+
+  let deliverable;
+  try {
+    deliverable = await Deliverable.findOne({ deliverableId });
+  } catch (err) {
+    console.error('[retractDeliverableHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!deliverable) {
+    return res.status(404).json({ code: 'DELIVERABLE_NOT_FOUND', message: 'Deliverable not found' });
+  }
+
+  // Already retracted
+  if (deliverable.status === 'retracted') {
+    return res.status(409).json({ code: 'ALREADY_RETRACTED', message: 'Deliverable has already been retracted' });
+  }
+
+  // Only 'accepted' status can be retracted — review already started otherwise
+  if (deliverable.status !== 'accepted') {
+    return res.status(409).json({
+      code: 'REVIEW_ALREADY_STARTED',
+      message: `Cannot retract a deliverable with status '${deliverable.status}' — only 'accepted' submissions may be retracted`,
+    });
+  }
+
+  try {
+    await Deliverable.updateOne({ deliverableId }, { $set: { status: 'retracted' } });
+  } catch (err) {
+    console.error('[retractDeliverableHandler] status update error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to update deliverable status' });
+  }
+
+  AuditLog.create({
+    action: 'DELIVERABLE_RETRACTED',
+    actorId: req.user.userId,
+    groupId: deliverable.groupId,
+    payload: { deliverableId },
+    ipAddress: req.ip ?? null,
+    userAgent: req.headers['user-agent'] ?? null,
+  }).catch((err) => console.error('[retractDeliverableHandler] audit log error:', err.message));
+
+  return res.status(200).json({ deliverableId, status: 'retracted' });
+};
+
+module.exports = {
+  validateGroup,
+  submitDeliverable,
+  validateFormatHandler,
+  validateDeadlineHandler,
+  listDeliverablesHandler,
+  getDeliverableHandler,
+  retractDeliverableHandler,
+};

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -101,6 +101,9 @@ const auditLogSchema = new mongoose.Schema(
         'DELIVERABLE_DEADLINE_VALIDATION_SUCCESS',
         'DELIVERABLE_DEADLINE_VALIDATION_FAILED',
 
+        // --- Deliverable Read & Retract ---
+        'DELIVERABLE_RETRACTED',
+
         // --- System & Test ---
         'TEST_ACTION',
       ],

--- a/backend/src/models/Deliverable.js
+++ b/backend/src/models/Deliverable.js
@@ -48,9 +48,35 @@ const deliverableSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    sprintId: {
+      type: String,
+      default: null,
+      index: true,
+    },
+    version: {
+      type: Number,
+      default: 1,
+      min: 1,
+    },
+    validationHistory: {
+      type: [
+        {
+          step: {
+            type: String,
+            enum: ['format_validation', 'deadline_validation', 'storage'],
+            required: true,
+          },
+          passed: { type: Boolean, required: true },
+          checkedAt: { type: Date, required: true },
+          failureReasons: { type: [String], default: [] },
+          _id: false,
+        },
+      ],
+      default: [],
+    },
     status: {
       type: String,
-      enum: ['submitted', 'reviewed', 'accepted', 'rejected'],
+      enum: ['submitted', 'reviewed', 'accepted', 'rejected', 'retracted'],
       default: 'submitted',
     },
     feedback: {

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -5,10 +5,32 @@ const router = express.Router();
 
 const { deliverableAuthMiddleware, roleMiddleware } = require('../middleware/auth');
 const { uploadSingle } = require('../middleware/upload');
-const { validateGroup, submitDeliverable, validateFormatHandler, validateDeadlineHandler } = require('../controllers/deliverableController');
+const {
+  validateGroup,
+  submitDeliverable,
+  validateFormatHandler,
+  validateDeadlineHandler,
+  listDeliverablesHandler,
+  getDeliverableHandler,
+  retractDeliverableHandler,
+} = require('../controllers/deliverableController');
 
 // All deliverable routes require a valid JWT; req.user = { userId, role, groupId }
 router.use(deliverableAuthMiddleware);
+
+/**
+ * GET /api/deliverables
+ * List deliverables for a group with optional filters and pagination.
+ * Students see their own group only; coordinators may query any group.
+ */
+router.get('/', listDeliverablesHandler);
+
+/**
+ * GET /api/deliverables/:deliverableId
+ * Full deliverable record including validationHistory.
+ * Students can only view deliverables belonging to their own group.
+ */
+router.get('/:deliverableId', getDeliverableHandler);
 
 /**
  * POST /api/deliverables/validate-group
@@ -69,16 +91,10 @@ router.post(
 
 /**
  * DELETE /api/deliverables/:deliverableId/retract
- * Accepted role: coordinator
- * Controller to be implemented in subsequent Process 5 issues.
+ * Coordinator only. Allowed only when status === 'accepted'.
+ * Sets status = 'retracted'; does not delete the file from disk.
  */
-router.delete(
-  '/:deliverableId/retract',
-  roleMiddleware(['coordinator']),
-  (_req, res) => {
-    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Retract endpoint not yet implemented' });
-  }
-);
+router.delete('/:deliverableId/retract', roleMiddleware(['coordinator']), retractDeliverableHandler);
 
 /**
  * POST /api/v1/deliverables/:deliverableId/comments

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -669,6 +669,99 @@ const options = {
       },
 
       // ── DELIVERABLES ──────────────────────────────────────────────────────
+      '/deliverables': {
+        get: {
+          tags: ['Deliverables'],
+          summary: 'List deliverables for a group (paginated)',
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: 'groupId', in: 'query', required: false, schema: { type: 'string' }, description: 'Required for coordinator; defaults to own group for student' },
+            { name: 'sprintId', in: 'query', required: false, schema: { type: 'string' } },
+            { name: 'status', in: 'query', required: false, schema: { type: 'string', enum: ['submitted', 'reviewed', 'accepted', 'rejected', 'retracted'] } },
+            { name: 'page', in: 'query', required: false, schema: { type: 'integer', default: 1 } },
+            { name: 'limit', in: 'query', required: false, schema: { type: 'integer', default: 20, maximum: 100 } },
+          ],
+          responses: {
+            200: {
+              description: 'Paginated deliverable list',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      groupId: { type: 'string' },
+                      total: { type: 'integer' },
+                      page: { type: 'integer' },
+                      limit: { type: 'integer' },
+                      deliverables: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            deliverableId: { type: 'string' },
+                            deliverableType: { type: 'string' },
+                            sprintId: { type: 'string', nullable: true },
+                            status: { type: 'string' },
+                            submittedAt: { type: 'string', format: 'date-time' },
+                            version: { type: 'integer' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            403: { description: 'Student querying another group' },
+          },
+        },
+      },
+      '/deliverables/{deliverableId}': {
+        get: {
+          tags: ['Deliverables'],
+          summary: 'Get full deliverable details including validation history',
+          security: [{ bearerAuth: [] }],
+          parameters: [{ name: 'deliverableId', in: 'path', required: true, schema: { type: 'string' } }],
+          responses: {
+            200: {
+              description: 'Full deliverable record',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      deliverableId: { type: 'string' },
+                      groupId: { type: 'string' },
+                      committeeId: { type: 'string' },
+                      deliverableType: { type: 'string' },
+                      sprintId: { type: 'string', nullable: true },
+                      version: { type: 'integer' },
+                      status: { type: 'string' },
+                      submittedAt: { type: 'string', format: 'date-time' },
+                      storageRef: { type: 'string' },
+                      feedback: { type: 'string', nullable: true },
+                      validationHistory: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            step: { type: 'string', enum: ['format_validation', 'deadline_validation', 'storage'] },
+                            passed: { type: 'boolean' },
+                            checkedAt: { type: 'string', format: 'date-time' },
+                            failureReasons: { type: 'array', items: { type: 'string' } },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            403: { description: 'Student viewing another group deliverable' },
+            404: { description: 'Deliverable not found' },
+          },
+        },
+      },
       '/deliverables/validate-group': {
         post: {
           tags: ['Deliverables'],


### PR DESCRIPTION
- Extend Deliverable model with sprintId, version, validationHistory
  (format_validation / deadline_validation / storage steps) and retracted status
- Add GET /api/deliverables with pagination and groupId, sprintId, status filters;
  students restricted to their own group
- Add GET /api/deliverables/:deliverableId returning full record with validationHistory
- Add DELETE /api/deliverables/:deliverableId/retract (coordinator only);
  allowed only when status === 'accepted', returns 409 if review already started
- Register DELIVERABLE_RETRACTED in AuditLog action enum
- Add Swagger definitions for all three endpoints
- Extend seed script with test Deliverable records and coordinator JWT