### PR TITLE
feat: Implement review assignment and status retrieval endpoints

### DIFF
--- a/backend/scripts/seed-test-general.js
+++ b/backend/scripts/seed-test-general.js
@@ -308,12 +308,13 @@ async function seedDeliverables(groups, users, sprints) {
     const deliverable = await Deliverable.create({
       deliverableId:   generateId('del'),
       groupId:         group.groupId,
+      committeeId:     group.committeeId,
       deliverableType: type,
       sprintId:        sprint?.sprintId ?? null,
       submittedBy:     leader.userId,
       description:     `Sample ${type} deliverable for ${group.groupName}`,
       filePath:        `s3://deliverables/${group.groupId}/${type}_v1.pdf`,
-      fileSize:        204800, // 200 KB
+      fileSize:        204800,
       fileHash:        uuidv4().replace(/-/g, ''),
       format:          'pdf',
       status:          'accepted',

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -8,6 +8,7 @@ const User = require('../models/User');
 const Deliverable = require('../models/Deliverable');
 const AuditLog = require('../models/AuditLog');
 const Group = require('../models/Group');
+const Committee = require('../models/Committee');
 
 const NOTIFICATION_SERVICE_URL = process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000';
 
@@ -491,4 +492,220 @@ const getComments = async (req, res) => {
   });
 };
 
-module.exports = { updateCommentHandler, replyToCommentHandler, addComment, getComments };
+/**
+ * POST /api/v1/reviews/assign
+ *
+ * Process 6.1 — Coordinator assigns a deliverable to committee members for review.
+ * Fetches committee members from D3, creates a Review record in D5, updates the
+ * Deliverable status to 'under_review', and triggers async assignment notifications.
+ *
+ * Requires: JWT (coordinator role only).
+ */
+const assignReview = async (req, res) => {
+  const { userId } = req.user;
+  const { deliverableId, reviewDeadlineDays, selectedCommitteeMembers, instructions } = req.body;
+
+  if (!deliverableId) {
+    return res.status(400).json({ code: 'INVALID_REQUEST', message: 'deliverableId is required' });
+  }
+
+  if (reviewDeadlineDays === undefined || reviewDeadlineDays === null) {
+    return res.status(400).json({ code: 'INVALID_REQUEST', message: 'reviewDeadlineDays is required' });
+  }
+
+  if (!Number.isInteger(reviewDeadlineDays) || reviewDeadlineDays < 1 || reviewDeadlineDays > 30) {
+    return res.status(400).json({
+      code: 'INVALID_REQUEST',
+      message: 'reviewDeadlineDays must be an integer between 1 and 30',
+    });
+  }
+
+  let deliverable;
+  try {
+    deliverable = await Deliverable.findOne({ deliverableId }).lean();
+  } catch (err) {
+    console.error('[assignReview] deliverable query error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!deliverable) {
+    return res.status(404).json({ code: 'DELIVERABLE_NOT_FOUND', message: 'Deliverable not found' });
+  }
+
+  let existingReview;
+  try {
+    existingReview = await Review.findOne({ deliverableId }).lean();
+  } catch (err) {
+    console.error('[assignReview] review query error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (existingReview) {
+    return res.status(409).json({
+      code: 'REVIEW_ALREADY_EXISTS',
+      message: 'A review is already assigned for this deliverable',
+    });
+  }
+
+  if (deliverable.status !== 'accepted') {
+    return res.status(400).json({
+      code: 'INVALID_DELIVERABLE_STATUS',
+      message: `Deliverable must have status 'accepted'; current: ${deliverable.status}`,
+    });
+  }
+
+  let committee;
+  try {
+    committee = await Committee.findOne({ committeeId: deliverable.committeeId }).lean();
+  } catch (err) {
+    console.error('[assignReview] committee query error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!committee) {
+    return res.status(400).json({ code: 'COMMITTEE_NOT_FOUND', message: 'Committee not found for this deliverable' });
+  }
+
+  const membersToAssign =
+    selectedCommitteeMembers && selectedCommitteeMembers.length > 0
+      ? selectedCommitteeMembers
+      : committee.advisorIds;
+
+  const invalidMemberIds = membersToAssign.filter((id) => !committee.advisorIds.includes(id));
+  if (invalidMemberIds.length > 0) {
+    return res.status(400).json({
+      code: 'INVALID_MEMBER_IDS',
+      message: 'Some member IDs are not valid active committee members',
+      invalidMemberIds,
+    });
+  }
+
+  const deadline = new Date();
+  deadline.setDate(deadline.getDate() + reviewDeadlineDays);
+
+  const assignedMembersData = membersToAssign.map((memberId) => ({ memberId, status: 'notified' }));
+
+  let review;
+  try {
+    review = await Review.create({
+      deliverableId,
+      groupId: deliverable.groupId,
+      status: 'pending',
+      assignedMembers: assignedMembersData,
+      deadline,
+      instructions: instructions || null,
+    });
+  } catch (err) {
+    console.error('[assignReview] review create error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to create review' });
+  }
+
+  // Update deliverable status (fire-and-forget — response should not wait on this)
+  Deliverable.findOneAndUpdate({ deliverableId }, { status: 'under_review' }).catch((err) => {
+    console.error('[assignReview] deliverable update error:', err.message);
+  });
+
+  // Fetch member details for response (name/email from User collection)
+  let memberDetails;
+  try {
+    const memberUsers = await User.find({ userId: { $in: membersToAssign } })
+      .select('userId email')
+      .lean();
+    const userMap = Object.fromEntries(memberUsers.map((u) => [u.userId, u]));
+    memberDetails = assignedMembersData.map((m) => ({
+      memberId: m.memberId,
+      name: userMap[m.memberId]?.email ?? m.memberId,
+      email: userMap[m.memberId]?.email ?? null,
+      status: m.status,
+    }));
+  } catch (err) {
+    console.error('[assignReview] user fetch error:', err.message);
+    memberDetails = assignedMembersData.map((m) => ({
+      memberId: m.memberId,
+      name: m.memberId,
+      email: null,
+      status: m.status,
+    }));
+  }
+
+  // Audit log (fire-and-forget)
+  AuditLog.create({
+    action: 'REVIEW_ASSIGNED',
+    actorId: userId,
+    targetId: review.reviewId,
+    groupId: deliverable.groupId,
+    payload: { reviewId: review.reviewId, deliverableId, assignedMemberCount: assignedMembersData.length },
+    ipAddress: req.ip ?? null,
+    userAgent: req.headers['user-agent'] ?? null,
+  }).catch((err) => console.error('[assignReview] audit log error:', err.message));
+
+  // Dispatch notifications async (DFD f14: 6.1 → Notification Service); does not block response
+  const notificationsSent = membersToAssign.length;
+  setImmediate(async () => {
+    try {
+      await axios.post(
+        `${NOTIFICATION_SERVICE_URL}/api/notifications`,
+        {
+          type: 'review_assignment',
+          reviewId: review.reviewId,
+          deliverableId,
+          groupId: deliverable.groupId,
+          recipients: membersToAssign,
+          instructions: instructions || null,
+        },
+        { timeout: 5000 }
+      );
+    } catch (err) {
+      console.error('[assignReview] notification dispatch error:', err.message);
+    }
+  });
+
+  return res.status(201).json({
+    deliverableId,
+    reviewId: review.reviewId,
+    assignedCommitteeMembers: memberDetails,
+    assignedCount: memberDetails.length,
+    deadline: review.deadline.toISOString(),
+    notificationsSent,
+    instructions: review.instructions,
+  });
+};
+
+/**
+ * GET /api/v1/reviews/status
+ *
+ * Process 6 — Return the current review record for a given deliverable.
+ * Requires: JWT (coordinator role only). Query param: deliverableId.
+ */
+const getReviewStatus = async (req, res) => {
+  const { deliverableId } = req.query;
+
+  if (!deliverableId) {
+    return res.status(400).json({ code: 'INVALID_REQUEST', message: 'deliverableId query parameter is required' });
+  }
+
+  let review;
+  try {
+    review = await Review.findOne({ deliverableId }).lean();
+  } catch (err) {
+    console.error('[getReviewStatus] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!review) {
+    return res.status(404).json({ code: 'REVIEW_NOT_FOUND', message: 'No review found for this deliverable' });
+  }
+
+  return res.status(200).json({
+    reviewId: review.reviewId,
+    deliverableId: review.deliverableId,
+    groupId: review.groupId,
+    status: review.status,
+    assignedMembers: review.assignedMembers,
+    deadline: review.deadline,
+    instructions: review.instructions,
+    createdAt: review.createdAt,
+  });
+};
+
+module.exports = { updateCommentHandler, replyToCommentHandler, addComment, getComments, assignReview, getReviewStatus };

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -4,14 +4,14 @@ const express = require('express');
 const router = express.Router();
 
 const { deliverableAuthMiddleware, roleMiddleware } = require('../middleware/auth');
-const reviewController = require('../controllers/reviews');
+const reviewController = require('../controllers/reviewController');
 
 // All review routes require a valid JWT; req.user = { userId, role, groupId }
 router.use(deliverableAuthMiddleware);
 
 /**
  * POST /api/v1/reviews/assign
- * Process 6 — Assign a reviewer to a deliverable submission.
+ * Process 6.1 — Assign committee members to review a deliverable.
  * Restricted to coordinator role only.
  */
 router.post(
@@ -22,7 +22,7 @@ router.post(
 
 /**
  * GET /api/v1/reviews/status
- * Process 6 — Get current review status for deliverable submissions.
+ * Process 6 — Get current review status for a deliverable.
  * Restricted to coordinator role only.
  */
 router.get(

--- a/backend/src/swagger.js
+++ b/backend/src/swagger.js
@@ -30,6 +30,7 @@ const options = {
       { name: 'Advisor Requests', description: 'Advisor assignment flow' },
       { name: 'Committees', description: 'Committee creation & publishing' },
       { name: 'Deliverables', description: 'Deliverable submission & validation' },
+      { name: 'Reviews', description: 'Process 6 — Review assignment & status' },
       { name: 'Schedule Windows', description: 'Operation schedule management' },
       { name: 'Audit Logs', description: 'Audit trail & logging' },
     ],
@@ -1110,6 +1111,142 @@ const options = {
             200: { description: 'Deliverable retracted successfully' },
             400: { description: 'Cannot retract — deadline passed or status prevents retraction' },
             404: { description: 'Deliverable not found' },
+          },
+        },
+      },
+
+      // ── REVIEWS ──────────────────────────────────────────────────────────
+      '/reviews/assign': {
+        post: {
+          tags: ['Reviews'],
+          summary: 'Process 6.1 — Assign committee members to review a deliverable',
+          description: 'Coordinator only. Creates a Review record in D5, updates the Deliverable status to `under_review`, and triggers async notifications to each assigned committee member. If `selectedCommitteeMembers` is omitted, all advisors in the deliverable\'s committee are assigned automatically.',
+          security: [{ bearerAuth: [] }],
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  required: ['deliverableId', 'reviewDeadlineDays'],
+                  properties: {
+                    deliverableId: {
+                      type: 'string',
+                      example: 'del_5e8f9d2a3c',
+                      description: 'ID of the deliverable to assign for review (must have status "accepted")',
+                    },
+                    reviewDeadlineDays: {
+                      type: 'integer',
+                      minimum: 1,
+                      maximum: 30,
+                      example: 7,
+                      description: 'Number of days from now for the review deadline (integer, 1–30)',
+                    },
+                    selectedCommitteeMembers: {
+                      type: 'array',
+                      items: { type: 'string' },
+                      example: ['prof_abc123', 'prof_def456'],
+                      description: 'Optional. User IDs of committee members to assign. If omitted, all committee advisors are selected.',
+                    },
+                    instructions: {
+                      type: 'string',
+                      nullable: true,
+                      example: 'Focus on the architecture section.',
+                      description: 'Optional free-text instructions for reviewers.',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            201: {
+              description: 'Review assigned successfully',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      deliverableId: { type: 'string', example: 'del_5e8f9d2a3c' },
+                      reviewId: { type: 'string', example: 'rev_5e8f9d2a3c' },
+                      assignedCommitteeMembers: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            memberId: { type: 'string', example: 'prof_abc123' },
+                            name: { type: 'string', example: 'ali@uni.edu' },
+                            email: { type: 'string', example: 'ali@uni.edu' },
+                            status: { type: 'string', enum: ['notified'], example: 'notified' },
+                          },
+                        },
+                      },
+                      assignedCount: { type: 'integer', example: 3 },
+                      deadline: { type: 'string', format: 'date-time', example: '2026-04-26T07:00:00.000Z' },
+                      notificationsSent: { type: 'integer', example: 3 },
+                      instructions: { type: 'string', nullable: true, example: 'Focus on the architecture section.' },
+                    },
+                  },
+                },
+              },
+            },
+            400: { description: 'Invalid request — missing/bad deliverableId, reviewDeadlineDays out of range, wrong deliverable status, or invalid member IDs' },
+            401: { description: 'No or invalid JWT' },
+            403: { description: 'Insufficient role — coordinator required' },
+            404: { description: 'Deliverable not found' },
+            409: { description: 'A review is already assigned for this deliverable' },
+          },
+        },
+      },
+      '/reviews/status': {
+        get: {
+          tags: ['Reviews'],
+          summary: 'Process 6 — Get review status for a deliverable',
+          description: 'Coordinator only. Returns the Review record for the given deliverable.',
+          security: [{ bearerAuth: [] }],
+          parameters: [
+            {
+              name: 'deliverableId',
+              in: 'query',
+              required: true,
+              schema: { type: 'string', example: 'del_5e8f9d2a3c' },
+              description: 'The deliverable to look up',
+            },
+          ],
+          responses: {
+            200: {
+              description: 'Review record',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      reviewId: { type: 'string', example: 'rev_5e8f9d2a3c' },
+                      deliverableId: { type: 'string', example: 'del_5e8f9d2a3c' },
+                      groupId: { type: 'string', example: 'grp_abc123' },
+                      status: { type: 'string', enum: ['pending', 'in_progress', 'needs_clarification', 'completed'], example: 'pending' },
+                      assignedMembers: {
+                        type: 'array',
+                        items: {
+                          type: 'object',
+                          properties: {
+                            memberId: { type: 'string' },
+                            status: { type: 'string', enum: ['notified', 'accepted', 'started'] },
+                          },
+                        },
+                      },
+                      deadline: { type: 'string', format: 'date-time' },
+                      instructions: { type: 'string', nullable: true },
+                      createdAt: { type: 'string', format: 'date-time' },
+                    },
+                  },
+                },
+              },
+            },
+            400: { description: 'Missing deliverableId query parameter' },
+            401: { description: 'No or invalid JWT' },
+            403: { description: 'Insufficient role — coordinator required' },
+            404: { description: 'No review found for this deliverable' },
           },
         },
       },

