### PR TITLE
feat(notifications): implement unified deliverable & review notification service (#177 + #191)

### DIFF
--- a/backend/scripts/seed-test-general.js
+++ b/backend/scripts/seed-test-general.js
@@ -15,6 +15,7 @@ const AdvisorAssignment = require('../src/models/AdvisorAssignment');
 const AuditLog          = require('../src/models/AuditLog');
 const Deliverable       = require('../src/models/Deliverable');
 const SprintRecord      = require('../src/models/SprintRecord');
+const SprintConfig      = require('../src/models/SprintConfig');
 
 // Utilities
 const { hashPassword }        = require('../src/utils/password');
@@ -40,7 +41,7 @@ const generateId = (prefix) => `${prefix}_${uuidv4().split('-')[0]}`;
  */
 async function seedUsers() {
   console.log('🌱 Seeding users...');
-  
+
   const users = {};
   for (const [role, creds] of Object.entries(TEST_USERS)) {
     const userRole = role.includes('student') ? 'student'
@@ -69,7 +70,7 @@ async function seedUsers() {
  */
 async function seedCommittees(professorId) {
   console.log('🌱 Seeding committees...');
-  
+
   const committees = [];
   for (let i = 1; i <= 2; i++) {
     const committee = await Committee.create({
@@ -96,9 +97,9 @@ async function seedCommittees(professorId) {
  */
 async function seedGroups(users, committees) {
   console.log('🌱 Seeding groups...');
-  
+
   const groups = [];
-  
+
   // Group 1: Alice as leader, Bob as member
   const group1 = await Group.create({
     groupId: generateId('grp'),
@@ -138,7 +139,7 @@ async function seedGroups(users, committees) {
  */
 async function seedScheduleWindows() {
   console.log('🌱 Seeding schedule windows...');
-  
+
   const now = new Date();
   const windows = [];
 
@@ -171,7 +172,7 @@ async function seedScheduleWindows() {
  */
 async function seedAdvisorSetup(groups, users) {
   console.log('🌱 Seeding advisor requests & assignments...');
-  
+
   const request = await AdvisorRequest.create({
     requestId: generateId('arq'),
     groupId: groups[0].groupId,
@@ -202,7 +203,7 @@ async function seedAdvisorSetup(groups, users) {
  */
 async function seedAuditLogs(users) {
   console.log('🌱 Seeding audit logs...');
-  
+
   const actions = [
     { action: 'ACCOUNT_CREATED', userId: users.student1.userId, description: 'Student 1 account created' },
     { action: 'LOGIN_SUCCESS', userId: users.student1.userId, description: 'Student 1 login' },
@@ -233,7 +234,7 @@ async function seedAuditLogs(users) {
  */
 async function seedSprintRecords(groups, committees) {
   console.log('🌱 Seeding sprint records...');
-  
+
   const sprints = [];
 
   for (let i = 1; i <= 2; i++) {
@@ -256,31 +257,72 @@ async function seedSprintRecords(groups, committees) {
 }
 
 /**
- * Create sample deliverables
+ * Create sprint configs (deadlines) for each sprint + deliverable type combination.
+ * Required by Process 5.4 (validate-deadline).
  */
-async function seedDeliverables(groups, committees) {
+async function seedSprintConfigs(sprints) {
+  console.log('🌱 Seeding sprint configs (deadlines)...');
+
+  const configs = [];
+  const deliverableTypes = [
+    'proposal',
+    'statement_of_work',
+    'demo',
+    'interim_report',
+    'final_report',
+  ];
+
+  const uniqueSprintIds = [...new Set(sprints.map((s) => s.sprintId))];
+
+  for (const sprintId of uniqueSprintIds) {
+    for (const deliverableType of deliverableTypes) {
+      const config = await SprintConfig.create({
+        sprintId,
+        deliverableType,
+        deadline: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000), // 30 gün sonra
+        description: `Test deadline — ${sprintId} / ${deliverableType}`,
+      });
+      configs.push(config);
+      console.log(`  ✓ Created sprint config: ${sprintId} / ${deliverableType}`);
+    }
+  }
+
+  return configs;
+}
+
+/**
+ * Create sample deliverables — aligned with current Deliverable schema (D4).
+ */
+async function seedDeliverables(groups, users, sprints) {
   console.log('🌱 Seeding deliverables...');
-  
+
   const deliverables = [];
   const types = ['proposal', 'statement_of_work', 'demo'];
 
   for (let i = 0; i < groups.length; i++) {
-    const deliverableType = types[i % types.length];
+    const group  = groups[i];
+    const leader = i === 0 ? users.student1 : users.student3;
+    const sprint = sprints.find((s) => s.groupId === group.groupId) ?? sprints[i * 2];
+    const type   = types[i % types.length];
+
     const deliverable = await Deliverable.create({
-      deliverableId: generateId('del'),
-      groupId: groups[i].groupId,
-      deliverableType,
-      submittedBy: groups[i].members[0].userId,
-      submittedAt: new Date(),
-      filePath: `uploads/${groups[i].groupId}/${deliverableType}_v1.pdf`,
-      fileSize: 102400,
-      fileHash: `hash_${generateId('h')}`,
-      format: 'pdf',
-      status: 'under_review',
+      deliverableId:   generateId('del'),
+      groupId:         group.groupId,
+      deliverableType: type,
+      sprintId:        sprint?.sprintId ?? null,
+      submittedBy:     leader.userId,
+      description:     `Sample ${type} deliverable for ${group.groupName}`,
+      filePath:        `s3://deliverables/${group.groupId}/${type}_v1.pdf`,
+      fileSize:        204800, // 200 KB
+      fileHash:        uuidv4().replace(/-/g, ''),
+      format:          'pdf',
+      status:          'accepted',
+      version:         1,
+      submittedAt:     new Date(),
     });
 
     deliverables.push(deliverable);
-    console.log(`  ✓ Created deliverable: ${groups[i].groupName} - ${deliverableType}`);
+    console.log(`  ✓ Created deliverable: ${group.groupName} - ${type}`);
   }
 
   return deliverables;
@@ -307,6 +349,7 @@ async function run() {
     await AuditLog.deleteMany({ auditId: { $regex: /^aud_/ } });
     await SprintRecord.deleteMany({ sprintRecordId: { $regex: /^spr_/ } });
     await Deliverable.deleteMany({ deliverableId: { $regex: /^del_/ } });
+    await SprintConfig.deleteMany({ sprintId: { $regex: /^sprint_/ } });
 
     console.log('  ✓ Cleaned up old test data\n');
 
@@ -329,10 +372,13 @@ async function run() {
     await seedAuditLogs(users);
     console.log();
 
-    const sprints      = await seedSprintRecords(groups, committees);
+    const sprints = await seedSprintRecords(groups, committees);
     console.log();
 
-    const deliverables = await seedDeliverables(groups, committees);
+    const sprintConfigs = await seedSprintConfigs(sprints);
+    console.log();
+
+    const deliverables = await seedDeliverables(groups, users, sprints);
     console.log();
 
     // Create a Review for each deliverable so comment endpoints work immediately
@@ -387,6 +433,13 @@ async function run() {
     for (const s of sprints) {
       const g = groups.find(g => g.groupId === s.groupId);
       console.log(`  ${(g?.groupName ?? s.groupId).padEnd(22)} | sprintRecordId: ${s.sprintRecordId.padEnd(16)} | sprintId: ${s.sprintId}`);
+    }
+
+    // Sprint Configs
+    console.log(`\n⏰ SPRINT CONFIGS (DEADLINES)`);
+    console.log(sep);
+    for (const c of sprintConfigs) {
+      console.log(`  ${c.sprintId.padEnd(16)} | type: ${c.deliverableType.padEnd(20)} | deadline: ${c.deadline.toISOString()}`);
     }
 
     // Tokens

--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -5,6 +5,7 @@ const jwt = require('jsonwebtoken');
 const { v4: uuidv4 } = require('uuid');
 const Group = require('../models/Group');
 const Committee = require('../models/Committee');
+const User = require('../models/User');
 const AuditLog = require('../models/AuditLog');
 const DeliverableStaging = require('../models/DeliverableStaging');
 const Deliverable = require('../models/Deliverable');
@@ -12,6 +13,11 @@ const mongoose = require('mongoose');
 const { hashData } = require('../utils/fileHash');
 const { runFormatValidation, runDeadlineValidation } = require('../services/deliverableValidationService');
 const { persistDeliverableFile, createFinalRecord } = require('../services/storageService');
+const {
+  notifyCommittee,
+  notifyCoordinator,
+  notifyStudents,
+} = require('../services/deliverableNotificationService');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
 
@@ -628,6 +634,112 @@ const retractDeliverableHandler = async (req, res) => {
   return res.status(200).json({ deliverableId, status: 'retracted' });
 };
 
+/**
+ * POST /api/deliverables/:deliverableId/notify
+ *
+ * Process 5.6 — Queue post-submission notifications to committee, coordinator, and students.
+ *
+ * Prerequisites:
+ *   1. JWT (any authenticated role) — enforced by route middleware
+ *   2. Deliverable must exist
+ *   3. Notifications must not have been sent already (notifiedAt is null)
+ *
+ * Returns 202 immediately; notifications are dispatched asynchronously.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const notifyDeliverableHandler = async (req, res) => {
+  const { deliverableId } = req.params;
+
+  let deliverable;
+  try {
+    deliverable = await Deliverable.findOne({ deliverableId }).lean();
+  } catch (err) {
+    console.error('[notifyDeliverableHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!deliverable) {
+    return res.status(404).json({ code: 'DELIVERABLE_NOT_FOUND', message: 'Deliverable not found' });
+  }
+
+  if (deliverable.notifiedAt) {
+    return res.status(409).json({
+      code: 'ALREADY_NOTIFIED',
+      message: 'Notifications have already been sent for this deliverable',
+    });
+  }
+
+  // Mark notifiedAt before dispatching to prevent duplicate sends on concurrent calls.
+  try {
+    await Deliverable.updateOne({ deliverableId }, { $set: { notifiedAt: new Date() } });
+  } catch (err) {
+    console.error('[notifyDeliverableHandler] notifiedAt update error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to mark deliverable as notified' });
+  }
+
+  // Count expected tasks for the response (best-effort; uses cached lean reads).
+  const { groupId } = deliverable;
+  let tasksQueued = 0;
+  try {
+    const [group, coordinatorCount] = await Promise.all([
+      Group.findOne({ groupId }).select('committeeId members leaderId').lean(),
+      User.countDocuments({ role: { $in: ['coordinator', 'admin'] }, accountStatus: 'active' }),
+    ]);
+
+    if (group?.committeeId) {
+      const committee = await Committee.findOne({ committeeId: group.committeeId })
+        .select('advisorIds juryIds')
+        .lean();
+      if (committee) {
+        tasksQueued += new Set([
+          ...(committee.advisorIds || []),
+          ...(committee.juryIds || []),
+        ]).size;
+      }
+    }
+
+    tasksQueued += coordinatorCount;
+
+    const acceptedIds = (group?.members || [])
+      .filter((m) => m.status === 'accepted')
+      .map((m) => m.userId);
+    if (group?.leaderId && !acceptedIds.includes(group.leaderId)) {
+      acceptedIds.push(group.leaderId);
+    }
+    tasksQueued += acceptedIds.length;
+  } catch (err) {
+    console.error('[notifyDeliverableHandler] task count error (non-fatal):', err.message);
+  }
+
+  // Fire-and-forget — response is already sent before these complete.
+  Promise.allSettled([
+    notifyCommittee(deliverableId, groupId),
+    notifyCoordinator(deliverableId, groupId),
+    notifyStudents(deliverableId, groupId),
+  ]).catch((err) => {
+    console.error('[notifyDeliverableHandler] Async dispatch error:', err.message);
+  });
+
+  AuditLog.create({
+    action: 'DELIVERABLE_NOTIFIED',
+    actorId: req.user?.userId || 'system',
+    groupId,
+    payload: { deliverableId, tasksQueued },
+    ipAddress: req.ip || null,
+    userAgent: req.headers['user-agent'] || null,
+  }).catch((err) => {
+    console.error('[notifyDeliverableHandler] Audit log error:', err.message);
+  });
+
+  return res.status(202).json({
+    deliverableId,
+    tasksQueued,
+    estimatedDeliveryMinutes: 5,
+  });
+};
+
 module.exports = {
   validateGroup,
   submitDeliverable,
@@ -637,4 +749,5 @@ module.exports = {
   listDeliverablesHandler,
   getDeliverableHandler,
   retractDeliverableHandler,
+  notifyDeliverableHandler,
 };

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -113,6 +113,14 @@ const auditLogSchema = new mongoose.Schema(
         'COMMENT_REPLIED',
         'COMMENT_RESOLVED',
 
+        // --- Deliverable Storage (Process 5.5) ---
+        'DELIVERABLE_STORED',
+
+        // --- Deliverable Notifications (Process 5.6 & 6) ---
+        'NOTIFICATION_SENT',
+        'NOTIFICATION_FAILED',
+        'DELIVERABLE_NOTIFIED',
+
         // --- System & Test ---
         'TEST_ACTION',
       ],

--- a/backend/src/models/Deliverable.js
+++ b/backend/src/models/Deliverable.js
@@ -104,6 +104,10 @@ const deliverableSchema = new mongoose.Schema(
       required: true,
       default: () => new Date(),
     },
+    notifiedAt: {
+      type: Date,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -14,6 +14,7 @@ const {
   listDeliverablesHandler,
   getDeliverableHandler,
   retractDeliverableHandler,
+  notifyDeliverableHandler,
 } = require('../controllers/deliverableController');
 const { updateCommentHandler, replyToCommentHandler } = require('../controllers/reviewController');
 const { addComment, getComments } = require('../controllers/reviewController');
@@ -110,6 +111,14 @@ router.post(
  * Sets status = 'retracted'; does not delete the file from disk.
  */
 router.delete('/:deliverableId/retract', roleMiddleware(['coordinator']), retractDeliverableHandler);
+
+/**
+ * POST /api/deliverables/:deliverableId/notify
+ * Process 5.6 — Queue post-submission notifications to committee, coordinator, and students.
+ * Requires JWT. Returns 202 immediately; notifications are delivered asynchronously.
+ * Returns 409 if notifications have already been sent (notifiedAt is set).
+ */
+router.post('/:deliverableId/notify', notifyDeliverableHandler);
 
 /**
  * POST /api/deliverables/:deliverableId/comments

--- a/backend/src/services/deliverableNotificationService.js
+++ b/backend/src/services/deliverableNotificationService.js
@@ -1,0 +1,619 @@
+'use strict';
+
+/**
+ * Deliverable & Review Notification Service
+ *
+ * Handles all stakeholder email notifications for:
+ *   - Process 5.6: Post-submission (committee, coordinator, students)
+ *   - Process 6:   Review workflow (assignment, clarifications, completion)
+ *
+ * Infrastructure:
+ *   - Nodemailer with SMTP config from env vars (SMTP_HOST/EMAIL_HOST, etc.)
+ *   - Single transporter instance reused across all calls
+ *   - All sends are async and non-blocking
+ *   - Retry up to 3 times with exponential backoff (1 s, 2 s, 4 s)
+ *   - Failures logged to audit trail; no exceptions thrown to callers
+ *   - Audit trail: { type, recipientId, deliverableId, sentAt, success,
+ *                    templateUsed, attempts, failureReason }
+ */
+
+const path = require('path');
+const fs = require('fs');
+const nodemailer = require('nodemailer');
+
+const Group = require('../models/Group');
+const Committee = require('../models/Committee');
+const User = require('../models/User');
+const Review = require('../models/Review');
+const Comment = require('../models/Comment');
+const Deliverable = require('../models/Deliverable');
+const AuditLog = require('../models/AuditLog');
+
+// ─── Retry constants ──────────────────────────────────────────────────────────
+
+const MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 1000; // 1 s → 2 s → 4 s
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ─── Template loading ─────────────────────────────────────────────────────────
+
+const TEMPLATE_DIR = path.join(__dirname, '../templates');
+
+const _loadTemplate = (filename) => {
+  try {
+    return fs.readFileSync(path.join(TEMPLATE_DIR, filename), 'utf8');
+  } catch {
+    return null;
+  }
+};
+
+// Cache templates at module-load time so disk I/O happens once.
+const _templateCache = {
+  'deliverable-committee.txt': _loadTemplate('deliverable-committee.txt'),
+  'deliverable-coordinator.txt': _loadTemplate('deliverable-coordinator.txt'),
+  'deliverable-student.txt': _loadTemplate('deliverable-student.txt'),
+  'review-assignment.txt': _loadTemplate('review-assignment.txt'),
+  'review-clarification-request.txt': _loadTemplate('review-clarification-request.txt'),
+  'review-clarification-reply.txt': _loadTemplate('review-clarification-reply.txt'),
+  'review-completed-coordinator.txt': _loadTemplate('review-completed-coordinator.txt'),
+  'review-completed-student.txt': _loadTemplate('review-completed-student.txt'),
+  'review-completed-committee.txt': _loadTemplate('review-completed-committee.txt'),
+};
+
+/**
+ * Render a named template by replacing {{key}} placeholders with vars values.
+ * Returns empty string if the template file was not found.
+ */
+const renderTemplate = (templateName, vars = {}) => {
+  const tmpl = _templateCache[templateName] || '';
+  return Object.entries(vars).reduce(
+    (acc, [key, val]) =>
+      acc.replaceAll(`{{${key}}}`, val != null ? String(val) : ''),
+    tmpl
+  );
+};
+
+// ─── Transporter (singleton) ──────────────────────────────────────────────────
+
+const _isDevMode = () => {
+  const user = process.env.SMTP_USER || process.env.EMAIL_USER;
+  if (!user || user === 'your-email@gmail.com') return true;
+  return !(
+    process.env.SMTP_HOST ||
+    process.env.EMAIL_HOST ||
+    process.env.EMAIL_SERVICE
+  );
+};
+
+let _transporter = null;
+
+const _getTransporter = () => {
+  if (_transporter) return _transporter;
+  if (_isDevMode()) return null;
+
+  const host = process.env.SMTP_HOST || process.env.EMAIL_HOST;
+  const port = parseInt(process.env.SMTP_PORT || process.env.EMAIL_PORT || '587', 10);
+  const user = process.env.SMTP_USER || process.env.EMAIL_USER;
+  const pass = process.env.SMTP_PASS || process.env.EMAIL_PASSWORD;
+
+  if (host) {
+    _transporter = nodemailer.createTransport({
+      host,
+      port,
+      secure: process.env.EMAIL_SECURE === 'true',
+      auth: { user, pass },
+    });
+  } else {
+    _transporter = nodemailer.createTransport({
+      service: process.env.EMAIL_SERVICE || 'gmail',
+      auth: { user, pass },
+    });
+  }
+  return _transporter;
+};
+
+// ─── Error classification ─────────────────────────────────────────────────────
+
+const isTransientError = (err) => {
+  if (!err) return false;
+  const code = err.code || '';
+  const responseCode = err.responseCode || 0;
+  const message = (err.message || '').toLowerCase();
+
+  if (['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'ECONNREFUSED', 'EHOSTUNREACH'].includes(code)) {
+    return true;
+  }
+  if (responseCode >= 400 && responseCode < 500 && responseCode !== 452) {
+    return true;
+  }
+  if (message.includes('connection timed out') || message.includes('network')) {
+    return true;
+  }
+  return false;
+};
+
+// ─── Core send with retry ─────────────────────────────────────────────────────
+
+/**
+ * Send mail with up to MAX_ATTEMPTS tries and exponential backoff.
+ * In dev mode (no SMTP configured) logs to console and returns success.
+ *
+ * @returns {{ success, messageId, attempts, error?, permanent? }}
+ */
+const sendWithRetry = async (mailOptions) => {
+  const transporter = _getTransporter();
+
+  if (!transporter) {
+    // Dev / test mode — log and return immediately
+    console.log(
+      `[NOTIFY] [DEV] To: ${mailOptions.to} | Subject: ${mailOptions.subject}`
+    );
+    return { success: true, messageId: 'dev-mode', attempts: 0 };
+  }
+
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const info = await transporter.sendMail(mailOptions);
+      return { success: true, messageId: info.messageId, attempts: attempt };
+    } catch (err) {
+      lastError = err;
+      if (!isTransientError(err)) {
+        console.error(
+          `[NOTIFY] Permanent failure (attempt ${attempt}) to ${mailOptions.to}:`,
+          err.message
+        );
+        return { success: false, error: err.message, attempts: attempt, permanent: true };
+      }
+      if (attempt < MAX_ATTEMPTS) {
+        const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
+        console.warn(
+          `[NOTIFY] Transient failure (attempt ${attempt}/${MAX_ATTEMPTS}), retrying in ${delay}ms:`,
+          err.message
+        );
+        await sleep(delay);
+      } else {
+        console.error(
+          `[NOTIFY] All ${MAX_ATTEMPTS} attempts exhausted for ${mailOptions.to}:`,
+          err.message
+        );
+      }
+    }
+  }
+  return { success: false, error: lastError?.message, attempts: MAX_ATTEMPTS, permanent: false };
+};
+
+// ─── Audit trail ──────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort audit log. Never throws.
+ */
+const logNotification = ({ type, recipientId, deliverableId, sentAt, success, templateUsed, attempts, failureReason }) => {
+  AuditLog.create({
+    action: success ? 'NOTIFICATION_SENT' : 'NOTIFICATION_FAILED',
+    actorId: 'system',
+    targetId: recipientId || null,
+    groupId: null,
+    payload: {
+      type,
+      recipientId: recipientId || null,
+      deliverableId: deliverableId || null,
+      sentAt: sentAt || new Date(),
+      success,
+      templateUsed,
+      attempts,
+      failureReason: failureReason || null,
+    },
+  }).catch((err) => {
+    console.error(`[NOTIFY] Audit log failed (non-fatal):`, err.message);
+  });
+};
+
+// ─── Low-level email dispatcher ───────────────────────────────────────────────
+
+const _fromAddress = () => {
+  const user = process.env.SMTP_USER || process.env.EMAIL_USER || 'noreply@system.local';
+  return `"Senior Project System" <${user}>`;
+};
+
+/**
+ * Send one notification email, log result to audit trail, and return the send result.
+ * Never throws.
+ */
+const _sendOne = async ({ to, subject, text, templateName, recipientId, deliverableId, notificationType }) => {
+  try {
+    const result = await sendWithRetry({ from: _fromAddress(), to, subject, text });
+    const sentAt = new Date();
+    logNotification({
+      type: notificationType,
+      recipientId,
+      deliverableId,
+      sentAt,
+      success: result.success,
+      templateUsed: templateName,
+      attempts: result.attempts,
+      failureReason: result.success ? null : result.error,
+    });
+    return { recipientId, success: result.success, attempts: result.attempts };
+  } catch (err) {
+    console.error(`[NOTIFY] _sendOne unexpected error for ${recipientId}:`, err.message);
+    logNotification({
+      type: notificationType,
+      recipientId,
+      deliverableId,
+      sentAt: new Date(),
+      success: false,
+      templateUsed: templateName,
+      attempts: 0,
+      failureReason: err.message,
+    });
+    return { recipientId, success: false, attempts: 0 };
+  }
+};
+
+// ─── Data queries (D1 / D2 / D3) ─────────────────────────────────────────────
+
+/**
+ * D3 — committee member users for a group's assigned committee.
+ * Returns [{ userId, email }]
+ */
+const _getCommitteeMemberUsers = async (groupId) => {
+  const group = await Group.findOne({ groupId }).select('committeeId').lean();
+  if (!group?.committeeId) return [];
+  const committee = await Committee.findOne({ committeeId: group.committeeId })
+    .select('advisorIds juryIds')
+    .lean();
+  if (!committee) return [];
+  const memberIds = [
+    ...new Set([...(committee.advisorIds || []), ...(committee.juryIds || [])]),
+  ];
+  return User.find({ userId: { $in: memberIds } }).select('userId email').lean();
+};
+
+/**
+ * D1 — active coordinator/admin users.
+ * Returns [{ userId, email }]
+ */
+const _getCoordinatorUsers = async () =>
+  User.find({ role: { $in: ['coordinator', 'admin'] }, accountStatus: 'active' })
+    .select('userId email')
+    .lean();
+
+/**
+ * D2 — accepted group member users (includes leader).
+ * Returns [{ userId, email }]
+ */
+const _getGroupMemberUsers = async (groupId) => {
+  const group = await Group.findOne({ groupId }).select('members leaderId').lean();
+  if (!group) return [];
+  const acceptedIds = (group.members || [])
+    .filter((m) => m.status === 'accepted')
+    .map((m) => m.userId);
+  if (group.leaderId && !acceptedIds.includes(group.leaderId)) {
+    acceptedIds.push(group.leaderId);
+  }
+  return User.find({ userId: { $in: acceptedIds } }).select('userId email').lean();
+};
+
+// ─── Process 5.6 Notification Functions ──────────────────────────────────────
+
+/**
+ * Notify all committee members that a new deliverable is ready for review.
+ * Trigger: POST /api/deliverables/:deliverableId/notify
+ * Template: deliverable-committee.txt
+ *
+ * @param {string} deliverableId
+ * @param {string} groupId
+ * @returns {Promise<Array>} per-recipient send results
+ */
+const notifyCommittee = async (deliverableId, groupId) => {
+  let groupName = groupId;
+  try {
+    const g = await Group.findOne({ groupId }).select('groupName').lean();
+    if (g?.groupName) groupName = g.groupName;
+  } catch { /* non-fatal */ }
+
+  const members = await _getCommitteeMemberUsers(groupId);
+  return Promise.all(
+    members.map(({ userId, email }) => {
+      const text = renderTemplate('deliverable-committee.txt', { id: deliverableId, groupName });
+      return _sendOne({
+        to: email,
+        subject: `New Deliverable #${deliverableId} from ${groupName} is ready for review`,
+        text: text || `New Deliverable #${deliverableId} from ${groupName} is ready for review.`,
+        templateName: 'deliverable-committee.txt',
+        recipientId: userId,
+        deliverableId,
+        notificationType: 'COMMITTEE_DELIVERABLE_SUBMITTED',
+      });
+    })
+  );
+};
+
+/**
+ * Notify coordinator/admin that a deliverable was submitted.
+ * Trigger: POST /api/deliverables/:deliverableId/notify
+ * Template: deliverable-coordinator.txt
+ *
+ * @param {string} deliverableId
+ * @param {string} groupId
+ * @returns {Promise<Array>}
+ */
+const notifyCoordinator = async (deliverableId, groupId) => {
+  let groupName = groupId;
+  try {
+    const g = await Group.findOne({ groupId }).select('groupName').lean();
+    if (g?.groupName) groupName = g.groupName;
+  } catch { /* non-fatal */ }
+
+  const coordinators = await _getCoordinatorUsers();
+  return Promise.all(
+    coordinators.map(({ userId, email }) => {
+      const text = renderTemplate('deliverable-coordinator.txt', { id: deliverableId, groupName });
+      return _sendOne({
+        to: email,
+        subject: `Deliverable #${deliverableId} submitted by ${groupName}`,
+        text: text || `Deliverable #${deliverableId} submitted by ${groupName}.`,
+        templateName: 'deliverable-coordinator.txt',
+        recipientId: userId,
+        deliverableId,
+        notificationType: 'COORDINATOR_DELIVERABLE_SUBMITTED',
+      });
+    })
+  );
+};
+
+/**
+ * Notify all group members that their submission was received.
+ * Trigger: POST /api/deliverables/:deliverableId/notify
+ * Template: deliverable-student.txt
+ *
+ * @param {string} deliverableId
+ * @param {string} groupId
+ * @returns {Promise<Array>}
+ */
+const notifyStudents = async (deliverableId, groupId) => {
+  const timestamp = new Date().toISOString();
+  const members = await _getGroupMemberUsers(groupId);
+  return Promise.all(
+    members.map(({ userId, email }) => {
+      const text = renderTemplate('deliverable-student.txt', { id: deliverableId, timestamp });
+      return _sendOne({
+        to: email,
+        subject: `Submission received — Deliverable #${deliverableId}`,
+        text: text || `Submission received — ID #${deliverableId}, Time: ${timestamp}.`,
+        templateName: 'deliverable-student.txt',
+        recipientId: userId,
+        deliverableId,
+        notificationType: 'STUDENT_DELIVERABLE_RECEIVED',
+      });
+    })
+  );
+};
+
+// ─── Process 6 Notification Functions ────────────────────────────────────────
+
+/**
+ * Notify a reviewer they have been assigned to a deliverable.
+ * Trigger: Issue #186 (review assignment endpoint)
+ * Template: review-assignment.txt
+ *
+ * @param {string} reviewId
+ * @param {string} memberId
+ * @returns {Promise<object|null>}
+ */
+const notifyReviewerAssigned = async (reviewId, memberId) => {
+  const review = await Review.findOne({ reviewId }).lean();
+  if (!review) return null;
+
+  const deliverable = await Deliverable.findOne({ deliverableId: review.deliverableId }).lean();
+  const group = deliverable
+    ? await Group.findOne({ groupId: deliverable.groupId }).select('groupName').lean()
+    : null;
+
+  const user = await User.findOne({ userId: memberId }).select('userId email').lean();
+  if (!user) return null;
+
+  const text = renderTemplate('review-assignment.txt', {
+    deliverableId: review.deliverableId,
+    groupName: group?.groupName || review.groupId,
+    deadline: review.deadline
+      ? new Date(review.deadline).toISOString().split('T')[0]
+      : 'TBD',
+    instructions: review.instructions || 'No specific instructions provided.',
+  });
+
+  return _sendOne({
+    to: user.email,
+    subject: `Review assignment: Deliverable #${review.deliverableId}`,
+    text: text || `You have been assigned to review deliverable #${review.deliverableId}.`,
+    templateName: 'review-assignment.txt',
+    recipientId: memberId,
+    deliverableId: review.deliverableId,
+    notificationType: 'REVIEWER_ASSIGNED',
+  });
+};
+
+/**
+ * Notify group members that a clarification was requested on their deliverable.
+ * Trigger: Issue #188 when needsResponse: true comment is added
+ * Template: review-clarification-request.txt
+ *
+ * @param {string} commentId
+ * @param {string} groupId
+ * @returns {Promise<Array>}
+ */
+const notifyClarificationRequested = async (commentId, groupId) => {
+  const comment = await Comment.findOne({ commentId }).lean();
+  if (!comment) return [];
+
+  const members = await _getGroupMemberUsers(groupId);
+  return Promise.all(
+    members.map(({ userId, email }) => {
+      const text = renderTemplate('review-clarification-request.txt', {
+        deliverableId: comment.deliverableId,
+        commentContent: comment.content,
+      });
+      return _sendOne({
+        to: email,
+        subject: `Clarification requested on your deliverable #${comment.deliverableId}`,
+        text: text || `Clarification requested on your deliverable #${comment.deliverableId}: ${comment.content}`,
+        templateName: 'review-clarification-request.txt',
+        recipientId: userId,
+        deliverableId: comment.deliverableId,
+        notificationType: 'CLARIFICATION_REQUESTED',
+      });
+    })
+  );
+};
+
+/**
+ * Notify the reviewer that a student replied to their clarification.
+ * Trigger: Issue #189 when a student posts a reply to a clarification
+ * Template: review-clarification-reply.txt
+ *
+ * @param {string} commentId
+ * @param {string} reviewerId
+ * @returns {Promise<object|null>}
+ */
+const notifyStudentReplied = async (commentId, reviewerId) => {
+  const comment = await Comment.findOne({ commentId }).lean();
+  if (!comment) return null;
+
+  const deliverable = await Deliverable.findOne({ deliverableId: comment.deliverableId }).lean();
+  const group = deliverable
+    ? await Group.findOne({ groupId: deliverable.groupId }).select('groupName').lean()
+    : null;
+  const lastReply =
+    comment.replies && comment.replies.length > 0
+      ? comment.replies[comment.replies.length - 1]
+      : null;
+
+  const user = await User.findOne({ userId: reviewerId }).select('userId email').lean();
+  if (!user) return null;
+
+  const text = renderTemplate('review-clarification-reply.txt', {
+    groupName: group?.groupName || deliverable?.groupId || '',
+    deliverableId: comment.deliverableId,
+    replyContent: lastReply?.content || '',
+  });
+
+  return _sendOne({
+    to: user.email,
+    subject: `Reply to your clarification on deliverable #${comment.deliverableId}`,
+    text: text || `A group replied to your clarification on deliverable #${comment.deliverableId}.`,
+    templateName: 'review-clarification-reply.txt',
+    recipientId: reviewerId,
+    deliverableId: comment.deliverableId,
+    notificationType: 'STUDENT_REPLIED',
+  });
+};
+
+/**
+ * Notify coordinator, group members, and committee when a review is completed.
+ * Trigger: Issue #190 when Review status changes to 'completed'
+ * Templates: review-completed-{coordinator,student,committee}.txt
+ *
+ * @param {string} reviewId
+ * @returns {Promise<Array>} all per-recipient send results
+ */
+const notifyReviewCompleted = async (reviewId) => {
+  const review = await Review.findOne({ reviewId }).lean();
+  if (!review) return [];
+
+  const deliverable = await Deliverable.findOne({ deliverableId: review.deliverableId }).lean();
+  const group = deliverable
+    ? await Group.findOne({ groupId: deliverable.groupId }).select('groupName committeeId').lean()
+    : null;
+
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const link = `${frontendUrl}/deliverables/${review.deliverableId}`;
+  const groupName = group?.groupName || review.groupId || '';
+  const { deliverableId } = review;
+
+  const sends = [];
+
+  // Notify coordinator(s) — D1
+  const coordinators = await _getCoordinatorUsers();
+  for (const { userId, email } of coordinators) {
+    const text = renderTemplate('review-completed-coordinator.txt', { deliverableId, groupName, link });
+    sends.push(
+      _sendOne({
+        to: email,
+        subject: `Review complete: Deliverable #${deliverableId}`,
+        text: text || `Review of deliverable #${deliverableId} from ${groupName} is complete. See: ${link}`,
+        templateName: 'review-completed-coordinator.txt',
+        recipientId: userId,
+        deliverableId,
+        notificationType: 'REVIEW_COMPLETED_COORDINATOR',
+      })
+    );
+  }
+
+  // Notify group members — D2
+  if (deliverable?.groupId) {
+    const members = await _getGroupMemberUsers(deliverable.groupId);
+    for (const { userId, email } of members) {
+      const text = renderTemplate('review-completed-student.txt', {
+        deliverableId,
+        sectionSummary: 'See the full comment thread for details.',
+      });
+      sends.push(
+        _sendOne({
+          to: email,
+          subject: `Review complete: Your deliverable #${deliverableId}`,
+          text: text || `The review of your deliverable #${deliverableId} is complete.`,
+          templateName: 'review-completed-student.txt',
+          recipientId: userId,
+          deliverableId,
+          notificationType: 'REVIEW_COMPLETED_STUDENT',
+        })
+      );
+    }
+  }
+
+  // Notify committee members — D3
+  if (deliverable?.groupId) {
+    const members = await _getCommitteeMemberUsers(deliverable.groupId);
+    for (const { userId, email } of members) {
+      const text = renderTemplate('review-completed-committee.txt', { deliverableId });
+      sends.push(
+        _sendOne({
+          to: email,
+          subject: `Review logged as complete: Deliverable #${deliverableId}`,
+          text: text || `Review of deliverable #${deliverableId} has been logged as complete.`,
+          templateName: 'review-completed-committee.txt',
+          recipientId: userId,
+          deliverableId,
+          notificationType: 'REVIEW_COMPLETED_COMMITTEE',
+        })
+      );
+    }
+  }
+
+  return Promise.all(sends);
+};
+
+// ─── Exports ──────────────────────────────────────────────────────────────────
+
+module.exports = {
+  // Process 5.6
+  notifyCommittee,
+  notifyCoordinator,
+  notifyStudents,
+  // Process 6
+  notifyReviewerAssigned,
+  notifyClarificationRequested,
+  notifyStudentReplied,
+  notifyReviewCompleted,
+  // Exposed for unit testing
+  _internal: {
+    renderTemplate,
+    sendWithRetry,
+    isTransientError,
+    logNotification,
+    _getTransporter,
+    _isDevMode,
+  },
+};

--- a/backend/src/templates/deliverable-committee.txt
+++ b/backend/src/templates/deliverable-committee.txt
@@ -1,0 +1,6 @@
+New Deliverable #{{id}} from {{groupName}} is ready for review.
+
+Please log in to the Senior Project Management System to begin your review.
+
+---
+Senior Project Management System

--- a/backend/src/templates/deliverable-coordinator.txt
+++ b/backend/src/templates/deliverable-coordinator.txt
@@ -1,0 +1,7 @@
+Deliverable #{{id}} submitted by {{groupName}}.
+
+The submission has passed all validation checks and is now stored permanently.
+You may assign reviewers from the Review Management section.
+
+---
+Senior Project Management System

--- a/backend/src/templates/deliverable-student.txt
+++ b/backend/src/templates/deliverable-student.txt
@@ -1,0 +1,7 @@
+Submission received — ID #{{id}}, Time: {{timestamp}}
+
+Your deliverable has been successfully submitted and stored.
+You will be notified when the review process begins.
+
+---
+Senior Project Management System

--- a/backend/src/templates/review-assignment.txt
+++ b/backend/src/templates/review-assignment.txt
@@ -1,0 +1,9 @@
+You have been assigned to review deliverable #{{deliverableId}} from {{groupName}}.
+
+Deadline: {{deadline}}
+Instructions: {{instructions}}
+
+Please log in to the Senior Project Management System to begin your review.
+
+---
+Senior Project Management System

--- a/backend/src/templates/review-clarification-reply.txt
+++ b/backend/src/templates/review-clarification-reply.txt
@@ -1,0 +1,6 @@
+Group {{groupName}} replied to your clarification on deliverable #{{deliverableId}}: {{replyContent}}
+
+Please log in to the Senior Project Management System to continue the thread.
+
+---
+Senior Project Management System

--- a/backend/src/templates/review-clarification-request.txt
+++ b/backend/src/templates/review-clarification-request.txt
@@ -1,0 +1,6 @@
+Clarification requested on your deliverable #{{deliverableId}}: {{commentContent}}
+
+Please log in to the Senior Project Management System and reply to the comment thread.
+
+---
+Senior Project Management System

--- a/backend/src/templates/review-completed-committee.txt
+++ b/backend/src/templates/review-completed-committee.txt
@@ -1,0 +1,6 @@
+Review of deliverable #{{deliverableId}} has been logged as complete.
+
+No further action is required from committee members at this stage.
+
+---
+Senior Project Management System

--- a/backend/src/templates/review-completed-coordinator.txt
+++ b/backend/src/templates/review-completed-coordinator.txt
@@ -1,0 +1,7 @@
+Review of deliverable #{{deliverableId}} from {{groupName}} is complete.
+
+Open clarifications: 0
+See full comment thread at: {{link}}
+
+---
+Senior Project Management System

--- a/backend/src/templates/review-completed-student.txt
+++ b/backend/src/templates/review-completed-student.txt
@@ -1,0 +1,9 @@
+The review of your deliverable #{{deliverableId}} is complete.
+
+Section feedback summary: {{sectionSummary}}
+All clarifications resolved.
+
+Please log in to the Senior Project Management System to view the full review.
+
+---
+Senior Project Management System

--- a/frontend/src/api/deliverableAPI.js
+++ b/frontend/src/api/deliverableAPI.js
@@ -1,0 +1,80 @@
+import apiClient from './apiClient';
+
+/**
+ * Deliverable API Abstraction Layer
+ * Handles the 4-step submission pipeline (5.2 → 5.3 → 5.4 → 5.5)
+ */
+
+/**
+ * Process 5.2 - Submit deliverable file and create staging record
+ * @param {FormData} formData - Contains file, groupId, deliverableType, sprintId, description, etc.
+ * @param {string} validationToken - Short-lived token from group validation
+ * @returns {Promise<{stagingId: string, fileHash: string, sizeMb: number, mimeType: string}>}
+ */
+export const submitDeliverable = async (formData, validationToken) => {
+  const response = await apiClient.post('/deliverables/submit', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      'Authorization-Validation': validationToken,
+    },
+  });
+  return response.data;
+};
+
+/**
+ * Process 5.3 - Validate file format
+ * @param {string} stagingId - ID from submitDeliverable
+ * @param {string} validationToken - Short-lived token
+ * @returns {Promise<{stagingId: string, validatedAt: string, mimeType: string, code: string}>}
+ */
+export const validateFormat = async (stagingId, validationToken) => {
+  const response = await apiClient.post(
+    `/deliverables/${stagingId}/validate-format`,
+    {},
+    {
+      headers: {
+        'Authorization-Validation': validationToken,
+      },
+    }
+  );
+  return response.data;
+};
+
+/**
+ * Process 5.4 - Validate deadline compliance
+ * @param {string} stagingId - ID from submitDeliverable
+ * @param {string} sprintId - Sprint identifier
+ * @param {string} validationToken - Short-lived token
+ * @returns {Promise<{stagingId: string, sprintId: string, deadlineMet: boolean, code: string}>}
+ */
+export const validateDeadline = async (stagingId, sprintId, validationToken) => {
+  const response = await apiClient.post(
+    `/deliverables/${stagingId}/validate-deadline`,
+    { sprintId },
+    {
+      headers: {
+        'Authorization-Validation': validationToken,
+      },
+    }
+  );
+  return response.data;
+};
+
+/**
+ * Process 5.5 - Store deliverable permanently in database
+ * @param {string} stagingId - ID from submitDeliverable
+ * @param {string} validationToken - Short-lived token
+ * @returns {Promise<{deliverableId: string, stagingId: string, submittedAt: string, version: string, code: string}>}
+ */
+export const storeDeliverable = async (stagingId, validationToken) => {
+  const response = await apiClient.post(
+    `/deliverables/${stagingId}/store`,
+    {},
+    {
+      headers: {
+        'Authorization-Validation': validationToken,
+      },
+    }
+  );
+  return response.data;
+};

--- a/frontend/src/components/deliverables/FileUploadWidget.jsx
+++ b/frontend/src/components/deliverables/FileUploadWidget.jsx
@@ -1,41 +1,123 @@
-import React, { useState } from 'react';
-import apiClient from '../../api/apiClient';
+import React, { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  submitDeliverable,
+  validateFormat,
+  validateDeadline,
+  storeDeliverable,
+} from '../../api/deliverableAPI';
 
-/**
- * FileUploadWidget Component — Process 5.2
- * Handles the actual file selection and upload using the validationToken.
- */
 const FileUploadWidget = ({
   validationToken,
   groupId,
   deliverableType,
   sprintId,
   description,
-  onSuccess
 }) => {
-  const [file, setFile] = useState(null);
-  const [uploadState, setUploadState] = useState('initial'); // initial, uploading, success, error
-  const [progress, setProgress] = useState(0);
-  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+  const fileInputRef = useRef(null);
+  const dragOverRef = useRef(false);
 
-  const handleFileChange = (e) => {
-    const selectedFile = e.target.files[0];
-    if (selectedFile) {
-      setFile(selectedFile);
-      setError(null);
+  const [file, setFile] = useState(null);
+  const [fileSizeWarning, setFileSizeWarning] = useState(null);
+  const [pipelineState, setPipelineState] = useState('file-selection');
+  const [currentStep, setCurrentStep] = useState(null);
+  const [completedSteps, setCompletedSteps] = useState([]);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [stagingId, setStagingId] = useState(null);
+  const [successData, setSuccessData] = useState(null);
+  const [error, setError] = useState(null);
+  const [errorCode, setErrorCode] = useState(null);
+  const [failedStep, setFailedStep] = useState(null);
+
+  const ACCEPTED_TYPES = ['.pdf', '.docx', '.md', '.zip'];
+  const ACCEPTED_MIME_TYPES = [
+    'application/pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'text/markdown',
+    'application/zip',
+    'application/x-zip-compressed',
+  ];
+  const SIZE_WARN_MB = 500;
+  const SIZE_BLOCK_MB = 1000;
+
+  const validateFile = (selectedFile) => {
+    if (!selectedFile) return false;
+
+    const fileExtension = '.' + selectedFile.name.split('.').pop().toLowerCase();
+    const isValidType =
+      ACCEPTED_TYPES.includes(fileExtension) ||
+      ACCEPTED_MIME_TYPES.includes(selectedFile.type);
+
+    if (!isValidType) {
+      setError(`Invalid file type. Accepted types: ${ACCEPTED_TYPES.join(', ')}`);
+      setErrorCode('INVALID_FILE_TYPE');
+      return false;
     }
+
+    const sizeMB = selectedFile.size / (1024 * 1024);
+
+    if (sizeMB > SIZE_BLOCK_MB) {
+      setError(`File size exceeds 1GB limit. Current size: ${sizeMB.toFixed(2)}MB`);
+      setErrorCode('FILE_TOO_LARGE');
+      return false;
+    }
+
+    if (sizeMB > SIZE_WARN_MB) {
+      setFileSizeWarning(`File is ${sizeMB.toFixed(2)}MB (larger than recommended 500MB)`);
+    } else {
+      setFileSizeWarning(null);
+    }
+
+    setError(null);
+    setErrorCode(null);
+    return true;
   };
 
-  const handleUpload = async () => {
+  const handleFileSelect = (selectedFile) => {
+    if (validateFile(selectedFile)) setFile(selectedFile);
+  };
+
+  const handleFileInputChange = (e) => {
+    const selectedFile = e.target.files?.[0];
+    if (selectedFile) handleFileSelect(selectedFile);
+  };
+
+  const handleDragOver = (e) => {
+    e.preventDefault();
+    dragOverRef.current = true;
+  };
+
+  const handleDragLeave = (e) => {
+    e.preventDefault();
+    dragOverRef.current = false;
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    dragOverRef.current = false;
+    const droppedFile = e.dataTransfer.files?.[0];
+    if (droppedFile) handleFileSelect(droppedFile);
+  };
+
+  // ── FIX 1: local `activeStep` instead of stale `currentStep` state ──
+  const executePipeline = async () => {
     if (!file) {
       setError('Please select a file first.');
       return;
     }
 
-    setUploadState('uploading');
-    setProgress(10); // Start progress
+    setPipelineState('uploading');
+    setCompletedSteps([]);
+    setFailedStep(null);
+    setError(null);
+    setErrorCode(null);
+
+    let activeStep = 0;
 
     try {
+      activeStep = 1;
+      setCurrentStep(1);
       const formData = new FormData();
       formData.append('groupId', groupId);
       formData.append('deliverableType', deliverableType);
@@ -43,120 +125,374 @@ const FileUploadWidget = ({
       formData.append('file', file);
       if (description) formData.append('description', description);
 
-      const response = await apiClient.post('/deliverables/submit', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data',
-          'Authorization-Validation': validationToken,
-        },
-        onUploadProgress: (progressEvent) => {
-          const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total);
-          setProgress(percentCompleted);
-        },
-      });
+      const submitResponse = await submitDeliverable(formData, validationToken);
+      setStagingId(submitResponse.stagingId);
+      setUploadProgress(25);
+      setCompletedSteps([1]);
 
-      setUploadState('success');
-      if (onSuccess) onSuccess(response.data);
+      activeStep = 2;
+      setCurrentStep(2);
+      await validateFormat(submitResponse.stagingId, validationToken);
+      setUploadProgress(50);
+      setCompletedSteps([1, 2]);
+
+      activeStep = 3;
+      setCurrentStep(3);
+      await validateDeadline(submitResponse.stagingId, sprintId, validationToken);
+      setUploadProgress(75);
+      setCompletedSteps([1, 2, 3]);
+
+      activeStep = 4;
+      setCurrentStep(4);
+      const storeResponse = await storeDeliverable(submitResponse.stagingId, validationToken);
+      setUploadProgress(100);
+      setCompletedSteps([1, 2, 3, 4]);
+      setSuccessData(storeResponse);
+      setPipelineState('success');
+      setCurrentStep(null);
     } catch (err) {
-      setError(err.response?.data?.message || 'Upload failed. Please try again.');
-      setUploadState('error');
+      const errData = err.response?.data;
+      setFailedStep(activeStep);
+      setError(errData?.message || `Step ${activeStep} failed. Please try again.`);
+      setErrorCode(errData?.code || `STEP_${activeStep}_FAILED`);
+      setPipelineState('error');
     }
   };
 
-  if (uploadState === 'success') {
+  // ── FIX 2: retry continues pipeline from failed step ──
+  const handleRetry = () => {
+    if (!stagingId || !failedStep) return;
+
+    setPipelineState('uploading');
+    setError(null);
+    setErrorCode(null);
+
+    const retryFromStep = async (fromStep) => {
+      let activeStep = fromStep;
+
+      try {
+        if (activeStep === 2) {
+          setCurrentStep(2);
+          await validateFormat(stagingId, validationToken);
+          setCompletedSteps([1, 2]);
+          setUploadProgress(50);
+          activeStep = 3;
+        }
+
+        if (activeStep === 3) {
+          setCurrentStep(3);
+          await validateDeadline(stagingId, sprintId, validationToken);
+          setCompletedSteps([1, 2, 3]);
+          setUploadProgress(75);
+          activeStep = 4;
+        }
+
+        if (activeStep === 4) {
+          setCurrentStep(4);
+          const storeResponse = await storeDeliverable(stagingId, validationToken);
+          setCompletedSteps([1, 2, 3, 4]);
+          setUploadProgress(100);
+          setSuccessData(storeResponse);
+          setPipelineState('success');
+          setCurrentStep(null);
+        }
+      } catch (err) {
+        const errData = err.response?.data;
+        setFailedStep(activeStep);
+        setError(errData?.message || `Retry failed at step ${activeStep}. Please try again.`);
+        setErrorCode(errData?.code || `RETRY_STEP_${activeStep}_FAILED`);
+        setPipelineState('error');
+      }
+    };
+
+    retryFromStep(failedStep);
+  };
+
+  const handleCancel = () => {
+    setFile(null);
+    setStagingId(null);
+    setFileSizeWarning(null);
+    setError(null);
+    setErrorCode(null);
+    setFailedStep(null);
+    setCurrentStep(null);
+    setCompletedSteps([]);
+    setUploadProgress(0);
+    setPipelineState('file-selection');
+  };
+
+  const handleViewSubmission = () => {
+    if (successData?.deliverableId) {
+      navigate(`/dashboard/deliverables/${successData.deliverableId}`);
+    }
+  };
+
+  // ── Success State ──
+  if (pipelineState === 'success' && successData) {
     return (
-      <div className="bg-emerald-50 border border-emerald-100 p-8 rounded-3xl text-center">
-        <div className="h-16 w-16 bg-emerald-500 text-white rounded-full flex items-center justify-center mx-auto mb-4 shadow-lg shadow-emerald-100">
-          <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
-          </svg>
+      <div className="w-full max-w-xl mx-auto">
+        <div className="bg-white p-8 rounded-3xl border border-slate-100 shadow-sm">
+          <div className="bg-emerald-50 border border-emerald-100 p-8 rounded-3xl text-center">
+            <div className="h-16 w-16 bg-emerald-500 text-white rounded-full flex items-center justify-center mx-auto mb-4 shadow-lg shadow-emerald-100">
+              <svg className="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="3" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h3 className="text-xl font-bold text-emerald-900 mb-2">Submission successful!</h3>
+            <p className="text-emerald-700 text-sm mb-6">Your deliverable has been successfully stored.</p>
+
+            <div className="bg-white rounded-2xl p-4 mb-6 space-y-2 text-left border border-emerald-100">
+              <div className="flex justify-between items-center">
+                <span className="text-xs font-bold uppercase text-slate-400">Deliverable ID</span>
+                <span className="text-sm font-mono text-slate-700">{successData.deliverableId}</span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-xs font-bold uppercase text-slate-400">Submitted At</span>
+                <span className="text-sm text-slate-700">
+                  {new Date(successData.submittedAt).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'short',
+                    day: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+                </span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span className="text-xs font-bold uppercase text-slate-400">Version</span>
+                <span className="text-sm text-slate-700">{successData.version}</span>
+              </div>
+            </div>
+
+            <button
+              onClick={handleViewSubmission}
+              className="w-full px-6 py-2 bg-emerald-600 text-white font-bold rounded-xl hover:bg-emerald-700 transition-all"
+            >
+              View Submission
+            </button>
+          </div>
         </div>
-        <h3 className="text-xl font-bold text-emerald-900 mb-2">Upload Complete!</h3>
-        <p className="text-emerald-700 text-sm mb-6">Your deliverable has been safely staged in the Academic Center.</p>
-        <button
-          onClick={() => window.location.reload()}
-          className="px-6 py-2 bg-emerald-600 text-white font-bold rounded-xl hover:bg-emerald-700 transition-all"
-        >
-          Done
-        </button>
       </div>
     );
   }
 
-  return (
-    <div className="bg-white p-8 rounded-3xl border border-slate-100 shadow-sm">
-      <h3 className="text-lg font-bold text-slate-800 mb-6 flex items-center gap-2">
-        <svg className="h-5 w-5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-        </svg>
-        Finalize Submission
-      </h3>
+  // ── File Selection State ──
+  if (pipelineState === 'file-selection') {
+    return (
+      <div className="w-full max-w-xl mx-auto">
+        <div className="bg-white p-8 rounded-3xl border border-slate-100 shadow-sm">
+          <h3 className="text-lg font-bold text-slate-800 mb-6 flex items-center gap-2">
+            <svg className="h-5 w-5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            Finalize Submission
+          </h3>
 
-      <div className="mb-8 p-4 bg-indigo-50/50 rounded-2xl border border-indigo-100">
-        <div className="grid grid-cols-2 gap-4 text-xs font-bold uppercase tracking-wider">
-          <div>
-            <span className="text-slate-400 block mb-1">Type</span>
-            <span className="text-indigo-600">{deliverableType.replace(/_/g, ' ')}</span>
-          </div>
-          <div>
-            <span className="text-slate-400 block mb-1">Sprint</span>
-            <span className="text-indigo-600">{sprintId}</span>
-          </div>
-        </div>
-      </div>
-
-      <div className="space-y-6">
-        <div className="relative group">
-          <input
-            type="file"
-            id="file-upload"
-            onChange={handleFileChange}
-            className="hidden"
-          />
-          <label
-            htmlFor="file-upload"
-            className={`w-full h-40 border-2 border-dashed rounded-3xl flex flex-col items-center justify-center cursor-pointer transition-all ${file ? 'border-emerald-200 bg-emerald-50/10' : 'border-slate-200 bg-slate-50 hover:border-indigo-300'
-              }`}
-          >
-            <div className={`p-3 rounded-full mb-3 ${file ? 'bg-emerald-100 text-emerald-600' : 'bg-slate-100 text-slate-400 group-hover:bg-indigo-100 group-hover:text-indigo-500'}`}>
-              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
-              </svg>
+          <div className="mb-8 p-4 bg-indigo-50/50 rounded-2xl border border-indigo-100">
+            <div className="grid grid-cols-2 gap-4 text-xs font-bold uppercase tracking-wider">
+              <div>
+                <span className="text-slate-400 block mb-1">Type</span>
+                <span className="text-indigo-600">{deliverableType.replace(/_/g, ' ')}</span>
+              </div>
+              <div>
+                <span className="text-slate-400 block mb-1">Sprint</span>
+                <span className="text-indigo-600">{sprintId}</span>
+              </div>
             </div>
-            {file ? (
-              <span className="text-sm font-bold text-slate-700">{file.name}</span>
-            ) : (
-              <span className="text-sm font-bold text-slate-400 group-hover:text-indigo-600 transition-colors">Select PDF or Archive</span>
+          </div>
+
+          <div className="space-y-6">
+            <div className="relative group">
+              <input
+                ref={fileInputRef}
+                type="file"
+                id="file-upload"
+                onChange={handleFileInputChange}
+                accept={ACCEPTED_TYPES.join(',')}
+                className="hidden"
+              />
+              <label
+                htmlFor="file-upload"
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                className={`w-full h-40 border-2 border-dashed rounded-3xl flex flex-col items-center justify-center cursor-pointer transition-all ${
+                  file ? 'border-emerald-200 bg-emerald-50/10' : 'border-slate-200 bg-slate-50 hover:border-indigo-300'
+                }`}
+              >
+                <div className={`p-3 rounded-full mb-3 ${
+                  file ? 'bg-emerald-100 text-emerald-600' : 'bg-slate-100 text-slate-400 group-hover:bg-indigo-100 group-hover:text-indigo-500'
+                }`}>
+                  <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                  </svg>
+                </div>
+                {file ? (
+                  <span className="text-sm font-bold text-slate-700">{file.name}</span>
+                ) : (
+                  <>
+                    <span className="text-sm font-bold text-slate-400 group-hover:text-indigo-600 transition-colors">
+                      Drag and drop your file here
+                    </span>
+                    <span className="text-xs text-slate-400 mt-1 uppercase tracking-widest font-bold">
+                      or click to browse
+                    </span>
+                  </>
+                )}
+                <span className="text-[10px] text-slate-400 mt-2 uppercase tracking-widest font-bold">
+                  {ACCEPTED_TYPES.join(', ')} • Max 1GB
+                </span>
+              </label>
+            </div>
+
+            {fileSizeWarning && (
+              <div className="p-4 bg-yellow-50 border border-yellow-100 rounded-2xl flex items-start gap-3">
+                <div className="text-yellow-600 mt-0.5">
+                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <p className="text-xs font-bold text-yellow-800">{fileSizeWarning}</p>
+              </div>
             )}
-            <span className="text-[10px] text-slate-400 mt-1 uppercase tracking-widest font-bold">Max 50MB</span>
-          </label>
-        </div>
 
-        {uploadState === 'uploading' && (
-          <div className="space-y-2">
-            <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-indigo-500 transition-all duration-300"
-                style={{ width: `${progress}%` }}
-              ></div>
-            </div>
-            <div className="flex justify-between text-[10px] font-bold text-slate-400 uppercase">
-              <span>Uploading...</span>
-              <span>{progress}%</span>
-            </div>
+            {error && (
+              <div className="p-4 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-3">
+                <div className="text-red-500 mt-0.5">
+                  <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <p className="text-xs font-bold text-red-800">{error}</p>
+              </div>
+            )}
+
+            <button
+              onClick={executePipeline}
+              disabled={!file}
+              className={`${
+                !file ? 'opacity-50 cursor-not-allowed' : 'opacity-100 cursor-pointer hover:shadow-lg'
+              } w-full p-[13px] bg-gradient-to-br from-[#667eea] to-[#764ba2] text-white rounded-md text-base font-semibold transition-all duration-200 mt-2`}
+            >
+              Submit Deliverable
+            </button>
           </div>
-        )}
-
-        {error && <p className="text-xs text-red-500 font-bold">{error}</p>}
-
-        <button
-          onClick={handleUpload}
-          disabled={!file || uploadState === 'uploading'}
-          className={`${!file || uploadState === 'uploading' ? "opacity-50 cursor-not-allowed" : "opacity-100 cursor-pointer"} w-full p-[13px] bg-gradient-to-br from-[#667eea] to-[#764ba2] text-white rounded-md text-base font-semibold transition-opacity duration-200 mt-2`} >
-          {uploadState === 'uploading' ? 'Sending to Staging...' : 'Submit Deliverable'}
-        </button>
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
+
+  // ── Uploading / Error State ──
+  if (pipelineState === 'uploading' || pipelineState === 'error') {
+    return (
+      <div className="w-full max-w-xl mx-auto">
+        <div className="bg-white p-8 rounded-3xl border border-slate-100 shadow-sm">
+          <h3 className="text-lg font-bold text-slate-800 mb-8">Submission Pipeline</h3>
+
+          <div className="space-y-4 mb-8">
+            {[1, 2, 3, 4].map((stepNum) => (
+              <div key={stepNum} className="flex items-center gap-4">
+                <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center font-bold text-sm transition-all ${
+                  completedSteps.includes(stepNum)
+                    ? 'bg-emerald-500 text-white'
+                    : failedStep === stepNum
+                    ? 'bg-red-500 text-white'
+                    : currentStep === stepNum
+                    ? 'bg-indigo-500 text-white animate-pulse'
+                    : 'bg-slate-200 text-slate-600'
+                }`}>
+                  {completedSteps.includes(stepNum) ? (
+                    <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                    </svg>
+                  ) : failedStep === stepNum ? (
+                    <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                    </svg>
+                  ) : (
+                    stepNum
+                  )}
+                </div>
+
+                <div className="flex-1">
+                  <div className="text-sm font-bold text-slate-800">
+                    {stepNum === 1 && 'Uploading File'}
+                    {stepNum === 2 && 'Validating Format'}
+                    {stepNum === 3 && 'Checking Deadline'}
+                    {stepNum === 4 && 'Saving Submission'}
+                  </div>
+                  <div className="text-xs text-slate-500">
+                    {stepNum === 1 && 'Transferring file to staging area'}
+                    {stepNum === 2 && 'Verifying file format and integrity'}
+                    {stepNum === 3 && 'Confirming deadline compliance'}
+                    {stepNum === 4 && 'Storing submission permanently'}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {pipelineState === 'uploading' && (
+            <div className="mb-8 space-y-2">
+              <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-gradient-to-r from-indigo-500 to-purple-500 transition-all duration-500"
+                  style={{ width: `${uploadProgress}%` }}
+                />
+              </div>
+              <div className="flex justify-between text-[10px] font-bold text-slate-400 uppercase">
+                <span>Processing...</span>
+                <span>{uploadProgress}%</span>
+              </div>
+            </div>
+          )}
+
+          {pipelineState === 'error' && error && (
+            <div className="mb-6 p-4 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-3">
+              <div className="text-red-500 mt-0.5">
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-bold text-red-800">{error}</p>
+                <p className="text-xs text-red-600 mt-1">{failedStep && `Failed at step ${failedStep}`}</p>
+              </div>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            {pipelineState === 'error' && (
+              <>
+                <button
+                  onClick={handleRetry}
+                  className="flex-1 px-4 py-3 bg-indigo-600 text-white font-bold rounded-md hover:bg-indigo-700 transition-all"
+                >
+                  Retry Step {failedStep}
+                </button>
+                <button
+                  onClick={handleCancel}
+                  className="flex-1 px-4 py-3 bg-slate-200 text-slate-700 font-bold rounded-md hover:bg-slate-300 transition-all"
+                >
+                  Cancel
+                </button>
+              </>
+            )}
+            {pipelineState === 'uploading' && (
+              <button
+                onClick={handleCancel}
+                className="w-full px-4 py-3 bg-slate-200 text-slate-700 font-bold rounded-md hover:bg-slate-300 transition-all"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
 };
 
 export default FileUploadWidget;


### PR DESCRIPTION
Consolidates post-submission (Process 5.6) and review workflow (Process 6) notifications into a single deliverable notification service.

- Add deliverableNotificationService.js: nodemailer with SMTP/env config, single transporter singleton, retry up to 3x with exponential backoff (1s→2s→4s), full audit trail per send (type, recipientId, deliverableId, sentAt, success, templateUsed, attempts, failureReason)
- Add 9 email templates: deliverable-{committee,coordinator,student}.txt and review-{assignment,clarification-request,clarification-reply, completed-coordinator,completed-student,completed-committee}.txt
- Add POST /api/deliverables/:deliverableId/notify (Process 5.6): 404 if not found, 409 if already notified, sets notifiedAt atomically, returns 202 with tasksQueued immediately (fire-and-forget dispatch)
- Add notifiedAt field to Deliverable model for idempotency guard
- Add NOTIFICATION_SENT, NOTIFICATION_FAILED, DELIVERABLE_NOTIFIED, DELIVERABLE_STORED to AuditLog enum

Process 6 functions (notifyReviewerAssigned, notifyClarificationRequested, notifyStudentReplied, notifyReviewCompleted) are exported and ready for wiring by issues #186, #189, #190.