### PR TITLE
feat(reviews): add ReviewManagement page and ReviewAssignmentForm component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -28,6 +28,7 @@ import AdvisorAssociationPanel from './components/AdvisorAssociationPanel';
 import DeliverableSubmissionForm from './components/DeliverableSubmissionForm.jsx';
 import SubmitDeliverablePage from './pages/SubmitDeliverablePage.jsx';
 import ReviewPage from './pages/ReviewPage.jsx';
+import ReviewManagement from './pages/ReviewManagement.jsx';
 
 
 const Profile = () => <div className="page">Profile - Coming Soon</div>;
@@ -127,6 +128,10 @@ function App() {
             <Route
               path="/dashboard/reviews/:deliverableId"
               element={<ProtectedRoute component={ReviewPage} requiredRoles={['professor', 'coordinator', 'committee_member', 'admin']} />}
+            />
+            <Route
+              path="/dashboard/reviews"
+              element={<ProtectedRoute component={ReviewManagement} requiredRoles={['coordinator', 'admin']} />}
             />
             <Route
               path="/jury/committees"

--- a/frontend/src/api/reviewAPI.js
+++ b/frontend/src/api/reviewAPI.js
@@ -87,6 +87,61 @@ export const addReply = async (commentId, content) => {
   return response.data;
 };
 
+/**
+ * GET /api/v1/reviews/status
+ * Fetch review management dashboard statistics
+ * @returns {Promise<{pending: number, in_progress: number, needs_clarification: number, completed: number, reviews: Array}>}
+ */
+export const getReviewStatus = async () => {
+  const response = await apiClient.get('/reviews/status');
+  return response.data;
+};
+
+/**
+ * POST /api/v1/reviews/assign
+ * Assign reviewers to a deliverable
+ * @param {Object} data - Assignment data
+ * @param {string} data.deliverableId - ID of the deliverable to assign
+ * @param {number} data.reviewDeadlineDays - Number of days until review deadline (1-30)
+ * @param {Array<string>} data.selectedCommitteeMembers - Array of committee member IDs (optional)
+ * @param {string} data.instructions - Review instructions (optional)
+ * @returns {Promise<{reviewAssignmentId: string, deliverableId: string, assignedCount: number, deadline: string}>}
+ */
+export const assignReview = async (data) => {
+  const response = await apiClient.post('/reviews/assign', data);
+  return response.data;
+};
+
+/**
+ * GET /api/v1/reviews
+ * Fetch all reviews with optional filtering
+ * @param {Object} options - Query parameters
+ * @param {string} options.status - Filter by status: 'pending', 'in_progress', 'needs_clarification', 'completed'
+ * @param {number} options.page - Page number (default 1)
+ * @param {number} options.limit - Items per page (default 20)
+ * @returns {Promise<{reviews: Array, total: number, page: number, limit: number, totalPages: number}>}
+ */
+export const getReviews = async (options = {}) => {
+  const params = new URLSearchParams({
+    page: options.page || 1,
+    limit: options.limit || 20,
+    ...(options.status && { status: options.status }),
+  });
+
+  const response = await apiClient.get(`/reviews?${params.toString()}`);
+  return response.data;
+};
+
+/**
+ * GET /api/v1/committees/candidates
+ * Fetch list of available committee members for assignment
+ * @returns {Promise<{candidates: Array<{id: string, name: string, email: string}>}>}
+ */
+export const getCommitteeCandidates = async () => {
+  const response = await apiClient.get('/committees/candidates');
+  return response.data;
+};
+
 export default {
   getDeliverableDetails,
   getComments,
@@ -94,4 +149,8 @@ export default {
   editComment,
   resolveComment,
   addReply,
+  getReviewStatus,
+  assignReview,
+  getReviews,
+  getCommitteeCandidates,
 };

--- a/frontend/src/components/reviews/ReviewAssignmentForm.css
+++ b/frontend/src/components/reviews/ReviewAssignmentForm.css
@@ -1,0 +1,287 @@
+/* ReviewAssignmentForm.css */
+
+.assignment-form {
+  width: 100%;
+}
+
+/* Modal Overlay */
+.assignment-form-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  padding: 1rem;
+}
+
+/* Modal Container */
+.assignment-form-modal {
+  background-color: white;
+  border-radius: 0.5rem;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 32rem;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+/* Modal Header */
+.assignment-form-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.5rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.assignment-form-header h2 {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.assignment-form-header p {
+  font-size: 0.875rem;
+  color: #4b5563;
+  margin-top: 0.25rem;
+}
+
+/* Modal Body (Form) */
+.assignment-form-body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+/* Form Group */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #1f2937;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.form-input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: #1f2937;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.form-input:disabled {
+  background-color: #f3f4f6;
+  cursor: not-allowed;
+  color: #6b7280;
+}
+
+.form-input[type='number'] {
+  padding: 0.5rem 0.75rem;
+}
+
+.form-input[type='text'] {
+  padding: 0.5rem 0.75rem;
+}
+
+.form-input[type='textarea'],
+textarea.form-input {
+  font-family: inherit;
+  resize: vertical;
+  min-height: 6rem;
+}
+
+.form-input[multiple] {
+  padding: 0.5rem;
+}
+
+.form-input[multiple] option {
+  padding: 0.25rem 0.5rem;
+}
+
+/* Helper Text */
+.form-group > p {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+/* Tags/Chips for Selected Members */
+.form-group > div.mt-2 {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.inline-flex {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  background-color: #dbeafe;
+  color: #0c4a6e;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+}
+
+.inline-flex button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-left: 0.25rem;
+  cursor: pointer;
+  font-weight: 700;
+  color: #1e40af;
+}
+
+.inline-flex button:hover {
+  color: #1e3a8a;
+}
+
+/* Modal Footer */
+.assignment-form-footer {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  padding-top: 1rem;
+  border-top: 1px solid #e5e7eb;
+  margin-top: 0.5rem;
+}
+
+/* Buttons */
+.btn {
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.btn-primary:active:not(:disabled) {
+  background-color: #1d4ed8;
+}
+
+.btn-secondary {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #d1d5db;
+}
+
+.btn-secondary:active:not(:disabled) {
+  background-color: #d1d5db;
+}
+
+/* Alerts */
+.mb-4 {
+  margin-bottom: 1rem;
+}
+
+.p-3 {
+  padding: 0.75rem;
+}
+
+.bg-red-50 {
+  background-color: #fef2f2;
+}
+
+.border-red-200 {
+  border-color: #fecaca;
+}
+
+.text-red-800 {
+  color: #7f1d1d;
+}
+
+.bg-green-50 {
+  background-color: #f0fdf4;
+}
+
+.border-green-200 {
+  border-color: #bbf7d0;
+}
+
+.text-green-800 {
+  color: #15803d;
+}
+
+.bg-yellow-50 {
+  background-color: #fffbeb;
+}
+
+.border-yellow-200 {
+  border-color: #fde68a;
+}
+
+.text-yellow-800 {
+  color: #78350f;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .assignment-form-overlay {
+    padding: 0;
+  }
+
+  .assignment-form-modal {
+    max-width: 100%;
+    border-radius: 0;
+    max-height: 100vh;
+  }
+
+  .assignment-form-header {
+    padding: 1rem;
+  }
+
+  .assignment-form-body {
+    padding: 1rem;
+  }
+
+  .assignment-form-footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/reviews/ReviewAssignmentForm.jsx
+++ b/frontend/src/components/reviews/ReviewAssignmentForm.jsx
@@ -1,0 +1,325 @@
+import React, { useEffect, useState } from 'react';
+import { assignReview, getCommitteeCandidates } from '../../api/reviewAPI';
+import './ReviewAssignmentForm.css';
+
+/**
+ * ReviewAssignmentForm Component
+ * Allows coordinators to assign reviewers to a deliverable
+ * Triggered by clicking on a deliverable with status 'accepted'
+ * Note: authorization is enforced at the route level (ReviewManagement page)
+ */
+const ReviewAssignmentForm = ({ deliverable, onSuccess, onCancel }) => {
+  // Form state
+  const [reviewDeadlineDays, setReviewDeadlineDays] = useState(7);
+  const [selectedCommitteeMembers, setSelectedCommitteeMembers] = useState([]);
+  const [instructions, setInstructions] = useState('');
+  const [candidates, setCandidates] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [candidatesLoading, setCandidatesLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  // Get deliverable type display name
+  const getDeliverableTypeName = (type) => {
+    const names = {
+      proposal: 'Proposal',
+      statement_of_work: 'Statement of Work',
+      demo: 'Demo',
+      interim_report: 'Interim Report',
+      final_report: 'Final Report',
+    };
+    return names[type] || type;
+  };
+
+  // Format date
+  const formatDate = (date) => {
+    return new Date(date).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  // Fetch committee candidates on mount
+  useEffect(() => {
+    const fetchCandidates = async () => {
+      try {
+        setCandidatesLoading(true);
+        const data = await getCommitteeCandidates();
+        setCandidates(data.candidates || []);
+      } catch (err) {
+        const message = err?.response?.data?.message || 'Failed to load committee members';
+        setError(message);
+      } finally {
+        setCandidatesLoading(false);
+      }
+    };
+
+    fetchCandidates();
+  }, []);
+
+  // Handle committee member multi-select
+  const handleMemberChange = (e) => {
+    const options = e.target.options;
+    const selected = [];
+    for (let i = 0; i < options.length; i++) {
+      if (options[i].selected) {
+        selected.push(options[i].value);
+      }
+    }
+    setSelectedCommitteeMembers(selected);
+  };
+
+  // Validate form fields
+  const validateForm = () => {
+    if (!reviewDeadlineDays || reviewDeadlineDays < 1 || reviewDeadlineDays > 30) {
+      setError('Review deadline must be between 1 and 30 days');
+      return false;
+    }
+
+    if (instructions.length > 2000) {
+      setError('Instructions cannot exceed 2000 characters');
+      return false;
+    }
+
+    return true;
+  };
+
+  // Handle form submission
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+
+    if (!validateForm()) return;
+
+    try {
+      setLoading(true);
+
+      const assignmentData = {
+        deliverableId: deliverable.id || deliverable.deliverableId,
+        reviewDeadlineDays: parseInt(reviewDeadlineDays, 10),
+        ...(selectedCommitteeMembers.length > 0 && { selectedCommitteeMembers }),
+        ...(instructions.trim() && { instructions: instructions.trim() }),
+      };
+
+      const result = await assignReview(assignmentData);
+
+      const deadlineDate = new Date();
+      deadlineDate.setDate(deadlineDate.getDate() + parseInt(reviewDeadlineDays, 10));
+
+      setSuccess(
+        `Review assignment successful! ${
+          result.assignedCount || selectedCommitteeMembers.length || 'Reviewers'
+        } assigned. Deadline: ${formatDate(deadlineDate)}`
+      );
+
+      // Call onSuccess after showing confirmation briefly
+      setTimeout(() => {
+        if (onSuccess) onSuccess(result);
+      }, 2000);
+    } catch (err) {
+      const message = err?.response?.data?.message || 'Failed to assign review';
+      const code = err?.response?.data?.code;
+
+      if (err?.response?.status === 403) {
+        setError('You do not have permission to assign reviews');
+      } else if (code) {
+        setError(`${message} (${code})`);
+      } else {
+        setError(message);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!deliverable) {
+    return (
+      <div className="assignment-form bg-red-50 border border-red-200 rounded-lg p-4">
+        <p className="text-red-800">No deliverable selected.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="assignment-form-overlay" role="dialog" aria-modal="true" aria-labelledby="assign-form-title">
+      <div className="assignment-form-modal">
+        {/* Header */}
+        <div className="assignment-form-header">
+          <div>
+            <h2 id="assign-form-title" className="text-xl font-bold text-gray-900">
+              Assign Reviewers
+            </h2>
+            <p className="text-sm text-gray-600 mt-1">
+              {getDeliverableTypeName(deliverable.deliverableType || deliverable.type)} •{' '}
+              {deliverable.groupId || deliverable.group_id}
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            className="text-gray-400 hover:text-gray-600 text-2xl leading-none"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="assignment-form-body">
+          {/* Error Alert */}
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg" role="alert">
+              <p className="text-red-800 text-sm">{error}</p>
+            </div>
+          )}
+
+          {/* Success Alert */}
+          {success && (
+            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg" role="status">
+              <p className="text-green-800 text-sm">{success}</p>
+            </div>
+          )}
+
+          {/* Deliverable ID (Read-only) */}
+          <div className="form-group">
+            <label htmlFor="deliverableId" className="form-label">
+              Deliverable ID
+            </label>
+            <input
+              type="text"
+              id="deliverableId"
+              value={deliverable.id || deliverable.deliverableId || ''}
+              disabled
+              className="form-input"
+            />
+          </div>
+
+          {/* Review Deadline Days */}
+          <div className="form-group">
+            <label htmlFor="reviewDeadlineDays" className="form-label">
+              Review Deadline (Days) <span className="text-red-500" aria-hidden="true">*</span>
+            </label>
+            <input
+              type="number"
+              id="reviewDeadlineDays"
+              min="1"
+              max="30"
+              value={reviewDeadlineDays}
+              onChange={(e) => setReviewDeadlineDays(e.target.value)}
+              required
+              disabled={loading}
+              className="form-input"
+              placeholder="e.g., 7"
+            />
+            <p className="text-xs text-gray-600 mt-1">Between 1 and 30 days</p>
+          </div>
+
+          {/* Committee Members Multi-Select */}
+          <div className="form-group">
+            <label htmlFor="committees" className="form-label">
+              Assign Committee Members (Optional)
+            </label>
+            {candidatesLoading ? (
+              <div className="text-sm text-gray-600">Loading committee members...</div>
+            ) : candidates.length === 0 ? (
+              <div className="text-sm text-gray-600 bg-yellow-50 border border-yellow-200 rounded p-2">
+                No committee members available for assignment
+              </div>
+            ) : (
+              <select
+                id="committees"
+                multiple
+                value={selectedCommitteeMembers}
+                onChange={handleMemberChange}
+                disabled={loading || candidatesLoading}
+                className="form-input"
+                size="5"
+                aria-describedby="committees-hint"
+              >
+                {candidates.map((candidate) => (
+                  <option key={candidate.id} value={candidate.id}>
+                    {candidate.name} ({candidate.email})
+                  </option>
+                ))}
+              </select>
+            )}
+            <p id="committees-hint" className="text-xs text-gray-600 mt-1">
+              Hold Ctrl/Cmd to select multiple members
+            </p>
+
+            {/* Selected member tags */}
+            {selectedCommitteeMembers.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2" aria-label="Selected members">
+                {selectedCommitteeMembers.map((memberId) => {
+                  const member = candidates.find((c) => c.id === memberId);
+                  return (
+                    <span
+                      key={memberId}
+                      className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 text-xs rounded"
+                    >
+                      {member?.name || memberId}
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setSelectedCommitteeMembers(
+                            selectedCommitteeMembers.filter((m) => m !== memberId)
+                          )
+                        }
+                        className="text-blue-600 hover:text-blue-900 font-bold"
+                        aria-label={`Remove ${member?.name || memberId}`}
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Instructions */}
+          <div className="form-group">
+            <label htmlFor="instructions" className="form-label">
+              Review Instructions (Optional)
+            </label>
+            <textarea
+              id="instructions"
+              value={instructions}
+              onChange={(e) => setInstructions(e.target.value)}
+              maxLength="2000"
+              rows="4"
+              disabled={loading}
+              className="form-input"
+              placeholder="Enter specific review instructions or criteria..."
+            />
+            <p className="text-xs text-gray-600 mt-1" aria-live="polite">
+              {instructions.length}/2000 characters
+            </p>
+          </div>
+
+          {/* Form Actions */}
+          <div className="assignment-form-footer">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={loading}
+              className="btn btn-secondary"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={loading || candidatesLoading}
+              className="btn btn-primary"
+            >
+              {loading ? 'Assigning...' : 'Assign Reviewers'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ReviewAssignmentForm;

--- a/frontend/src/pages/ReviewManagement.css
+++ b/frontend/src/pages/ReviewManagement.css
@@ -1,0 +1,322 @@
+/* ReviewManagement.css */
+
+.review-management-page {
+  width: 100%;
+  min-height: 100vh;
+  background-color: #f9fafb;
+}
+
+/* Header */
+.review-management-header {
+  background: white;
+  border-bottom: 1px solid #e5e7eb;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+}
+
+.page-title {
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: #111827;
+  margin: 0;
+}
+
+.page-subtitle {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 0.5rem;
+}
+
+/* Statistics Container */
+.review-stats-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  max-width: 72rem; /* FIX: was 6rem, cards were invisible */
+  margin: 0 auto 2rem;
+  padding: 0 1rem;
+}
+
+.stat-card {
+  background: white;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+  padding: 1.5rem;
+  text-align: center;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.15s;
+}
+
+.stat-card:hover {
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+.stat-value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  color: #6b7280;
+  margin-top: 0.5rem;
+  font-weight: 500;
+}
+
+/* Controls */
+.review-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  background: white;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+}
+
+.filter-label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.5rem;
+}
+
+.filter-select {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  color: #1f2937;
+  background-color: white;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* Table Container */
+.reviews-table-container {
+  background: white;
+  border-radius: 0.5rem;
+  border: 1px solid #e5e7eb;
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.reviews-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.reviews-table thead {
+  background-color: #f3f4f6;
+  border-bottom: 2px solid #e5e7eb;
+}
+
+.reviews-table th {
+  padding: 0.75rem;
+  text-align: left;
+  font-weight: 600;
+  color: #374151;
+  white-space: nowrap;
+}
+
+.reviews-table tbody tr {
+  border-bottom: 1px solid #e5e7eb;
+  transition: background-color 0.15s;
+}
+
+.reviews-table tbody tr:hover {
+  background-color: #f9fafb;
+}
+
+.reviews-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.reviews-table td {
+  padding: 0.75rem;
+  color: #1f2937;
+}
+
+.reviews-table code {
+  background-color: #f3f4f6;
+  padding: 0.125rem 0.375rem;
+  border-radius: 0.25rem;
+  font-family: 'Monaco', 'Courier New', monospace;
+  color: #7c2d12;
+}
+
+/* Status Badge */
+.status-badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* Action Buttons */
+.btn-sm {
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.btn-sm:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background-color: #3b82f6;
+  color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background-color: #2563eb;
+  text-decoration: none;
+}
+
+.btn-secondary {
+  background-color: #e5e7eb;
+  color: #374151;
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background-color: #d1d5db;
+  text-decoration: none;
+}
+
+/* Empty State */
+.empty-state {
+  padding: 2rem;
+  text-align: center;
+  color: #6b7280;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding: 1rem;
+}
+
+.pagination-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  background-color: white;
+  color: #374151;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.pagination-btn:hover:not(:disabled) {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  color: #9ca3af;
+}
+
+.pagination-info {
+  font-size: 0.875rem;
+  color: #6b7280;
+  font-weight: 500;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .review-management-header {
+    padding: 1.5rem;
+  }
+
+  .review-stats-container {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+  }
+
+  .review-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-select {
+    width: 100%;
+  }
+
+  .reviews-table {
+    font-size: 0.75rem;
+  }
+
+  .reviews-table th,
+  .reviews-table td {
+    padding: 0.5rem 0.375rem;
+  }
+
+  .reviews-table code {
+    font-size: 0.7rem;
+  }
+
+  .btn-sm {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.7rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .reviews-table-container {
+    border-radius: 0;
+    margin: 0 -1rem;
+  }
+
+  .reviews-table {
+    font-size: 0.7rem;
+  }
+
+  .reviews-table th,
+  .reviews-table td {
+    padding: 0.375rem 0.25rem;
+  }
+
+  .review-stats-container {
+    max-width: 100%;
+  }
+
+  .stat-value {
+    font-size: 1.5rem;
+  }
+}

--- a/frontend/src/pages/ReviewManagement.jsx
+++ b/frontend/src/pages/ReviewManagement.jsx
@@ -1,0 +1,390 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getReviewStatus, getReviews } from '../api/reviewAPI';
+import ReviewAssignmentForm from '../components/reviews/ReviewAssignmentForm';
+import useAuthStore from '../store/authStore';
+import './ReviewManagement.css';
+
+/**
+ * ReviewManagement Page Component
+ * Coordinator-only dashboard for managing review assignments and monitoring progress
+ * URL: /dashboard/reviews
+ */
+const ReviewManagement = () => {
+  const navigate = useNavigate();
+  const user = useAuthStore((state) => state.user);
+
+  // State management
+  const [stats, setStats] = useState({
+    pending: 0,
+    in_progress: 0,
+    needs_clarification: 0,
+    completed: 0,
+  });
+  const [reviews, setReviews] = useState([]);
+  // FIX: removed unused filteredReviews state
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [selectedDeliverable, setSelectedDeliverable] = useState(null);
+  const [showAssignmentForm, setShowAssignmentForm] = useState(false);
+
+  const PAGE_SIZE = 20;
+
+  // Get deliverable type display name
+  const getDeliverableTypeName = (type) => {
+    const names = {
+      proposal: 'Proposal',
+      statement_of_work: 'Statement of Work',
+      demo: 'Demo',
+      interim_report: 'Interim Report',
+      final_report: 'Final Report',
+    };
+    return names[type] || type;
+  };
+
+  // Get status badge styling
+  const getStatusBadge = (status) => {
+    const styles = {
+      pending: 'bg-gray-100 text-gray-800',
+      in_progress: 'bg-blue-100 text-blue-800',
+      needs_clarification: 'bg-yellow-100 text-yellow-800',
+      completed: 'bg-green-100 text-green-800',
+    };
+    return styles[status] || 'bg-gray-100 text-gray-800';
+  };
+
+  // Format date helper
+  const formatDate = (date) => {
+    if (!date) return 'N/A';
+    return new Date(date).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  // Fetch review status and stats
+  const fetchReviewStatus = useCallback(async () => {
+    try {
+      const data = await getReviewStatus();
+      setStats({
+        pending: data.pending || 0,
+        in_progress: data.in_progress || 0,
+        needs_clarification: data.needs_clarification || 0,
+        completed: data.completed || 0,
+      });
+    } catch (err) {
+      const message = err?.response?.data?.message || 'Failed to load review statistics';
+      if (err?.response?.status === 403) {
+        setError('You do not have permission to view reviews');
+        navigate('/dashboard');
+      } else {
+        setError(message);
+      }
+    }
+  }, [navigate]);
+
+  // Fetch reviews with optional filtering
+  // FIX: added loading state management here so loading covers both calls
+  const fetchReviews = useCallback(async (page = 1, status = 'all') => {
+    try {
+      const options = {
+        page,
+        limit: PAGE_SIZE,
+        ...(status !== 'all' && { status }),
+      };
+
+      const data = await getReviews(options);
+      setReviews(data.reviews || []);
+      setCurrentPage(data.page || 1);
+      setTotalPages(data.totalPages || 1);
+    } catch (err) {
+      const message = err?.response?.data?.message || 'Failed to load reviews';
+      setError(message);
+    }
+  }, []);
+
+  // FIX: initial load runs both fetches in parallel under a single loading gate
+  // statusFilter is NOT in the dependency array to avoid double-fetching on filter change
+  useEffect(() => {
+    if (!user || (user.role !== 'coordinator' && user.role !== 'admin')) {
+      navigate('/dashboard');
+      return;
+    }
+
+    const initialLoad = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        await Promise.all([fetchReviewStatus(), fetchReviews(1, 'all')]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    initialLoad();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user, navigate]);
+
+  // Handle status filter change — manual fetch, no useEffect dependency on statusFilter
+  const handleStatusFilterChange = async (status) => {
+    setStatusFilter(status);
+    setCurrentPage(1);
+    setError('');
+    setLoading(true);
+    try {
+      await fetchReviews(1, status);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Handle pagination
+  const handlePageChange = async (newPage) => {
+    setError('');
+    setLoading(true);
+    try {
+      await fetchReviews(newPage, statusFilter);
+    } finally {
+      setLoading(false);
+    }
+    document.querySelector('.reviews-table-container')?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  // Handle assignment form open
+  const handleAssignClick = (review) => {
+    setSelectedDeliverable(review);
+    setShowAssignmentForm(true);
+  };
+
+  // Handle assignment form close
+  const handleAssignmentClose = () => {
+    setShowAssignmentForm(false);
+    setSelectedDeliverable(null);
+  };
+
+  // Handle assignment success — refresh both stats and list
+  const handleAssignmentSuccess = async () => {
+    setShowAssignmentForm(false);
+    setSelectedDeliverable(null);
+    setLoading(true);
+    setError('');
+    try {
+      await Promise.all([fetchReviewStatus(), fetchReviews(currentPage, statusFilter)]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Authorization check (before loading UI)
+  if (!user || (user.role !== 'coordinator' && user.role !== 'admin')) {
+    return (
+      <div className="review-management-page">
+        <div className="max-w-4xl mx-auto p-8">
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-yellow-900 mb-2">Access Denied</h2>
+            <p className="text-yellow-800 mb-4">
+              You do not have permission to access the review management dashboard.
+            </p>
+            <a
+              href="/dashboard"
+              className="inline-block px-4 py-2 bg-yellow-600 text-white rounded-md hover:bg-yellow-700"
+            >
+              ← Back to Dashboard
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="review-management-page">
+        <div className="flex items-center justify-center h-screen">
+          <div className="text-center">
+            <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+            <p className="mt-4 text-gray-600 font-medium">Loading reviews...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="review-management-page">
+      {/* Header */}
+      <div className="review-management-header">
+        <div>
+          <h1 className="page-title">Review Management</h1>
+          <p className="page-subtitle">Monitor and assign deliverable reviews</p>
+        </div>
+      </div>
+
+      {/* Error Alert */}
+      {error && (
+        <div className="max-w-6xl mx-auto px-4 mb-4">
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+            <p className="text-red-800">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Statistics Cards */}
+      <div className="review-stats-container">
+        <div className="stat-card">
+          <div className="stat-value text-gray-700">{stats.pending}</div>
+          <div className="stat-label">Pending</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-value text-blue-600">{stats.in_progress}</div>
+          <div className="stat-label">In Progress</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-value text-yellow-600">{stats.needs_clarification}</div>
+          <div className="stat-label">Clarification</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-value text-green-600">{stats.completed}</div>
+          <div className="stat-label">Completed</div>
+        </div>
+      </div>
+
+      {/* Reviews Section */}
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        {/* Filter Controls */}
+        <div className="review-controls">
+          <div>
+            <label htmlFor="statusFilter" className="filter-label">
+              Filter by Status:
+            </label>
+            <select
+              id="statusFilter"
+              value={statusFilter}
+              onChange={(e) => handleStatusFilterChange(e.target.value)}
+              className="filter-select"
+            >
+              <option value="all">All Reviews</option>
+              <option value="pending">Pending</option>
+              <option value="in_progress">In Progress</option>
+              <option value="needs_clarification">Needs Clarification</option>
+              <option value="completed">Completed</option>
+            </select>
+          </div>
+        </div>
+
+        {/* Reviews Table */}
+        <div className="reviews-table-container">
+          {reviews.length === 0 ? (
+            <div className="empty-state">
+              <p className="text-gray-600">No reviews found.</p>
+            </div>
+          ) : (
+            <div className="table-wrapper">
+              <table className="reviews-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Deliverable ID</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Group ID</th>
+                    <th scope="col">Sprint</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Comments</th>
+                    <th scope="col">Clarifications</th>
+                    <th scope="col">Deadline</th>
+                    <th scope="col">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {reviews.map((review) => (
+                    <tr key={review.deliverableId || review.id}>
+                      <td>
+                        <code className="text-sm">{review.deliverableId || review.id}</code>
+                      </td>
+                      <td>{getDeliverableTypeName(review.deliverableType || review.type)}</td>
+                      <td>{review.groupId || review.group_id || 'N/A'}</td>
+                      <td>{review.sprintId || review.sprint_id || 'N/A'}</td>
+                      <td>
+                        <span
+                          className={`status-badge ${getStatusBadge(
+                            review.reviewStatus || review.status
+                          )}`}
+                        >
+                          {(review.reviewStatus || review.status || 'pending')
+                            .replace(/_/g, ' ')
+                            .replace(/\b\w/g, (c) => c.toUpperCase())}
+                        </span>
+                      </td>
+                      <td className="text-center">{review.commentCount || 0}</td>
+                      <td className="text-center">{review.clarificationsRemaining || 0}</td>
+                      <td>{formatDate(review.deadline)}</td>
+                      <td>
+                        {review.deliverableStatus === 'accepted' && !review.reviewStatus ? (
+                          <button
+                            onClick={() => handleAssignClick(review)}
+                            className="btn-sm btn-primary"
+                            title="Assign reviewers to this deliverable"
+                          >
+                            Assign
+                          </button>
+                        ) : (
+                          <a
+                            href={`/dashboard/reviews/${review.deliverableId || review.id}`}
+                            className="btn-sm btn-secondary"
+                            title="View review details"
+                          >
+                            View
+                          </a>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="pagination">
+            <button
+              onClick={() => handlePageChange(currentPage - 1)}
+              disabled={currentPage === 1}
+              className="pagination-btn"
+              aria-label="Previous page"
+            >
+              ← Previous
+            </button>
+            <span className="pagination-info" aria-live="polite">
+              Page {currentPage} of {totalPages}
+            </span>
+            <button
+              onClick={() => handlePageChange(currentPage + 1)}
+              disabled={currentPage === totalPages}
+              className="pagination-btn"
+              aria-label="Next page"
+            >
+              Next →
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Assignment Form Modal */}
+      {showAssignmentForm && selectedDeliverable && (
+        <ReviewAssignmentForm
+          deliverable={selectedDeliverable}
+          onSuccess={handleAssignmentSuccess}
+          onCancel={handleAssignmentClose}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ReviewManagement;


### PR DESCRIPTION
## Summary
Implements the coordinator review management dashboard as described in the issue.

## Changes
- **`frontend/src/pages/ReviewManagement.jsx`** — Coordinator-only dashboard at `/dashboard/reviews`. Fetches stats via `GET /api/reviews/status`, lists reviews via `GET /api/reviews` with status filter and pagination. Redirects non-coordinators to `/dashboard`.
- **`frontend/src/components/reviews/ReviewAssignmentForm.jsx`** — Modal form triggered by clicking an unassigned (`accepted`) deliverable. Submits to `POST /api/reviews/assign`. Shows assigned count and deadline on success.
- **`frontend/src/api/reviewAPI.js`** — API abstraction layer for all review and committee endpoints.
- **`frontend/src/App.jsx`** — Route registered for `/dashboard/reviews`.

## Notes
⚠️ Full integration testing is pending — backend endpoints (`GET /api/reviews/status`, `GET /api/reviews`, `POST /api/reviews/assign`, `GET /api/committees/candidates`) are not yet available. Verification will be done once #186 and #190 are merged.

## Testing Done
- Coordinator redirect and access control verified at route level
- Student attempting to access `/dashboard/reviews` correctly redirected
- Filter, pagination, and loading state logic reviewed
- Accessibility: `aria` roles, `scope` on table headers, `aria-live` on dynamic content