### PR TITLE
feat(deliverables): implement Process 5.5 file storage and permanent …

### DIFF
--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -8,6 +8,7 @@ const Committee = require('../models/Committee');
 const AuditLog = require('../models/AuditLog');
 const DeliverableStaging = require('../models/DeliverableStaging');
 const Deliverable = require('../models/Deliverable');
+const mongoose = require('mongoose');
 const { hashData } = require('../utils/fileHash');
 const { runFormatValidation, runDeadlineValidation } = require('../services/deliverableValidationService');
 const { persistDeliverableFile, createFinalRecord } = require('../services/storageService');
@@ -385,37 +386,40 @@ const storeDeliverableHandler = async (req, res) => {
     });
   }
 
-  // 2. Move file to permanent storage
+  // 2–4. Move file, create DB record, and delete staging — all in a transaction so
+  //      createFinalRecord and deleteOne are atomic. persistDeliverableFile is
+  //      synchronous file I/O and cannot participate in the DB session; if it
+  //      succeeds but the transaction aborts, the permanent file is left orphaned
+  //      (acceptable trade-off — the staging record is preserved for retry).
   let fileInfo;
+  let deliverable;
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
   try {
     fileInfo = persistDeliverableFile(staging);
+    deliverable = await createFinalRecord(staging, fileInfo.savedPath, session);
+    await DeliverableStaging.deleteOne({ stagingId }, { session });
+    await session.commitTransaction();
   } catch (err) {
-    const statusCode = err.statusCode || 500;
-    const code = err.code || 'STORAGE_ERROR';
+    await session.abortTransaction();
 
-    if (statusCode === 507) {
+    if (err.statusCode === 507 || err.code === 'DISK_FULL') {
       return res.status(507).json({ code: 'DISK_FULL', message: 'Insufficient disk space — please retry later' });
     }
 
-    console.error('[storeDeliverableHandler] File storage error:', err);
-    return res.status(statusCode).json({ code, message: err.message });
-  }
+    if (err.statusCode === 400 && err.code === 'CHECKSUM_MISMATCH') {
+      return res.status(400).json({ code: 'CHECKSUM_MISMATCH', message: err.message });
+    }
 
-  // 3. Create permanent Deliverable record
-  let deliverable;
-  try {
-    deliverable = await createFinalRecord(staging, fileInfo.savedPath);
-  } catch (err) {
-    console.error('[storeDeliverableHandler] Deliverable record creation error:', err);
-    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to create deliverable record' });
-  }
+    if (err.statusCode === 404 && err.code === 'FILE_NOT_FOUND') {
+      return res.status(404).json({ code: 'STAGING_FILE_NOT_FOUND', message: err.message });
+    }
 
-  // 4. Delete staging record
-  try {
-    await DeliverableStaging.deleteOne({ stagingId });
-  } catch (err) {
-    // Non-fatal: log and continue — file and DB record are already committed
-    console.warn('[storeDeliverableHandler] Failed to delete staging record:', err.message);
+    console.error('[storeDeliverableHandler] Transaction error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to store deliverable' });
+  } finally {
+    session.endSession();
   }
 
   AuditLog.create({

--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -10,6 +10,7 @@ const DeliverableStaging = require('../models/DeliverableStaging');
 const Deliverable = require('../models/Deliverable');
 const { hashData } = require('../utils/fileHash');
 const { runFormatValidation, runDeadlineValidation } = require('../services/deliverableValidationService');
+const { persistDeliverableFile, createFinalRecord } = require('../services/storageService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 
@@ -345,6 +346,105 @@ const validateDeadlineHandler = async (req, res) => {
 };
 
 /**
+ * POST /api/deliverables/:stagingId/store
+ *
+ * Process 5.5 — Move staged file to permanent storage, create the final Deliverable
+ * record, and clean up the staging record. Point of no return.
+ *
+ * Prerequisites:
+ *   1. JWT (student role) — enforced by route middleware
+ *   2. Staging record exists and is in 'requirements_validated' status
+ *
+ * On success: deletes staging record, returns 201.
+ * On storage failure (disk full): staging record stays intact; returns 507.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const storeDeliverableHandler = async (req, res) => {
+  const { stagingId } = req.params;
+  const actorId = req.user?.userId;
+
+  // 1. Look up staging record
+  let staging;
+  try {
+    staging = await DeliverableStaging.findOne({ stagingId });
+  } catch (err) {
+    console.error('[storeDeliverableHandler] DB lookup error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!staging) {
+    return res.status(404).json({ code: 'STAGING_NOT_FOUND', message: 'Staging record not found' });
+  }
+
+  if (staging.status !== 'requirements_validated') {
+    return res.status(400).json({
+      code: 'INVALID_STAGING_STATUS',
+      message: `Staging record must be in 'requirements_validated' status (current: '${staging.status}')`,
+    });
+  }
+
+  // 2. Move file to permanent storage
+  let fileInfo;
+  try {
+    fileInfo = persistDeliverableFile(staging);
+  } catch (err) {
+    const statusCode = err.statusCode || 500;
+    const code = err.code || 'STORAGE_ERROR';
+
+    if (statusCode === 507) {
+      return res.status(507).json({ code: 'DISK_FULL', message: 'Insufficient disk space — please retry later' });
+    }
+
+    console.error('[storeDeliverableHandler] File storage error:', err);
+    return res.status(statusCode).json({ code, message: err.message });
+  }
+
+  // 3. Create permanent Deliverable record
+  let deliverable;
+  try {
+    deliverable = await createFinalRecord(staging, fileInfo.savedPath);
+  } catch (err) {
+    console.error('[storeDeliverableHandler] Deliverable record creation error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to create deliverable record' });
+  }
+
+  // 4. Delete staging record
+  try {
+    await DeliverableStaging.deleteOne({ stagingId });
+  } catch (err) {
+    // Non-fatal: log and continue — file and DB record are already committed
+    console.warn('[storeDeliverableHandler] Failed to delete staging record:', err.message);
+  }
+
+  AuditLog.create({
+    action: 'DELIVERABLE_STORED',
+    actorId,
+    groupId: staging.groupId,
+    payload: { stagingId, deliverableId: deliverable.deliverableId },
+    ipAddress: req.ip || null,
+    userAgent: req.headers['user-agent'] || null,
+  }).catch((err) => {
+    console.error('[storeDeliverableHandler] Audit log error:', err.message);
+  });
+
+  const sizeMb = parseFloat((deliverable.fileSize / (1024 * 1024)).toFixed(2));
+
+  return res.status(201).json({
+    deliverableId: deliverable.deliverableId,
+    groupId: deliverable.groupId,
+    deliverableType: deliverable.deliverableType,
+    status: deliverable.status,
+    fileHash: deliverable.fileHash,
+    sizeMb,
+    format: deliverable.format,
+    version: deliverable.version,
+    submittedAt: deliverable.submittedAt.toISOString(),
+  });
+};
+
+/**
  * GET /api/deliverables
  *
  * List deliverables for a group with optional filters and pagination.
@@ -393,7 +493,7 @@ const listDeliverablesHandler = async (req, res) => {
   try {
     [deliverables, total] = await Promise.all([
       Deliverable.find(filter)
-        .select('deliverableId type sprintId status submittedAt version')
+        .select('deliverableId deliverableType sprintId status submittedAt version')
         .sort({ submittedAt: -1 })
         .skip(skip)
         .limit(limit)
@@ -412,7 +512,7 @@ const listDeliverablesHandler = async (req, res) => {
     limit,
     deliverables: deliverables.map((d) => ({
       deliverableId: d.deliverableId,
-      deliverableType: d.type,
+      deliverableType: d.deliverableType,
       sprintId: d.sprintId ?? null,
       status: d.status,
       submittedAt: d.submittedAt,
@@ -454,17 +554,16 @@ const getDeliverableHandler = async (req, res) => {
   return res.status(200).json({
     deliverableId: deliverable.deliverableId,
     groupId: deliverable.groupId,
-    committeeId: deliverable.committeeId,
-    deliverableType: deliverable.type,
+    deliverableType: deliverable.deliverableType,
     sprintId: deliverable.sprintId ?? null,
     version: deliverable.version ?? 1,
     status: deliverable.status,
     submittedAt: deliverable.submittedAt,
-    storageRef: deliverable.storageRef,
-    feedback: deliverable.feedback ?? null,
-    reviewedBy: deliverable.reviewedBy ?? null,
-    reviewedAt: deliverable.reviewedAt ?? null,
-    validationHistory: deliverable.validationHistory ?? [],
+    filePath: deliverable.filePath,
+    fileHash: deliverable.fileHash,
+    fileSize: deliverable.fileSize,
+    format: deliverable.format,
+    description: deliverable.description ?? null,
   });
 };
 
@@ -530,6 +629,7 @@ module.exports = {
   submitDeliverable,
   validateFormatHandler,
   validateDeadlineHandler,
+  storeDeliverableHandler,
   listDeliverablesHandler,
   getDeliverableHandler,
   retractDeliverableHandler,

--- a/backend/src/migrations/007_create_deliverable_schema.js
+++ b/backend/src/migrations/007_create_deliverable_schema.js
@@ -1,0 +1,151 @@
+'use strict';
+
+/**
+ * Migration 007: Create Deliverable and DeliverableStaging collections (D4)
+ *
+ * Creates both collections with all required indexes for Process 5 (Deliverable Submission).
+ *
+ * Deliverable (D4):
+ *   Fields: deliverableId, groupId, deliverableType, sprintId, submittedBy, description,
+ *           filePath, fileSize, fileHash, format, status, version, submittedAt, createdAt, updatedAt
+ *   Indexes:
+ *     { deliverableId: 1 }                              — unique
+ *     { groupId: 1, createdAt: -1 }                    — group timeline queries
+ *     { status: 1 }                                    — status filter queries
+ *     { groupId: 1, deliverableType: 1, sprintId: 1 }  — version counting
+ *
+ * DeliverableStaging:
+ *   Indexes:
+ *     { stagingId: 1 }    — unique
+ *     { expiresAt: 1 }    — TTL (auto-delete expired staging records)
+ *     { groupId: 1 }      — rate-limit queries
+ */
+
+const DELIVERABLE_TYPES = ['proposal', 'statement_of_work', 'demo', 'interim_report', 'final_report'];
+const DELIVERABLE_STATUSES = ['accepted', 'under_review', 'awaiting_resubmission', 'evaluated', 'retracted'];
+
+const STAGING_STATUSES = [
+  'staging',
+  'format_validated',
+  'validation_failed',
+  'deadline_failed',
+  'requirements_validated',
+];
+
+/**
+ * Idempotent index creation helper — treats "already exists" as success.
+ */
+const createIndexSafely = async (collection, indexSpec, options, label) => {
+  try {
+    await collection.createIndex(indexSpec, options);
+    console.log(`[Migration 007] Created index ${label}`);
+  } catch (err) {
+    if (err.message.includes('already exists')) {
+      console.log(`[Migration 007] Index ${label} already exists — skipping`);
+    } else {
+      throw err;
+    }
+  }
+};
+
+const up = async (db) => {
+  const mongoDb = db.connection.db;
+  console.log('[Migration 007] Running — Deliverable + DeliverableStaging schema');
+
+  const existing = await mongoDb.listCollections().toArray();
+  const names = new Set(existing.map((c) => c.name));
+
+  // ── Deliverable collection ────────────────────────────────────────────────
+  if (!names.has('deliverables')) {
+    await mongoDb.createCollection('deliverables', {
+      validator: {
+        $jsonSchema: {
+          bsonType: 'object',
+          required: ['deliverableId', 'groupId', 'deliverableType', 'submittedBy', 'filePath', 'fileSize', 'fileHash', 'format', 'status'],
+          properties: {
+            deliverableId: { bsonType: 'string' },
+            groupId: { bsonType: 'string' },
+            deliverableType: { bsonType: 'string', enum: DELIVERABLE_TYPES },
+            sprintId: { bsonType: ['string', 'null'] },
+            submittedBy: { bsonType: 'string' },
+            description: { bsonType: ['string', 'null'] },
+            filePath: { bsonType: 'string' },
+            fileSize: { bsonType: 'number' },
+            fileHash: { bsonType: 'string' },
+            format: { bsonType: 'string' },
+            status: { bsonType: 'string', enum: DELIVERABLE_STATUSES },
+            version: { bsonType: 'int' },
+            submittedAt: { bsonType: 'date' },
+          },
+        },
+      },
+    });
+    console.log('[Migration 007] Created deliverables collection');
+  } else {
+    console.log('[Migration 007] deliverables collection already exists');
+  }
+
+  const deliverables = mongoDb.collection('deliverables');
+  await createIndexSafely(deliverables, { deliverableId: 1 }, { unique: true }, '{ deliverableId: 1 } UNIQUE');
+  await createIndexSafely(deliverables, { groupId: 1, createdAt: -1 }, {}, '{ groupId, createdAt }');
+  await createIndexSafely(deliverables, { status: 1 }, {}, '{ status }');
+  await createIndexSafely(deliverables, { groupId: 1, deliverableType: 1, sprintId: 1 }, {}, '{ groupId, deliverableType, sprintId }');
+
+  // ── DeliverableStaging collection ────────────────────────────────────────
+  if (!names.has('deliverable_stagings')) {
+    await mongoDb.createCollection('deliverable_stagings', {
+      validator: {
+        $jsonSchema: {
+          bsonType: 'object',
+          required: ['stagingId', 'groupId', 'deliverableType', 'sprintId', 'submittedBy', 'tempFilePath', 'fileSize', 'fileHash', 'mimeType', 'status'],
+          properties: {
+            stagingId: { bsonType: 'string' },
+            groupId: { bsonType: 'string' },
+            deliverableType: { bsonType: 'string', enum: DELIVERABLE_TYPES },
+            sprintId: { bsonType: 'string' },
+            submittedBy: { bsonType: 'string' },
+            description: { bsonType: ['string', 'null'] },
+            tempFilePath: { bsonType: 'string' },
+            fileSize: { bsonType: 'number' },
+            fileHash: { bsonType: 'string' },
+            mimeType: { bsonType: 'string' },
+            status: { bsonType: 'string', enum: STAGING_STATUSES },
+            expiresAt: { bsonType: 'date' },
+          },
+        },
+      },
+    });
+    console.log('[Migration 007] Created deliverable_stagings collection');
+  } else {
+    console.log('[Migration 007] deliverable_stagings collection already exists');
+  }
+
+  const stagings = mongoDb.collection('deliverable_stagings');
+  await createIndexSafely(stagings, { stagingId: 1 }, { unique: true }, '{ stagingId: 1 } UNIQUE');
+  await createIndexSafely(stagings, { expiresAt: 1 }, { expireAfterSeconds: 0 }, '{ expiresAt } TTL');
+  await createIndexSafely(stagings, { groupId: 1 }, {}, '{ groupId }');
+
+  console.log('[Migration 007] Complete');
+};
+
+const down = async (db) => {
+  const mongoDb = db.connection.db;
+  console.log('[Migration 007] Rolling back — dropping Deliverable + DeliverableStaging collections');
+
+  const existing = await mongoDb.listCollections().toArray();
+  const names = new Set(existing.map((c) => c.name));
+
+  if (names.has('deliverables')) {
+    await mongoDb.collection('deliverables').drop();
+    console.log('[Migration 007] Dropped deliverables');
+  }
+
+  if (names.has('deliverable_stagings')) {
+    await mongoDb.collection('deliverable_stagings').drop();
+    console.log('[Migration 007] Dropped deliverable_stagings');
+  }
+
+  console.log('[Migration 007] Rollback complete');
+};
+
+module.exports = { name: '007_create_deliverable_schema', up, down };

--- a/backend/src/models/Deliverable.js
+++ b/backend/src/models/Deliverable.js
@@ -1,14 +1,15 @@
+'use strict';
+
 const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
 
 /**
  * Deliverable Schema (D4 Data Store)
- * 
- * Represents student project deliverables submitted during committee evaluation.
- * Part of Process 4.5 (Deliverable Submission) workflow.
- * 
+ *
+ * Represents the permanent record created after Process 5.5 (file storage).
  * Flows:
- * - f12: 4.5 → D4 (deliverable submission)
- * - f14: D4 → D6 (cross-reference to sprint records)
+ *   f12: Process 5.5 → D4 (deliverable stored)
+ *   f14: D4 → D6 (cross-reference to sprint records)
  */
 const deliverableSchema = new mongoose.Schema(
   {
@@ -17,79 +18,59 @@ const deliverableSchema = new mongoose.Schema(
       required: true,
       unique: true,
       index: true,
-      default: () => `DEL-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`,
-    },
-    committeeId: {
-      type: String,
-      required: true,
-      index: true,
+      default: () => `del_${uuidv4().replace(/-/g, '').slice(0, 10)}`,
     },
     groupId: {
       type: String,
       required: true,
-      index: true,
     },
-    studentId: {
+    deliverableType: {
       type: String,
-      required: true,
-    },
-    type: {
-      type: String,
-      enum: ['proposal', 'statement-of-work', 'demonstration'],
-      required: true,
-      index: true,
-    },
-    submittedAt: {
-      type: Date,
-      required: true,
-      default: () => new Date(),
-    },
-    storageRef: {
-      type: String,
+      enum: ['proposal', 'statement_of_work', 'demo', 'interim_report', 'final_report'],
       required: true,
     },
     sprintId: {
       type: String,
       default: null,
-      index: true,
+    },
+    submittedBy: {
+      type: String,
+      required: true,
+    },
+    description: {
+      type: String,
+      default: null,
+    },
+    filePath: {
+      type: String,
+      required: true,
+    },
+    fileSize: {
+      type: Number,
+      required: true,
+    },
+    fileHash: {
+      type: String,
+      required: true,
+    },
+    format: {
+      type: String,
+      required: true,
+    },
+    status: {
+      type: String,
+      enum: ['accepted', 'under_review', 'awaiting_resubmission', 'evaluated', 'retracted'],
+      default: 'accepted',
     },
     version: {
       type: Number,
       default: 1,
       min: 1,
     },
-    validationHistory: {
-      type: [
-        {
-          step: {
-            type: String,
-            enum: ['format_validation', 'deadline_validation', 'storage'],
-            required: true,
-          },
-          passed: { type: Boolean, required: true },
-          checkedAt: { type: Date, required: true },
-          failureReasons: { type: [String], default: [] },
-          _id: false,
-        },
-      ],
-      default: [],
-    },
-    status: {
-      type: String,
-      enum: ['submitted', 'reviewed', 'accepted', 'rejected', 'retracted'],
-      default: 'submitted',
-    },
-    feedback: {
-      type: String,
-      default: null,
-    },
-    reviewedBy: {
-      type: String,
-      default: null,
-    },
-    reviewedAt: {
+    submittedAt: {
       type: Date,
-      default: null,
+      required: true,
+      default: () => new Date(),
     },
   },
   {
@@ -98,9 +79,9 @@ const deliverableSchema = new mongoose.Schema(
   }
 );
 
-// Compound indexes for common queries
-deliverableSchema.index({ committeeId: 1, groupId: 1 });
-deliverableSchema.index({ groupId: 1, type: 1 });
-deliverableSchema.index({ submittedAt: -1 });
+// Indexes per spec
+deliverableSchema.index({ groupId: 1, createdAt: -1 });
+deliverableSchema.index({ status: 1 });
+deliverableSchema.index({ groupId: 1, deliverableType: 1, sprintId: 1 });
 
 module.exports = mongoose.model('Deliverable', deliverableSchema);

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -10,6 +10,7 @@ const {
   submitDeliverable,
   validateFormatHandler,
   validateDeadlineHandler,
+  storeDeliverableHandler,
   listDeliverablesHandler,
   getDeliverableHandler,
   retractDeliverableHandler,
@@ -78,7 +79,7 @@ router.post(
  * POST /api/deliverables/:stagingId/submit
  * Accepted role: student
  * Parses multipart upload (field: "file") before reaching the controller.
- * Controller to be implemented in subsequent Process 5 issues.
+ * Kept as a stub for middleware testing (MIME-type filter, role guard).
  */
 router.post(
   '/:stagingId/submit',
@@ -87,6 +88,18 @@ router.post(
   (_req, res) => {
     res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Submit endpoint not yet implemented' });
   }
+);
+
+/**
+ * POST /api/deliverables/:stagingId/store
+ * Process 5.5 — Move staged file to permanent storage and create the final Deliverable record.
+ * Requires JWT (student role). Staging record must be in 'requirements_validated' status.
+ * Returns 201 on success; 507 if disk is full (staging record preserved for retry).
+ */
+router.post(
+  '/:stagingId/store',
+  roleMiddleware(['student']),
+  storeDeliverableHandler
 );
 
 /**

--- a/backend/src/services/deliverableValidationService.js
+++ b/backend/src/services/deliverableValidationService.js
@@ -287,7 +287,7 @@ const checkSubmissionEligibility = async (stagingId, sprintId) => {
   try {
     priorSubmissions = await Deliverable.countDocuments({
       groupId: staging.groupId,
-      type: staging.deliverableType,
+      deliverableType: staging.deliverableType,
     });
   } catch (err) {
     console.error('[deliverableValidationService] checkSubmissionEligibility D4 count error:', err.message);

--- a/backend/src/services/storageService.js
+++ b/backend/src/services/storageService.js
@@ -110,38 +110,45 @@ const persistDeliverableFile = (stagingRecord) => {
 };
 
 /**
- * createFinalRecord(stagingRecord, savedPath)
+ * createFinalRecord(stagingRecord, savedPath, session)
  *
  * Creates the permanent Deliverable document in D4 (status: 'accepted').
  * Computes version by counting prior submissions for the same group + deliverableType.
+ * Pass a Mongoose ClientSession to run this inside a transaction.
  *
  * @param {import('../models/DeliverableStaging').default} stagingRecord - DeliverableStaging document
  * @param {string} savedPath - Absolute path where the file was written
+ * @param {import('mongoose').ClientSession} [session] - Optional Mongoose session for transactions
  * @returns {Promise<import('../models/Deliverable').default>} Created Deliverable document
  */
-const createFinalRecord = async (stagingRecord, savedPath) => {
+const createFinalRecord = async (stagingRecord, savedPath, session) => {
   const { groupId, deliverableType, sprintId, submittedBy, description, fileHash, fileSize } = stagingRecord;
 
-  const priorCount = await Deliverable.countDocuments({ groupId, deliverableType });
+  const priorCount = await Deliverable.countDocuments({ groupId, deliverableType }).session(session ?? null);
   const version = priorCount + 1;
 
   const ext = path.extname(savedPath);
   const format = ext.replace(/^\./, '').toLowerCase() || 'bin';
 
-  const deliverable = await Deliverable.create({
-    groupId,
-    deliverableType,
-    sprintId: sprintId || null,
-    submittedBy,
-    description: description || null,
-    filePath: savedPath,
-    fileSize,
-    fileHash,
-    format,
-    status: 'accepted',
-    version,
-    submittedAt: new Date(),
-  });
+  const [deliverable] = await Deliverable.create(
+    [
+      {
+        groupId,
+        deliverableType,
+        sprintId: sprintId || null,
+        submittedBy,
+        description: description || null,
+        filePath: savedPath,
+        fileSize,
+        fileHash,
+        format,
+        status: 'accepted',
+        version,
+        submittedAt: new Date(),
+      },
+    ],
+    { session: session ?? null }
+  );
 
   return deliverable;
 };

--- a/backend/src/services/storageService.js
+++ b/backend/src/services/storageService.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { v4: uuidv4 } = require('uuid');
+const Deliverable = require('../models/Deliverable');
+
+const PERMANENT_BASE = path.join(process.cwd(), 'uploads', 'deliverables');
+
+/**
+ * Derive file extension from the file path, falling back to MIME type.
+ * @param {string} filePath
+ * @param {string} mimeType
+ * @returns {string} Extension including leading dot, e.g. '.pdf'
+ */
+const resolveExtension = (filePath, mimeType) => {
+  const extFromPath = path.extname(filePath);
+  if (extFromPath) return extFromPath;
+
+  const mimeToExt = {
+    'application/pdf': '.pdf',
+    'application/zip': '.zip',
+    'application/x-zip-compressed': '.zip',
+    'application/msword': '.doc',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  };
+  return mimeToExt[mimeType] || '.bin';
+};
+
+/**
+ * persistDeliverableFile(stagingId, groupId, deliverableType)
+ *
+ * Process 5.5 — Move the staged file to permanent storage.
+ *
+ * Steps:
+ *  1. Reads the staging record to find the temp file path and expected hash.
+ *  2. Verifies SHA256 checksum matches the value stored in the staging record.
+ *  3. Creates uploads/deliverables/{groupId}/ directory if it does not exist.
+ *  4. Writes file to uploads/deliverables/{groupId}/{uuid}.{ext}.
+ *  5. Deletes the staging temp file (best-effort; logs warning on failure).
+ *
+ * On disk-full the write throws ENOSPC — the caller should propagate this as 507
+ * and leave the staging record intact so the user can retry.
+ *
+ * @param {import('../models/DeliverableStaging').default} stagingRecord - DeliverableStaging document
+ * @returns {{ savedPath: string, fileSize: number, checksum: string, format: string, timestamp: string }}
+ */
+const persistDeliverableFile = (stagingRecord) => {
+  const { tempFilePath, fileHash, fileSize, mimeType } = stagingRecord;
+
+  // 1. Verify SHA256 checksum and read file content
+  if (!fs.existsSync(tempFilePath)) {
+    const err = new Error(`Staging file not found: ${tempFilePath}`);
+    err.statusCode = 404;
+    err.code = 'FILE_NOT_FOUND';
+    throw err;
+  }
+
+  const content = fs.readFileSync(tempFilePath);
+  const actualHash = crypto.createHash('sha256').update(content).digest('hex');
+
+  if (actualHash !== fileHash) {
+    const err = new Error('File checksum mismatch — file may have been corrupted');
+    err.statusCode = 400;
+    err.code = 'CHECKSUM_MISMATCH';
+    throw err;
+  }
+
+  // 2. Determine extension and format
+  const ext = resolveExtension(tempFilePath, mimeType);
+  const format = ext.replace(/^\./, '').toLowerCase() || 'bin';
+
+  // 3. Create destination directory
+  const destDir = path.join(PERMANENT_BASE, stagingRecord.groupId);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+
+  // 4. Write to permanent path (unique name via UUID)
+  const uniqueName = `${uuidv4().replace(/-/g, '')}${ext}`;
+  const savedPath = path.join(destDir, uniqueName);
+
+  try {
+    fs.writeFileSync(savedPath, content);
+  } catch (err) {
+    if (err.code === 'ENOSPC') {
+      const e = new Error('Insufficient disk space');
+      e.statusCode = 507;
+      e.code = 'DISK_FULL';
+      throw e;
+    }
+    throw err;
+  }
+
+  // 5. Remove staging file (best-effort)
+  try {
+    fs.unlinkSync(tempFilePath);
+  } catch (err) {
+    console.warn(`[storageService] Could not delete staging file ${tempFilePath}: ${err.message}`);
+  }
+
+  return {
+    savedPath,
+    fileSize,
+    checksum: fileHash,
+    format,
+    timestamp: new Date().toISOString(),
+  };
+};
+
+/**
+ * createFinalRecord(stagingRecord, savedPath)
+ *
+ * Creates the permanent Deliverable document in D4 (status: 'accepted').
+ * Computes version by counting prior submissions for the same group + deliverableType.
+ *
+ * @param {import('../models/DeliverableStaging').default} stagingRecord - DeliverableStaging document
+ * @param {string} savedPath - Absolute path where the file was written
+ * @returns {Promise<import('../models/Deliverable').default>} Created Deliverable document
+ */
+const createFinalRecord = async (stagingRecord, savedPath) => {
+  const { groupId, deliverableType, sprintId, submittedBy, description, fileHash, fileSize } = stagingRecord;
+
+  const priorCount = await Deliverable.countDocuments({ groupId, deliverableType });
+  const version = priorCount + 1;
+
+  const ext = path.extname(savedPath);
+  const format = ext.replace(/^\./, '').toLowerCase() || 'bin';
+
+  const deliverable = await Deliverable.create({
+    groupId,
+    deliverableType,
+    sprintId: sprintId || null,
+    submittedBy,
+    description: description || null,
+    filePath: savedPath,
+    fileSize,
+    fileHash,
+    format,
+    status: 'accepted',
+    version,
+    submittedAt: new Date(),
+  });
+
+  return deliverable;
+};
+
+module.exports = {
+  persistDeliverableFile,
+  createFinalRecord,
+};

--- a/backend/tests/deliverable-notifications.test.js
+++ b/backend/tests/deliverable-notifications.test.js
@@ -306,11 +306,13 @@ describe('Deliverable Notification Service', () => {
       // Create a deliverable
       const deliverable = await Deliverable.create({
         deliverableId: `del_${Date.now()}`,
-        committeeId,
         groupId: 'grp_001',
-        studentId: 'stu_001',
-        type: 'proposal',
-        storageRef: '/path/to/file.pdf',
+        deliverableType: 'proposal',
+        submittedBy: 'stu_001',
+        filePath: '/path/to/file.pdf',
+        fileSize: 1024,
+        fileHash: 'abc123def456',
+        format: 'pdf',
         status: 'accepted',
       });
 
@@ -396,11 +398,13 @@ describe('Deliverable Notification Service', () => {
     it('should track notification attempts', async () => {
       const deliverable = await Deliverable.create({
         deliverableId: `del_${Date.now()}`,
-        committeeId: 'com_dup_check',
         groupId: 'grp_001',
-        studentId: 'stu_001',
-        type: 'proposal',
-        storageRef: '/path/to/file.pdf',
+        deliverableType: 'proposal',
+        submittedBy: 'stu_001',
+        filePath: '/path/to/file.pdf',
+        fileSize: 1024,
+        fileHash: 'abc123def456',
+        format: 'pdf',
         status: 'accepted',
       });
 
@@ -430,11 +434,13 @@ describe('Deliverable Notification Service', () => {
     it('should allow different notification modes', async () => {
       const deliverable = await Deliverable.create({
         deliverableId: `del_timeout_${Date.now()}`,
-        committeeId: 'com_rename_mode',
         groupId: 'grp_001',
-        studentId: 'stu_001',
-        type: 'proposal',
-        storageRef: '/path/to/file.pdf',
+        deliverableType: 'proposal',
+        submittedBy: 'stu_001',
+        filePath: '/path/to/file.pdf',
+        fileSize: 1024,
+        fileHash: 'abc123def456',
+        format: 'pdf',
         status: 'accepted',
       });
 


### PR DESCRIPTION
…record (issue #176)

- Add POST /api/deliverables/:stagingId/store endpoint (student role, JWT required)
- Create storageService.js with persistDeliverableFile() (SHA256 verify, file move, 507 on disk full) and createFinalRecord() (Deliverable doc, status: accepted)
- Replace Deliverable model schema with spec fields: deliverableType, submittedBy, filePath, fileSize, fileHash, format; updated status enum
- Add migration 007_create_deliverable_schema.js for deliverables and deliverable_stagings collections with all required indexes
- Fix deliverableValidationService countDocuments query: type → deliverableType
- Update list/get handlers to use renamed model fields
- Fix deliverable-notifications test to use new schema fields