### PR TITLE
feat(process-6.2): implement edit/resolve comment and group reply end…

### DIFF
--- a/backend/scripts/seed-test-general.js
+++ b/backend/scripts/seed-test-general.js
@@ -262,23 +262,25 @@ async function seedDeliverables(groups, committees) {
   console.log('🌱 Seeding deliverables...');
   
   const deliverables = [];
-  const types = ['proposal', 'statement-of-work', 'demonstration'];
+  const types = ['proposal', 'statement_of_work', 'demo'];
 
   for (let i = 0; i < groups.length; i++) {
+    const deliverableType = types[i % types.length];
     const deliverable = await Deliverable.create({
       deliverableId: generateId('del'),
-      committeeId: committees[i].committeeId,
       groupId: groups[i].groupId,
-      studentId: groups[i].members[0].userId,
-      type: types[i % types.length],
+      deliverableType,
+      submittedBy: groups[i].members[0].userId,
       submittedAt: new Date(),
-      storageRef: `s3://deliverables/${groups[i].groupId}/${types[i % types.length]}_v1.pdf`,
-      status: 'submitted',
-      feedback: null,
+      filePath: `uploads/${groups[i].groupId}/${deliverableType}_v1.pdf`,
+      fileSize: 102400,
+      fileHash: `hash_${generateId('h')}`,
+      format: 'pdf',
+      status: 'under_review',
     });
 
     deliverables.push(deliverable);
-    console.log(`  ✓ Created deliverable: ${groups[i].groupName} - ${deliverable.type}`);
+    console.log(`  ✓ Created deliverable: ${groups[i].groupName} - ${deliverableType}`);
   }
 
   return deliverables;
@@ -376,7 +378,7 @@ async function run() {
       const d = deliverables[i];
       const r = reviews[i];
       const g = groups.find(g => g.groupId === d.groupId);
-      console.log(`  ${(g?.groupName ?? d.groupId).padEnd(22)} | deliverableId: ${d.deliverableId.padEnd(16)} | type: ${d.type.padEnd(18)} | reviewId: ${r.reviewId}`);
+      console.log(`  ${(g?.groupName ?? d.groupId).padEnd(22)} | deliverableId: ${d.deliverableId.padEnd(16)} | type: ${d.deliverableType.padEnd(18)} | reviewId: ${r.reviewId}`);
     }
 
     // Sprints

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const axios = require('axios');
+const { v4: uuidv4 } = require('uuid');
+const Comment = require('../models/Comment');
+const Review = require('../models/Review');
+
+const NOTIFICATION_SERVICE_URL = process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000';
+
+const VALID_STATUSES = ['open', 'resolved', 'acknowledged'];
+
+/**
+ * Serialize a Comment document for API responses.
+ */
+const formatComment = (comment) => ({
+  commentId: comment.commentId,
+  deliverableId: comment.deliverableId,
+  authorId: comment.authorId,
+  authorName: comment.authorName,
+  content: comment.content,
+  commentType: comment.commentType,
+  sectionNumber: comment.sectionNumber ?? null,
+  needsResponse: comment.needsResponse,
+  status: comment.status,
+  replies: comment.replies.map((r) => ({
+    replyId: r.replyId,
+    authorId: r.authorId,
+    content: r.content,
+    createdAt: r.createdAt,
+  })),
+  createdAt: comment.createdAt,
+  updatedAt: comment.updatedAt,
+});
+
+/**
+ * PATCH /api/deliverables/:deliverableId/comments/:commentId
+ *
+ * Process 6.2 — Edit or resolve a comment.
+ *
+ * Authorization rules:
+ *   - Only the comment author can update `content`
+ *   - coordinator OR comment author can update `status`
+ *
+ * After a successful update, if no open comments with needsResponse: true remain
+ * on this deliverable, the Review record is reverted to 'in_progress'.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const updateCommentHandler = async (req, res) => {
+  const { deliverableId, commentId } = req.params;
+  const { userId, role } = req.user;
+  const { content, status } = req.body;
+
+  if (content === undefined && status === undefined) {
+    return res.status(400).json({
+      code: 'INVALID_REQUEST',
+      message: 'At least one of content or status must be provided',
+    });
+  }
+
+  if (status !== undefined && !VALID_STATUSES.includes(status)) {
+    return res.status(400).json({
+      code: 'INVALID_STATUS',
+      message: `status must be one of: ${VALID_STATUSES.join(', ')}`,
+    });
+  }
+
+  let comment;
+  try {
+    comment = await Comment.findOne({ commentId, deliverableId });
+  } catch (err) {
+    console.error('[updateCommentHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!comment) {
+    return res.status(404).json({ code: 'COMMENT_NOT_FOUND', message: 'Comment not found' });
+  }
+
+  const isAuthor = comment.authorId === userId;
+  const isCoordinator = role === 'coordinator';
+
+  // Only comment author can edit content
+  if (content !== undefined && !isAuthor) {
+    return res.status(403).json({
+      code: 'FORBIDDEN',
+      message: 'Only the comment author can edit content',
+    });
+  }
+
+  // Only coordinator or comment author can change status
+  if (status !== undefined && !isAuthor && !isCoordinator) {
+    return res.status(403).json({
+      code: 'FORBIDDEN',
+      message: 'Only the comment author or a coordinator can update status',
+    });
+  }
+
+  if (content !== undefined) comment.content = content;
+  if (status !== undefined) comment.status = status;
+
+  try {
+    await comment.save();
+  } catch (err) {
+    console.error('[updateCommentHandler] save error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to update comment' });
+  }
+
+  // If no open needsResponse comments remain, revert Review to 'in_progress'
+  try {
+    const openCount = await Comment.countDocuments({
+      deliverableId,
+      status: 'open',
+      needsResponse: true,
+    });
+    if (openCount === 0) {
+      await Review.updateOne({ deliverableId }, { $set: { status: 'in_progress' } });
+    }
+  } catch (err) {
+    console.warn('[updateCommentHandler] Review status revert failed:', err.message);
+  }
+
+  return res.status(200).json(formatComment(comment));
+};
+
+/**
+ * POST /api/deliverables/:deliverableId/comments/:commentId/reply
+ *
+ * Process 6.2 — Append a reply to a comment thread.
+ *
+ * Allowed roles: student, coordinator, committee_member.
+ * Students use this to respond to clarification requests.
+ *
+ * Side-effects:
+ *   - If comment.needsResponse === true, auto-sets comment.status = 'acknowledged'
+ *   - Dispatches an async notification to the comment author (fire-and-forget)
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const replyToCommentHandler = async (req, res) => {
+  const { deliverableId, commentId } = req.params;
+  const { userId } = req.user;
+  const { content } = req.body;
+
+  if (!content || typeof content !== 'string' || content.trim().length === 0) {
+    return res.status(400).json({ code: 'INVALID_REQUEST', message: 'content is required' });
+  }
+  if (content.length > 2000) {
+    return res.status(400).json({
+      code: 'INVALID_REQUEST',
+      message: 'content must be 2000 characters or fewer',
+    });
+  }
+
+  let comment;
+  try {
+    comment = await Comment.findOne({ commentId, deliverableId });
+  } catch (err) {
+    console.error('[replyToCommentHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!comment) {
+    return res.status(404).json({ code: 'COMMENT_NOT_FOUND', message: 'Comment not found' });
+  }
+
+  comment.replies.push({
+    replyId: `rpl_${uuidv4().replace(/-/g, '').slice(0, 12)}`,
+    authorId: userId,
+    content: content.trim(),
+    createdAt: new Date(),
+  });
+
+  // Auto-acknowledge when this comment was waiting for a response
+  if (comment.needsResponse && comment.status !== 'acknowledged') {
+    comment.status = 'acknowledged';
+  }
+
+  try {
+    await comment.save();
+  } catch (err) {
+    console.error('[replyToCommentHandler] save error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to save reply' });
+  }
+
+  // Fire-and-forget: notify the comment author that a reply has been posted
+  if (comment.authorId !== userId) {
+    axios
+      .post(
+        `${NOTIFICATION_SERVICE_URL}/api/notifications`,
+        {
+          type: 'comment_reply',
+          recipientId: comment.authorId,
+          commentId,
+          deliverableId,
+          replierId: userId,
+        },
+        { timeout: 5000 }
+      )
+      .catch((err) => {
+        console.warn('[replyToCommentHandler] Notification dispatch failed:', err.message);
+      });
+  }
+
+  return res.status(201).json(formatComment(comment));
+};
+
+module.exports = { updateCommentHandler, replyToCommentHandler };

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -4,10 +4,24 @@ const axios = require('axios');
 const { v4: uuidv4 } = require('uuid');
 const Comment = require('../models/Comment');
 const Review = require('../models/Review');
+const User = require('../models/User');
+const Deliverable = require('../models/Deliverable');
+const AuditLog = require('../models/AuditLog');
+const Group = require('../models/Group');
 
 const NOTIFICATION_SERVICE_URL = process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000';
 
 const VALID_STATUSES = ['open', 'resolved', 'acknowledged'];
+const VALID_COMMENT_TYPES = ['general', 'question', 'clarification_required', 'suggestion', 'praise'];
+const VALID_SORT_FIELDS = ['timestamp', 'author', 'section', 'status'];
+const VALID_STATUS_FILTERS = ['open', 'resolved', 'acknowledged'];
+
+const SORT_MAP = {
+  timestamp: { createdAt: 1 },
+  author: { authorName: 1, createdAt: 1 },
+  section: { sectionNumber: 1, createdAt: 1 },
+  status: { status: 1, createdAt: 1 },
+};
 
 /**
  * Serialize a Comment document for API responses.
@@ -43,26 +57,7 @@ const formatComment = (comment) => ({
  *
  * After a successful update, if no open comments with needsResponse: true remain
  * on this deliverable, the Review record is reverted to 'in_progress'.
-const User = require('../models/User');
-const Deliverable = require('../models/Deliverable');
-const Review = require('../models/Review');
-const Comment = require('../models/Comment');
-const AuditLog = require('../models/AuditLog');
-const Group = require('../models/Group');
-
-const NOTIFICATION_SERVICE_URL =
-  process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000';
-
-const VALID_COMMENT_TYPES = ['general', 'question', 'clarification_required', 'suggestion', 'praise'];
-const VALID_SORT_FIELDS = ['timestamp', 'author', 'section', 'status'];
-const VALID_STATUS_FILTERS = ['open', 'resolved', 'acknowledged'];
-
-const SORT_MAP = {
-  timestamp: { createdAt: 1 },
-  author: { authorName: 1, createdAt: 1 },
-  section: { sectionNumber: 1, createdAt: 1 },
-  status: { status: 1, createdAt: 1 },
-};
+ */
 
 /**
  * POST /api/deliverables/:deliverableId/comments
@@ -168,6 +163,7 @@ const updateCommentHandler = async (req, res) => {
  * Side-effects:
  *   - If comment.needsResponse === true, auto-sets comment.status = 'acknowledged'
  *   - Dispatches an async notification to the comment author (fire-and-forget)
+  */
 const addComment = async (req, res) => {
   const { deliverableId } = req.params;
   const { userId } = req.user;
@@ -418,7 +414,6 @@ const replyToCommentHandler = async (req, res) => {
   return res.status(201).json(formatComment(comment));
 };
 
-module.exports = { updateCommentHandler, replyToCommentHandler };
 const getComments = async (req, res) => {
   const { deliverableId } = req.params;
   const { role, groupId: userGroupId } = req.user;
@@ -496,4 +491,4 @@ const getComments = async (req, res) => {
   });
 };
 
-module.exports = { addComment, getComments };
+module.exports = { updateCommentHandler, replyToCommentHandler, addComment, getComments };

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -130,6 +130,17 @@ router.post(
 router.get('/:deliverableId/comments', getComments);
 
 /**
+ * PATCH /api/v1/deliverables/:deliverableId/comments/:commentId
+ * Process 6.2 — Edit content or update status of a comment.
+ * Accessible by committee_member, coordinator, and student.
+ */
+router.patch(
+  '/:deliverableId/comments/:commentId',
+  roleMiddleware(['committee_member', 'coordinator', 'student']),
+  updateCommentHandler
+);
+
+/**
  * POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply
  * Process 6 — Reply to an existing review comment.
  * Accessible by committee_member, coordinator, and student.

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -14,6 +14,7 @@ const {
   getDeliverableHandler,
   retractDeliverableHandler,
 } = require('../controllers/deliverableController');
+const { updateCommentHandler, replyToCommentHandler } = require('../controllers/reviewController');
 
 // All deliverable routes require a valid JWT; req.user = { userId, role, groupId }
 router.use(deliverableAuthMiddleware);
@@ -97,7 +98,7 @@ router.post(
 router.delete('/:deliverableId/retract', roleMiddleware(['coordinator']), retractDeliverableHandler);
 
 /**
- * POST /api/v1/deliverables/:deliverableId/comments
+ * POST /api/deliverables/:deliverableId/comments
  * Process 6 — Initiate a review comment on a deliverable.
  * Accessible by committee_member and coordinator. Students may NOT initiate comments.
  */
@@ -110,16 +111,26 @@ router.post(
 );
 
 /**
- * POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply
- * Process 6 — Reply to an existing review comment.
- * Accessible by committee_member, coordinator, and student.
+ * PATCH /api/deliverables/:deliverableId/comments/:commentId
+ * Process 6.2 — Edit content (author only) or update status (author or coordinator).
+ * After update: if no open needsResponse comments remain, Review reverts to 'in_progress'.
+ */
+router.patch(
+  '/:deliverableId/comments/:commentId',
+  updateCommentHandler
+);
+
+/**
+ * POST /api/deliverables/:deliverableId/comments/:commentId/reply
+ * Process 6.2 — Append a reply to a comment thread.
+ * Students use this to respond to clarification requests.
+ * Auto-acknowledges the comment if needsResponse was true.
+ * Notifies the comment author asynchronously.
  */
 router.post(
   '/:deliverableId/comments/:commentId/reply',
   roleMiddleware(['committee_member', 'coordinator', 'student']),
-  (_req, res) => {
-    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Comment reply endpoint not yet implemented' });
-  }
+  replyToCommentHandler
 );
 
 module.exports = router;

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -927,6 +927,29 @@ const options = {
           parameters: [
             { name: 'deliverableId', in: 'path', required: true, schema: { type: 'string', example: 'del_abc123' } },
             { name: 'commentId', in: 'path', required: true, schema: { type: 'string', example: 'cmt_abc123' } },
+          ],
+          requestBody: {
+            required: false,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    content: { type: 'string', example: 'Updated comment text.' },
+                    status: { type: 'string', enum: ['open', 'resolved', 'acknowledged'], example: 'resolved' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            200: { description: 'Comment updated' },
+            400: { description: 'No fields provided or invalid status' },
+            403: { description: 'Not the comment author (for content) or insufficient role (for status)' },
+            404: { description: 'Comment not found' },
+          },
+        },
+      },
       '/deliverables/{deliverableId}/comments': {
         post: {
           tags: ['Deliverables'],
@@ -942,9 +965,6 @@ const options = {
               'application/json': {
                 schema: {
                   type: 'object',
-                  properties: {
-                    content: { type: 'string', example: 'Updated comment text.' },
-                    status: { type: 'string', enum: ['open', 'resolved', 'acknowledged'], example: 'resolved' },
                   required: ['content'],
                   properties: {
                     content: { type: 'string', minLength: 1, maxLength: 5000, example: 'This section needs clarification.' },
@@ -957,40 +977,6 @@ const options = {
             },
           },
           responses: {
-            200: { description: 'Comment updated' },
-            400: { description: 'No fields provided or invalid status' },
-            403: { description: 'Not the comment author (for content) or insufficient role (for status)' },
-            404: { description: 'Comment not found' },
-          },
-        },
-      },
-      '/deliverables/{deliverableId}/comments/{commentId}/reply': {
-        post: {
-          tags: ['Deliverables'],
-          summary: 'Process 6.2 — Append a reply to a comment thread',
-          security: [{ bearerAuth: [] }],
-          parameters: [
-            { name: 'deliverableId', in: 'path', required: true, schema: { type: 'string', example: 'del_abc123' } },
-            { name: 'commentId', in: 'path', required: true, schema: { type: 'string', example: 'cmt_abc123' } },
-          ],
-          requestBody: {
-            required: true,
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  required: ['content'],
-                  properties: {
-                    content: { type: 'string', minLength: 1, maxLength: 2000, example: 'Here is our clarification...' },
-                  },
-                },
-              },
-            },
-          },
-          responses: {
-            201: { description: 'Reply added; comment returned with updated replies array' },
-            400: { description: 'content missing or exceeds 2000 chars' },
-            404: { description: 'Comment not found' },
             201: {
               description: 'Comment created',
               content: {
@@ -1015,7 +1001,7 @@ const options = {
                 },
               },
             },
-            400: { description: 'Validation error or no active review — `{ code: "INVALID_REQUEST" | "NO_ACTIVE_REVIEW" }`' },
+            400: { description: 'Validation error or no active review' },
             403: { description: 'Students cannot initiate comments' },
             404: { description: 'Deliverable not found' },
           },
@@ -1068,6 +1054,36 @@ const options = {
             },
             403: { description: 'Student viewing another group\'s deliverable' },
             404: { description: 'Deliverable not found' },
+          },
+        },
+      },
+      '/deliverables/{deliverableId}/comments/{commentId}/reply': {
+        post: {
+          tags: ['Deliverables'],
+          summary: 'Process 6.2 — Append a reply to a comment thread',
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: 'deliverableId', in: 'path', required: true, schema: { type: 'string', example: 'del_abc123' } },
+            { name: 'commentId', in: 'path', required: true, schema: { type: 'string', example: 'cmt_abc123' } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['content'],
+                  properties: {
+                    content: { type: 'string', minLength: 1, maxLength: 2000, example: 'Here is our clarification...' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            201: { description: 'Reply added; comment returned with updated replies array' },
+            400: { description: 'content missing or exceeds 2000 chars' },
+            404: { description: 'Comment not found' },
           },
         },
       },

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -47,8 +47,8 @@ const options = {
                   type: 'object',
                   required: ['email', 'password'],
                   properties: {
-                    email: { type: 'string', example: 'alice@university.edu' },
-                    password: { type: 'string', example: 'Password123!' },
+                    email: { type: 'string', example: 'test.student@example.edu.tr' },
+                    password: { type: 'string', example: 'Test@1234' },
                   },
                 },
               },
@@ -916,6 +916,67 @@ const options = {
             200: { description: 'Deliverable submitted successfully' },
             400: { description: 'Validation failed or invalid request' },
             404: { description: 'Staging record not found' },
+          },
+        },
+      },
+      '/deliverables/{deliverableId}/comments/{commentId}': {
+        patch: {
+          tags: ['Deliverables'],
+          summary: 'Process 6.2 — Edit content or update status of a comment',
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: 'deliverableId', in: 'path', required: true, schema: { type: 'string', example: 'del_abc123' } },
+            { name: 'commentId', in: 'path', required: true, schema: { type: 'string', example: 'cmt_abc123' } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    content: { type: 'string', example: 'Updated comment text.' },
+                    status: { type: 'string', enum: ['open', 'resolved', 'acknowledged'], example: 'resolved' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            200: { description: 'Comment updated' },
+            400: { description: 'No fields provided or invalid status' },
+            403: { description: 'Not the comment author (for content) or insufficient role (for status)' },
+            404: { description: 'Comment not found' },
+          },
+        },
+      },
+      '/deliverables/{deliverableId}/comments/{commentId}/reply': {
+        post: {
+          tags: ['Deliverables'],
+          summary: 'Process 6.2 — Append a reply to a comment thread',
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            { name: 'deliverableId', in: 'path', required: true, schema: { type: 'string', example: 'del_abc123' } },
+            { name: 'commentId', in: 'path', required: true, schema: { type: 'string', example: 'cmt_abc123' } },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['content'],
+                  properties: {
+                    content: { type: 'string', minLength: 1, maxLength: 2000, example: 'Here is our clarification...' },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            201: { description: 'Reply added; comment returned with updated replies array' },
+            400: { description: 'content missing or exceeds 2000 chars' },
+            404: { description: 'Comment not found' },
           },
         },
       },


### PR DESCRIPTION
- Added `PATCH /api/deliverables/:deliverableId/comments/:commentId` — allows comment author to edit content, and author or coordinator to update status (`open`, `resolved`, `acknowledged`). Automatically reverts Review status to `in_progress` when no open `needsResponse` comments remain.
- Added `POST /api/deliverables/:deliverableId/comments/:commentId/reply` — allows students, coordinators, and committee members to reply to a comment thread. Auto-acknowledges the comment if `needsResponse` was true. Dispatches async notification to the comment author.
- Replaced 501 stub for reply route in `deliverables.js`
- Added Swagger docs for both endpoints