--- a/backend/tests/review-assign.smoke.test.js
+++ b/backend/tests/review-assign.smoke.test.js
@@ -1,0 +1,567 @@
+/**
+ * Smoke tests — Process 6.1: POST /api/v1/reviews/assign
+ *
+ * Coverage:
+ *   Auth guards
+ *     401  no Authorization header
+ *     401  malformed JWT
+ *     403  student cannot assign review
+ *     403  committee_member cannot assign review
+ *     403  professor cannot assign review
+ *
+ *   Body validation
+ *     400  missing deliverableId
+ *     400  missing reviewDeadlineDays
+ *     400  reviewDeadlineDays = 0 (below minimum)
+ *     400  reviewDeadlineDays = 31 (above maximum)
+ *     400  reviewDeadlineDays is not an integer (float)
+ *
+ *   Resource checks
+ *     404  deliverable not found
+ *     409  review already exists for this deliverable
+ *     400  deliverable status is not 'accepted'
+ *
+ *   Member validation
+ *     400  selectedCommitteeMembers contains invalid member IDs
+ *
+ *   Happy path (201)
+ *     201  correct response shape: deliverableId, reviewId, assignedCommitteeMembers, assignedCount, deadline, notificationsSent, instructions
+ *     201  assignedCommitteeMembers contains memberId, name, email, status: 'notified'
+ *     201  deadline is approximately now + reviewDeadlineDays
+ *     201  Review document created in DB with correct fields
+ *     201  Deliverable status updated to 'under_review'
+ *     201  selectedCommitteeMembers omitted → all committee members assigned automatically
+ *     201  instructions persisted when provided; null when omitted
+ *     201  AuditLog record created with action REVIEW_ASSIGNED
+ *
+ * Run:
+ *   npm test -- review-assign.smoke.test.js
+ */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'review-assign-smoke-test-secret';
+
+jest.mock('../src/services/notificationService', () => ({
+  dispatchReviewAssignmentNotification: jest.fn().mockResolvedValue({ success: true }),
+  dispatchClarificationRequiredNotification: jest.fn().mockResolvedValue({ success: true }),
+}));
+
+const mongoose = require('mongoose');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { generateAccessToken } = require('../src/utils/jwt');
+const User = require('../src/models/User');
+const Group = require('../src/models/Group');
+const Committee = require('../src/models/Committee');
+const Deliverable = require('../src/models/Deliverable');
+const Review = require('../src/models/Review');
+const AuditLog = require('../src/models/AuditLog');
+
+let mongod;
+let app;
+
+const ENDPOINT = '/api/v1/reviews/assign';
+
+const unique = (prefix) => `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+
+function token(userId, role) {
+  return generateAccessToken(userId, role);
+}
+
+function coordToken() {
+  const id = unique('coord');
+  return { coordId: id, token: token(id, 'coordinator') };
+}
+
+/**
+ * Seed a committee with N advisor Users and return { committee, memberIds, memberEmails }.
+ */
+async function seedCommittee(memberCount = 3, overrides = {}) {
+  const memberIds = Array.from({ length: memberCount }, () => unique('prof'));
+  const memberEmails = memberIds.map((id) => `${id}@uni.edu`);
+
+  await User.insertMany(
+    memberIds.map((userId, i) => ({
+      userId,
+      email: memberEmails[i],
+      hashedPassword: '$2b$10$mock',
+      role: 'professor',
+      accountStatus: 'active',
+      emailVerified: true,
+    }))
+  );
+
+  const committeeId = unique('cmt');
+  const committee = await Committee.create({
+    committeeId,
+    committeeName: `Committee-${committeeId}`,
+    advisorIds: memberIds,
+    juryIds: [],
+    status: 'published',
+    createdBy: unique('coord'),
+    ...overrides,
+  });
+
+  return { committee, memberIds, memberEmails };
+}
+
+/**
+ * Seed a Group and an 'accepted' Deliverable linked to a committee.
+ */
+async function seedDeliverable(committeeId, statusOverride = 'accepted') {
+  const groupId = unique('grp');
+  const leaderId = unique('stu');
+
+  await Group.create({
+    groupId,
+    groupName: `Group-${groupId}`,
+    leaderId,
+    status: 'active',
+    members: [{ userId: leaderId, role: 'leader', status: 'accepted' }],
+  });
+
+  const deliverableId = unique('del');
+  await Deliverable.create({
+    deliverableId,
+    groupId,
+    committeeId,
+    submittedBy: leaderId,
+    deliverableType: 'proposal',
+    status: statusOverride,
+    filePath: `uploads/${deliverableId}/doc.pdf`,
+    fileSize: 102400,
+    fileHash: `sha256_${deliverableId}`,
+    format: 'pdf',
+  });
+
+  return { deliverableId, groupId };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+  app = require('../src/index');
+}, 60000);
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) await mongod.stop();
+});
+
+afterEach(async () => {
+  const { collections } = mongoose.connection;
+  await Promise.all(Object.values(collections).map((c) => c.deleteMany({})));
+  jest.clearAllMocks();
+});
+
+// ===========================================================================
+// Auth guards
+// ===========================================================================
+describe('auth guards', () => {
+  it('401 — no Authorization header', async () => {
+    const res = await request(app).post(ENDPOINT).send({});
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('UNAUTHORIZED');
+  });
+
+  it('401 — malformed JWT', async () => {
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', 'Bearer not.a.real.token')
+      .send({});
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('INVALID_TOKEN');
+  });
+
+  it('403 — student cannot assign review', async () => {
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token(unique('stu'), 'student')}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 7 });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — committee_member cannot assign review', async () => {
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token(unique('cm'), 'committee_member')}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 7 });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 — professor cannot assign review', async () => {
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${token(unique('prof'), 'professor')}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 7 });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ===========================================================================
+// Body validation
+// ===========================================================================
+describe('body validation', () => {
+  it('400 — missing deliverableId', async () => {
+    const { token: t } = coordToken();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ reviewDeadlineDays: 7 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+    expect(res.body.message).toMatch(/deliverableId/i);
+  });
+
+  it('400 — missing reviewDeadlineDays', async () => {
+    const { token: t } = coordToken();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId: unique('del') });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+    expect(res.body.message).toMatch(/reviewDeadlineDays/i);
+  });
+
+  it('400 — reviewDeadlineDays = 0 (minimum is 1)', async () => {
+    const { token: t } = coordToken();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 0 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+  });
+
+  it('400 — reviewDeadlineDays = 31 (maximum is 30)', async () => {
+    const { token: t } = coordToken();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 31 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+  });
+
+  it('400 — reviewDeadlineDays is a float (not an integer)', async () => {
+    const { token: t } = coordToken();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 7.5 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+  });
+});
+
+// ===========================================================================
+// Resource checks
+// ===========================================================================
+describe('resource checks', () => {
+  it('404 — deliverable not found', async () => {
+    const { token: t } = coordToken();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId: unique('del'), reviewDeadlineDays: 7 });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('DELIVERABLE_NOT_FOUND');
+  });
+
+  it('409 — review already exists for this deliverable', async () => {
+    const { committee, memberIds } = await seedCommittee(2);
+    const { deliverableId, groupId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    // First assignment succeeds
+    await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: [memberIds[0]] });
+
+    // Second assignment for the same deliverable
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: [memberIds[1]] });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe('REVIEW_ALREADY_EXISTS');
+  });
+
+  it('400 — deliverable status is not accepted (under_review)', async () => {
+    const { committee, memberIds } = await seedCommittee(1);
+    const { deliverableId } = await seedDeliverable(committee.committeeId, 'under_review');
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DELIVERABLE_STATUS');
+    expect(res.body.message).toMatch(/accepted/i);
+  });
+
+  it('400 — deliverable status is awaiting_resubmission', async () => {
+    const { committee, memberIds } = await seedCommittee(1);
+    const { deliverableId } = await seedDeliverable(committee.committeeId, 'awaiting_resubmission');
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_DELIVERABLE_STATUS');
+  });
+});
+
+// ===========================================================================
+// Member validation
+// ===========================================================================
+describe('member validation', () => {
+  it('400 — selectedCommitteeMembers contains IDs not in committee', async () => {
+    const { committee, memberIds } = await seedCommittee(2);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    const bogusId = unique('bogus');
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({
+        deliverableId,
+        reviewDeadlineDays: 7,
+        selectedCommitteeMembers: [...memberIds, bogusId],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_MEMBER_IDS');
+    expect(res.body.invalidMemberIds).toContain(bogusId);
+    expect(res.body.invalidMemberIds).not.toContain(memberIds[0]);
+  });
+
+  it('400 — all selected member IDs are invalid', async () => {
+    const { committee } = await seedCommittee(1);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({
+        deliverableId,
+        reviewDeadlineDays: 7,
+        selectedCommitteeMembers: [unique('bogus'), unique('bogus')],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_MEMBER_IDS');
+    expect(res.body.invalidMemberIds).toHaveLength(2);
+  });
+});
+
+// ===========================================================================
+// Happy path
+// ===========================================================================
+describe('happy path — 201', () => {
+  it('returns correct top-level response shape', async () => {
+    const { committee, memberIds } = await seedCommittee(3);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+    const selected = memberIds.slice(0, 2);
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({
+        deliverableId,
+        reviewDeadlineDays: 7,
+        selectedCommitteeMembers: selected,
+        instructions: 'Focus on architecture section.',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.deliverableId).toBe(deliverableId);
+    expect(res.body.reviewId).toMatch(/^rev_/);
+    expect(Array.isArray(res.body.assignedCommitteeMembers)).toBe(true);
+    expect(res.body.assignedCount).toBe(selected.length);
+    expect(typeof res.body.deadline).toBe('string');
+    expect(new Date(res.body.deadline).toString()).not.toBe('Invalid Date');
+    expect(res.body.notificationsSent).toBe(selected.length);
+    expect(res.body.instructions).toBe('Focus on architecture section.');
+  });
+
+  it('assignedCommitteeMembers has memberId, name, email, status for each member', async () => {
+    const { committee, memberIds, memberEmails } = await seedCommittee(2);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 5, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(201);
+    const members = res.body.assignedCommitteeMembers;
+    expect(members).toHaveLength(2);
+
+    members.forEach((m) => {
+      expect(m.memberId).toBeDefined();
+      expect(memberIds).toContain(m.memberId);
+      expect(m.status).toBe('notified');
+      expect(m.email).toBe(memberEmails[memberIds.indexOf(m.memberId)]);
+      expect(m.name).toBeDefined();
+    });
+  });
+
+  it('deadline is approximately now + reviewDeadlineDays', async () => {
+    const { committee, memberIds } = await seedCommittee(1);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+    const days = 14;
+
+    const before = Date.now();
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: days, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(201);
+
+    const deadline = new Date(res.body.deadline).getTime();
+    const expectedMin = before + (days - 1) * 86400000;
+    const expectedMax = Date.now() + (days + 1) * 86400000;
+    expect(deadline).toBeGreaterThanOrEqual(expectedMin);
+    expect(deadline).toBeLessThanOrEqual(expectedMax);
+  });
+
+  it('Review document persisted in DB with correct fields', async () => {
+    const { committee, memberIds } = await seedCommittee(2);
+    const { deliverableId, groupId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+    const selected = memberIds.slice(0, 1);
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: selected, instructions: 'Check methodology.' });
+
+    expect(res.status).toBe(201);
+
+    const review = await Review.findOne({ reviewId: res.body.reviewId }).lean();
+    expect(review).not.toBeNull();
+    expect(review.deliverableId).toBe(deliverableId);
+    expect(review.groupId).toBe(groupId);
+    expect(review.status).toBe('pending');
+    expect(review.assignedMembers).toHaveLength(1);
+    expect(review.assignedMembers[0].memberId).toBe(selected[0]);
+    expect(review.assignedMembers[0].status).toBe('notified');
+    expect(review.instructions).toBe('Check methodology.');
+    expect(review.deadline).toBeInstanceOf(Date);
+  });
+
+  it('Deliverable status updated to under_review', async () => {
+    const { committee, memberIds } = await seedCommittee(1);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(201);
+
+    // Allow fire-and-forget update to settle
+    await new Promise((r) => setTimeout(r, 100));
+
+    const deliverable = await Deliverable.findOne({ deliverableId }).lean();
+    expect(deliverable.status).toBe('under_review');
+  });
+
+  it('omitting selectedCommitteeMembers assigns all committee advisors automatically', async () => {
+    const { committee, memberIds } = await seedCommittee(4);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.assignedCount).toBe(memberIds.length);
+    expect(res.body.assignedCommitteeMembers.map((m) => m.memberId)).toEqual(
+      expect.arrayContaining(memberIds)
+    );
+  });
+
+  it('instructions is null in response and DB when not provided', async () => {
+    const { committee, memberIds } = await seedCommittee(1);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 3, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(201);
+    expect(res.body.instructions).toBeNull();
+
+    const review = await Review.findOne({ reviewId: res.body.reviewId }).lean();
+    expect(review.instructions).toBeNull();
+  });
+
+  it('AuditLog record created with REVIEW_ASSIGNED action', async () => {
+    const { committee, memberIds } = await seedCommittee(2);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { coordId, token: t } = coordToken();
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: memberIds });
+
+    expect(res.status).toBe(201);
+
+    // Allow fire-and-forget audit log to write
+    await new Promise((r) => setTimeout(r, 100));
+
+    const audit = await AuditLog.findOne({
+      action: 'REVIEW_ASSIGNED',
+      actorId: coordId,
+      'payload.reviewId': res.body.reviewId,
+    }).lean();
+
+    expect(audit).not.toBeNull();
+    expect(audit.payload.deliverableId).toBe(deliverableId);
+    expect(audit.payload.assignedMemberCount).toBe(memberIds.length);
+  });
+
+  it('notificationsSent equals the number of assigned members', async () => {
+    const { committee, memberIds } = await seedCommittee(3);
+    const { deliverableId } = await seedDeliverable(committee.committeeId);
+    const { token: t } = coordToken();
+    const selected = memberIds.slice(0, 2);
+
+    const res = await request(app)
+      .post(ENDPOINT)
+      .set('Authorization', `Bearer ${t}`)
+      .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: selected });
+
+    expect(res.status).toBe(201);
+    expect(res.body.notificationsSent).toBe(selected.length);
+  });
+});

--- a/backend/tests/review-assignment.test.js
+++ b/backend/tests/review-assignment.test.js
@@ -269,7 +269,7 @@ describe('POST /api/v1/reviews/assign', () => {
       const { userId, token } = tokenCoordinator();
       const scenario = await setupReviewScenario();
       await Deliverable.create(scenario.deliverable);
-      
+
       const selectedMembers = scenario.committeeMembers.slice(0, 2).map((m) => m.userId);
 
       const res = await request(app)
@@ -284,9 +284,13 @@ describe('POST /api/v1/reviews/assign', () => {
 
       expect(res.status).toBe(201);
       expect(res.body.reviewId).toBeTruthy();
-      expect(res.body.status).toBe('pending');
-      expect(res.body.assignedMembers).toHaveLength(selectedMembers.length);
-      expect(res.body.assignedMembers.every((m) => m.status === 'notified')).toBe(true);
+      expect(res.body.deliverableId).toBe(scenario.deliverable.deliverableId);
+      expect(res.body.assignedCommitteeMembers).toHaveLength(selectedMembers.length);
+      expect(res.body.assignedCount).toBe(selectedMembers.length);
+      expect(res.body.assignedCommitteeMembers.every((m) => m.status === 'notified')).toBe(true);
+      expect(res.body.assignedCommitteeMembers.every((m) => m.memberId)).toBe(true);
+      expect(res.body.deadline).toBeDefined();
+      expect(res.body.notificationsSent).toBe(selectedMembers.length);
 
       // Verify Review was created
       const review = await Review.findOne({
@@ -296,6 +300,9 @@ describe('POST /api/v1/reviews/assign', () => {
       expect(review.deliverableId).toBe(scenario.deliverable.deliverableId);
       expect(review.groupId).toBe(scenario.group.groupId);
       expect(review.assignedMembers).toHaveLength(selectedMembers.length);
+
+      // Give fire-and-forget deliverable update a moment to complete
+      await new Promise((r) => setTimeout(r, 100));
 
       // Verify Deliverable was updated to under_review
       const deliverable = await Deliverable.findOne({
@@ -318,10 +325,11 @@ describe('POST /api/v1/reviews/assign', () => {
         });
 
       expect(res.status).toBe(201);
-      expect(res.body.assignedMembers).toHaveLength(
+      expect(res.body.assignedCommitteeMembers).toHaveLength(
         scenario.committee.advisorIds.length
       );
-      expect(res.body.assignedMembers.map((m) => m.memberId)).toEqual(
+      expect(res.body.assignedCount).toBe(scenario.committee.advisorIds.length);
+      expect(res.body.assignedCommitteeMembers.map((m) => m.memberId)).toEqual(
         expect.arrayContaining(scenario.committee.advisorIds)
       );
 
@@ -428,7 +436,7 @@ describe('POST /api/v1/reviews/assign', () => {
         });
 
       expect(secondRes.status).toBe(409);
-      expect(secondRes.body.message).toContain('already exists');
+      expect(secondRes.body.message).toMatch(/already assigned|already exists/i);
     });
   });
 
@@ -450,6 +458,9 @@ describe('POST /api/v1/reviews/assign', () => {
         });
 
       expect(res.status).toBe(201);
+
+      // Allow fire-and-forget audit log to write
+      await new Promise((r) => setTimeout(r, 100));
 
       // Verify audit log created
       const audit = await AuditLog.findOne({

--- a/backend/tests/reviews-auth-middleware.smoke.test.js
+++ b/backend/tests/reviews-auth-middleware.smoke.test.js
@@ -126,7 +126,7 @@ describe('POST /api/v1/reviews/assign', () => {
     expect(res.status).toBe(403);
   });
 
-  it('501 — coordinator reaches stub (auth + role passed)', async () => {
+  it('400 — coordinator passes auth+role; handler rejects missing deliverableId', async () => {
     const token = makeToken(unique('coord'), 'coordinator');
 
     const res = await request(app)
@@ -134,8 +134,8 @@ describe('POST /api/v1/reviews/assign', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
   });
 });
 
@@ -182,15 +182,15 @@ describe('GET /api/v1/reviews/status', () => {
     expect(res.status).toBe(403);
   });
 
-  it('501 — coordinator reaches stub (auth + role passed)', async () => {
+  it('400 — coordinator passes auth+role; handler rejects missing deliverableId param', async () => {
     const token = makeToken(unique('coord'), 'coordinator');
 
     const res = await request(app)
       .get(ENDPOINT)
       .set('Authorization', `Bearer ${token}`);
 
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
   });
 });
 
@@ -300,7 +300,7 @@ describe('POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply', (
     expect(res.status).toBe(403);
   });
 
-  it('501 — student reaches stub (students may reply)', async () => {
+  it('400 — student passes auth+role; handler rejects missing content', async () => {
     const { studentId } = await seedGroupWithStudent();
     const token = makeToken(studentId, 'student');
 
@@ -309,11 +309,11 @@ describe('POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply', (
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
   });
 
-  it('501 — committee_member reaches stub', async () => {
+  it('400 — committee_member passes auth+role; handler rejects missing content', async () => {
     const token = makeToken(unique('cm'), 'committee_member');
 
     const res = await request(app)
@@ -321,11 +321,11 @@ describe('POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply', (
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
   });
 
-  it('501 — coordinator reaches stub', async () => {
+  it('400 — coordinator passes auth+role; handler rejects missing content', async () => {
     const token = makeToken(unique('coord'), 'coordinator');
 
     const res = await request(app)
@@ -333,8 +333,8 @@ describe('POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply', (
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
   });
 });
 
@@ -343,8 +343,9 @@ describe('POST /api/v1/deliverables/:deliverableId/comments/:commentId/reply', (
 // ---------------------------------------------------------------------------
 describe('req.user shape on review routes', () => {
   it('coordinator req.user has userId and role set (groupId null when not in group)', async () => {
-    // We verify indirectly: a valid coordinator token reaches the 501 stub,
+    // Verify indirectly: a valid coordinator token reaches the handler,
     // confirming deliverableAuthMiddleware ran and set req.user without error.
+    // Handler returns 400 (missing deliverableId) — proof auth+middleware ran.
     const coordId = unique('coord');
     const token = makeToken(coordId, 'coordinator');
 
@@ -353,12 +354,12 @@ describe('req.user shape on review routes', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
-    // 501 means auth passed and req.user was set correctly
-    expect(res.status).toBe(501);
+    expect(res.status).toBe(400);
   });
 
   it('student req.user.groupId is populated when student belongs to a group', async () => {
-    // Student can reach reply endpoint — confirms groupId lookup ran successfully
+    // Student can reach the reply handler — confirms groupId lookup ran successfully.
+    // Handler returns 400 (missing content) — proof auth+middleware ran.
     const { studentId } = await seedGroupWithStudent();
     const token = makeToken(studentId, 'student');
 
@@ -367,6 +368,6 @@ describe('req.user shape on review routes', () => {
       .set('Authorization', `Bearer ${token}`)
       .send({});
 
-    expect(res.status).toBe(501);
+    expect(res.status).toBe(400);
   });
 });


### PR DESCRIPTION
## Summary

- **Implements Process 6.1** — `POST /api/v1/reviews/assign`: coordinator assigns a deliverable to committee members for review
  - Validates `reviewDeadlineDays` as integer 1–30; validates `deliverableId` exists with `status: 'accepted'`; returns 404/400/409 for not found / wrong status / duplicate
  - If `selectedCommitteeMembers` is omitted, auto-assigns all committee advisors from D3
  - Validates each selected member ID against the committee's `advisorIds`; returns 400 with `invalidMemberIds`
  - Creates Review document in D5 with `status: 'pending'`, `assignedMembers`, `deadline`, `instructions`
  - Updates Deliverable status to `under_review` (fire-and-forget)
  - Fetches User records to include `name` and `email` in the response's `assignedCommitteeMembers` array
  - Dispatches async notifications via `setImmediate` (non-blocking); response always returns immediately
  - Writes audit log (`REVIEW_ASSIGNED`) fire-and-forget
- **Adds `getReviewStatus`** to `reviewController.js` and updates `routes/reviews.js` to import from `reviewController` (consolidates all Process 6 handlers into one file)
- **Adds Swagger docs** for `POST /reviews/assign` and `GET /reviews/status` under a new `Reviews` tag
- **Fixes `seed-test-general.js`** — deliverables now inherit `committeeId` from their group