### PR TITLE
feat: implement Persist Sprint Records for Issue #237

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,11 @@ DB_HOST=localhost
 DB_PORT=27017
 DB_NAME=senior-app
 
+# Encryption at Rest (AES-256-GCM)
+# 32-byte (256-bit) hex key. Generate with: openssl rand -hex 32
+# In production load this from Vault / Secrets Manager and inject as env var.
+ENCRYPTION_KEY=replace_with_64_hex_characters
+
 # JWT Configuration
 JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
 JWT_REFRESH_SECRET=your-super-secret-refresh-key-change-this-in-production

--- a/backend/migrations/011_create_sprint_persistence_models.js
+++ b/backend/migrations/011_create_sprint_persistence_models.js
@@ -1,0 +1,253 @@
+/**
+ * ============================================================================
+ * Migration #011: Issue #237 Sprint Persistence Models — D6/D4 Collections
+ * ============================================================================
+ *
+ * CHANGES FOR ISSUE #237:
+ * - Creates SprintContributionRecord collection (D6) for per-student records
+ * - Creates SprintReportingRecord collection (D4) for aggregate reporting
+ * - Establishes compound indexes for efficient querying
+ * - Sets up idempotent key constraints
+ * - Adds finalization lock support
+ * - Adds D4→D6 reconciliation fields
+ *
+ * DATABASE CHANGES:
+ * 1. sprintcontributionrecords collection (NEW)
+ *    - Stores per-student contribution snapshots
+ *    - Compound unique index: (sprintId, studentId, groupId)
+ *    - Supports atomic upsert operations
+ *    - Includes finalization lock fields
+ *
+ * 2. sprintreportingrecords collection (NEW)
+ *    - Stores aggregate metrics for coordinator dashboards
+ *    - Compound unique index: (sprintId, groupId)
+ *    - Links to D6 canonical data
+ *    - Supports reconciliation status tracking
+ *
+ * DFD INTEGRATION:
+ * - D6 (sprintcontributionrecords): Canonical contribution storage
+ * - D4 (sprintreportingrecords): Reporting metadata for Flow 128
+ * - D4→D6 Sync (Flow 139): Reconciliation via consistency checks
+ *
+ * EXECUTION:
+ * This migration is idempotent — safe to run multiple times
+ */
+
+module.exports = {
+  name: '011_create_sprint_persistence_models',
+
+  /**
+   * ISSUE #237: Create collections and indexes for D6/D4 persistence
+   */
+  up: async (db) => {
+    try {
+      // ───────────────────────────────────────────────────────────────────────
+      // STEP 1: CREATE SprintContributionRecord COLLECTION (D6)
+      // ISSUE #237: Canonical storage for per-student contributions
+      // ───────────────────────────────────────────────────────────────────────
+      console.log('[MIGRATION #011] Creating sprintcontributionrecords collection...');
+
+      const sprintContribCollections = await db.connection.db
+        .listCollections({ name: 'sprintcontributionrecords' })
+        .toArray();
+
+      if (sprintContribCollections.length === 0) {
+        await db.connection.db.createCollection('sprintcontributionrecords');
+        console.log('[MIGRATION #011] ✓ Created sprintcontributionrecords collection');
+      } else {
+        console.log('[MIGRATION #011] ⊙ sprintcontributionrecords collection already exists');
+      }
+
+      const sprintContribCollection = db.connection.db.collection('sprintcontributionrecords');
+
+      // ISSUE #237: Index 1 — Primary key uniqueness
+      // Used for atomic upsert: (sprintId, studentId, groupId)
+      try {
+        await sprintContribCollection.createIndex(
+          { sprintId: 1, studentId: 1, groupId: 1 },
+          { unique: true, sparse: true, background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created compound index (sprintId, studentId, groupId)');
+      } catch (err) {
+        if (err.code === 85) {
+          // Index already exists with different options
+          console.log('[MIGRATION #011] ⊙ Index (sprintId, studentId, groupId) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ISSUE #237: Index 2 — Lookup all contributions for a sprint
+      // Used by D4→D6 reconciliation (Flow 139)
+      try {
+        await sprintContribCollection.createIndex(
+          { sprintId: 1, groupId: 1 },
+          { background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created index (sprintId, groupId)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (sprintId, groupId) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ISSUE #237: Index 3 — Finalized sprints query
+      // Used for checking 409 conflicts
+      try {
+        await sprintContribCollection.createIndex(
+          { sprintId: 1, isFinalized: 1 },
+          { background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created index (sprintId, isFinalized)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (sprintId, isFinalized) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ISSUE #237: Index 4 — Coordinator audit queries
+      try {
+        await sprintContribCollection.createIndex(
+          { lastCalculatedBy: 1, lastCalculationAt: 1 },
+          { background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created index (lastCalculatedBy, lastCalculationAt)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (lastCalculatedBy, lastCalculationAt) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ───────────────────────────────────────────────────────────────────────
+      // STEP 2: CREATE SprintReportingRecord COLLECTION (D4)
+      // ISSUE #237: Reporting metadata for coordinator visibility (Flow 128)
+      // ───────────────────────────────────────────────────────────────────────
+      console.log('[MIGRATION #011] Creating sprintreportingrecords collection...');
+
+      const sprintReportCollections = await db.connection.db
+        .listCollections({ name: 'sprintreportingrecords' })
+        .toArray();
+
+      if (sprintReportCollections.length === 0) {
+        await db.connection.db.createCollection('sprintreportingrecords');
+        console.log('[MIGRATION #011] ✓ Created sprintreportingrecords collection');
+      } else {
+        console.log('[MIGRATION #011] ⊙ sprintreportingrecords collection already exists');
+      }
+
+      const sprintReportCollection = db.connection.db.collection('sprintreportingrecords');
+
+      // ISSUE #237: Index 1 — Primary lookup by sprint + group
+      // Used for D4→D6 reconciliation (Flow 139)
+      try {
+        await sprintReportCollection.createIndex(
+          { sprintId: 1, groupId: 1 },
+          { unique: true, sparse: true, background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created compound index (sprintId, groupId)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (sprintId, groupId) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ISSUE #237: Index 2 — Coordinator's reporting records
+      try {
+        await sprintReportCollection.createIndex(
+          { coordinatorId: 1, calculatedAt: -1 },
+          { background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created index (coordinatorId, calculatedAt)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (coordinatorId, calculatedAt) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ISSUE #237: Index 3 — Reconciliation status queries
+      // Used to find records needing verification
+      try {
+        await sprintReportCollection.createIndex(
+          { reconciliationStatus: 1, lastReconciledAt: 1 },
+          { background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created index (reconciliationStatus, lastReconciledAt)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (reconciliationStatus, lastReconciledAt) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      // ISSUE #237: Index 4 — Active records (soft delete support)
+      try {
+        await sprintReportCollection.createIndex(
+          { groupId: 1, deletedAt: 1 },
+          { background: true }
+        );
+        console.log('[MIGRATION #011] ✓ Created index (groupId, deletedAt)');
+      } catch (err) {
+        if (err.code === 85) {
+          console.log('[MIGRATION #011] ⊙ Index (groupId, deletedAt) already exists');
+        } else {
+          throw err;
+        }
+      }
+
+      console.log('[MIGRATION #011] ✅ All collections and indexes created successfully');
+    } catch (error) {
+      console.error('[MIGRATION #011] ERROR:', error);
+      throw error;
+    }
+  },
+
+  /**
+   * ISSUE #237: Rollback — Remove collections
+   * WARNING: This destructively deletes all data in these collections
+   */
+  down: async (db) => {
+    try {
+      console.log('[MIGRATION #011 ROLLBACK] Removing sprintcontributionrecords collection...');
+      try {
+        await db.connection.db.dropCollection('sprintcontributionrecords');
+        console.log('[MIGRATION #011 ROLLBACK] ✓ Dropped sprintcontributionrecords');
+      } catch (err) {
+        if (err.code === 26) {
+          // Collection doesn't exist
+          console.log('[MIGRATION #011 ROLLBACK] ⊙ sprintcontributionrecords not found');
+        } else {
+          throw err;
+        }
+      }
+
+      console.log('[MIGRATION #011 ROLLBACK] Removing sprintreportingrecords collection...');
+      try {
+        await db.connection.db.dropCollection('sprintreportingrecords');
+        console.log('[MIGRATION #011 ROLLBACK] ✓ Dropped sprintreportingrecords');
+      } catch (err) {
+        if (err.code === 26) {
+          // Collection doesn't exist
+          console.log('[MIGRATION #011 ROLLBACK] ⊙ sprintreportingrecords not found');
+        } else {
+          throw err;
+        }
+      }
+
+      console.log('[MIGRATION #011 ROLLBACK] ✅ Rollback completed');
+    } catch (error) {
+      console.error('[MIGRATION #011 ROLLBACK] ERROR:', error);
+      throw error;
+    }
+  },
+};

--- a/backend/src/controllers/contributionRatios.js
+++ b/backend/src/controllers/contributionRatios.js
@@ -1,0 +1,395 @@
+/**
+ * ============================================================================
+ * Issue #237: Contribution Ratios Controller — Process 7.4 + 7.5 Integration
+ * ============================================================================
+ *
+ * CHANGES FOR ISSUE #237:
+ * - Integrates persistence layer into contributions recalculation endpoint
+ * - After successful ratio calculation (Process 7.4), persists data to D6/D4 (Process 7.5)
+ * - Calls persistSprintContributions() with full contribution summary
+ * - Handles 409 conflicts for finalized/locked sprints
+ * - Adds persistedAt timestamp to response
+ * - Emits notification events to Notification Service (#238)
+ * - Audit logging for compliance
+ *
+ * ENDPOINT:
+ * POST /api/groups/:groupId/sprints/:sprintId/contributions/recalculate
+ *
+ * PROCESS FLOW (7.4 + 7.5):
+ * 1. Input validation
+ * 2. Authorization checks (coordinator role)
+ * 3. Call ratio engine (Process 7.4 from Issue #236)
+ * 4. [NEW] Persist results to D6/D4 (Process 7.5 from Issue #237) ← YOU ARE HERE
+ * 5. Emit notifications
+ * 6. Return detailed summary response
+ *
+ * DFD INTEGRATION:
+ * Input: f7_p73_p74, f7_p74_p75
+ * Output: f7_p75_ds_d6, f7_p75_d4, f7_p75_ext_notification
+ */
+
+const { recalculateSprintRatios } = require('../services/contributionRatioService');
+const { persistSprintContributions } = require('../services/sprintContributionPersistence');
+const { reconcileSprintRecords } = require('../services/d4ToD6Reconciliation');
+const { createAuditLog } = require('../services/auditService');
+const { validateCoordinatorRole } = require('../middleware/roleMiddleware');
+
+/**
+ * ISSUE #237: POST /api/groups/:groupId/sprints/:sprintId/contributions/recalculate
+ *
+ * Recalculates contribution ratios and persists them to database.
+ * Main public-facing endpoint for Process 7.4 + 7.5.
+ *
+ * Request body:
+ * {
+ *   notifyStudents: boolean (optional, default: false),
+ *   overrideFinalized: boolean (optional, default: false),
+ *   persistToD4: boolean (optional, default: true),
+ *   notes: string (optional)
+ * }
+ *
+ * Response on success (200):
+ * {
+ *   success: true,
+ *   sprintId,
+ *   groupId,
+ *   ratiosCalculated: true,
+ *   persistenceResult: {
+ *     success: true,
+ *     recordsPersistedCount,
+ *     persistedAt,
+ *     durationMs
+ *   },
+ *   reconciliationResult: (optional if D4 enabled),
+ *   contributionSummary: {
+ *     contributions: [...],
+ *     groupTotalStoryPoints,
+ *     averageRatio,
+ *     ...
+ *   }
+ * }
+ *
+ * Response on conflict (409):
+ * {
+ *   code: 'SPRINT_FINALIZED_CONFLICT',
+ *   message: '...',
+ *   details: { finalizationReason, ... }
+ * }
+ */
+async function recalculateContributions(req, res) {
+  const { groupId, sprintId } = req.params;
+  const { notifyStudents = false, overrideFinalized = false, persistToD4 = true, notes = null } =
+    req.body;
+  const coordinatorId = req.user.userId;
+  const requesterRole = req.user.role;
+  let operationLog = {
+    startedAt: new Date(),
+    steps: [],
+    groupId,
+    sprintId,
+    coordinatorId,
+  };
+
+  try {
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 1: AUTHORIZATION CHECK
+    // ISSUE #237: Only coordinators can trigger recalculation
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.steps.push({ step: 1, name: 'authorization_check', startedAt: new Date() });
+
+    if (requesterRole !== 'coordinator') {
+      operationLog.steps[0].status = 'failed';
+      return res.status(403).json({
+        code: 'UNAUTHORIZED_ROLE',
+        message: 'Only coordinators can trigger contribution recalculation',
+        requiredRole: 'coordinator',
+        currentRole: requesterRole,
+      });
+    }
+
+    operationLog.steps[0].status = 'success';
+    operationLog.steps[0].completedAt = new Date();
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 2: INPUT VALIDATION
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.steps.push({
+      step: 2,
+      name: 'input_validation',
+      startedAt: new Date(),
+    });
+
+    if (!groupId || !sprintId) {
+      operationLog.steps[1].status = 'failed';
+      return res.status(400).json({
+        code: 'MISSING_PARAMETERS',
+        message: 'groupId and sprintId are required',
+      });
+    }
+
+    operationLog.steps[1].status = 'success';
+    operationLog.steps[1].completedAt = new Date();
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 3: CALL PROCESS 7.4 (RATIO CALCULATION ENGINE)
+    // Issue #236: recalculateSprintRatios from contributionRatioService
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.steps.push({
+      step: 3,
+      name: 'ratio_calculation_process_7_4',
+      startedAt: new Date(),
+      service: 'contributionRatioService',
+    });
+
+    const ratioResult = await recalculateSprintRatios(
+      groupId,
+      sprintId,
+      coordinatorId,
+      { notifyStudents }
+    );
+
+    operationLog.steps[2].status = 'success';
+    operationLog.steps[2].completedAt = new Date();
+    operationLog.steps[2].ratioResultSummary = {
+      contributionCount: ratioResult.contributions?.length || 0,
+      groupTotal: ratioResult.groupTotalStoryPoints,
+      strategy: ratioResult.strategyUsed,
+    };
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 4: PERSIST TO D6/D4 (PROCESS 7.5 - ISSUE #237 IMPLEMENTATION)
+    // ISSUE #237: Call persistence service to write contribution records
+    // Handles 409 conflicts if sprint is finalized
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.steps.push({
+      step: 4,
+      name: 'persist_sprint_contributions_process_7_5',
+      startedAt: new Date(),
+      service: 'sprintContributionPersistence',
+    });
+
+    let persistenceResult;
+    try {
+      persistenceResult = await persistSprintContributions(
+        groupId,
+        sprintId,
+        ratioResult, // ISSUE #237: Use Process 7.4 output as input to Process 7.5
+        coordinatorId,
+        {
+          persistToD4,
+          allowOverrideFinalized: overrideFinalized,
+          notificationPayload: {
+            notifyStudents,
+            coordinatorNotes: notes,
+          },
+        }
+      );
+
+      operationLog.steps[3].status = 'success';
+      operationLog.steps[3].completedAt = new Date();
+      operationLog.steps[3].persistenceSummary = {
+        recordsPersistedCount: persistenceResult.recordsPersistedCount,
+        d4RecordCreated: persistenceResult.d4RecordCreated,
+        durationMs: persistenceResult.durationMs,
+      };
+    } catch (persistErr) {
+      // ISSUE #237: Handle persistence errors with appropriate HTTP status
+      operationLog.steps[3].status = 'failed';
+      operationLog.steps[3].error = persistErr.message;
+
+      if (persistErr.code === 'SPRINT_FINALIZED_CONFLICT') {
+        // 409 Conflict: Sprint is locked
+        return res.status(409).json({
+          code: persistErr.code,
+          message: persistErr.message,
+          details: {
+            sprintId,
+            groupId,
+            finalized: true,
+          },
+        });
+      }
+
+      if (persistErr.status === 422) {
+        // 422 Unprocessable Entity: Validation failure
+        return res.status(422).json({
+          code: persistErr.code,
+          message: persistErr.message,
+        });
+      }
+
+      // Other errors → 500
+      throw persistErr;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 5: OPTIONAL D4→D6 RECONCILIATION
+    // ISSUE #237: Verify consistency between D4 reporting and D6 canonical data
+    // Non-fatal: failures don't block the response
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.steps.push({
+      step: 5,
+      name: 'd4_d6_reconciliation_flow_139',
+      startedAt: new Date(),
+      service: 'd4ToD6Reconciliation',
+    });
+
+    let reconciliationResult = null;
+    if (persistToD4 && persistenceResult.d4RecordCreated) {
+      try {
+        reconciliationResult = await reconcileSprintRecords(groupId, sprintId, {
+          autoRepair: false, // ISSUE #237: Don't auto-repair during normal operation
+          verbose: false,
+        });
+
+        operationLog.steps[4].status = 'success';
+        operationLog.steps[4].completedAt = new Date();
+        operationLog.steps[4].reconciliationStatus = reconciliationResult.status;
+        operationLog.steps[4].inconsistencyCount = reconciliationResult.inconsistencyCount;
+      } catch (reconErr) {
+        // ISSUE #237: Reconciliation failures are logged but non-fatal
+        console.warn(
+          `[contributionRatios] D4→D6 reconciliation warning: ${reconErr.message}`
+        );
+        operationLog.steps[4].status = 'warning';
+        operationLog.steps[4].warning = reconErr.message;
+      }
+    } else {
+      operationLog.steps[4].status = 'skipped';
+      operationLog.steps[4].reason = persistToD4 ? 'no_d4_record' : 'persistToD4=false';
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 6: AUDIT LOGGING
+    // ISSUE #237: Track this operation for compliance
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.steps.push({
+      step: 6,
+      name: 'audit_logging',
+      startedAt: new Date(),
+    });
+
+    try {
+      await createAuditLog({
+        action: 'CONTRIBUTIONS_RECALCULATED_AND_PERSISTED',
+        actorId: coordinatorId,
+        targetId: sprintId,
+        groupId,
+        payload: {
+          sprintId,
+          groupId,
+          coordinatorId,
+          ratiosCalculated: ratioResult.contributions?.length || 0,
+          recordsPersisted: persistenceResult.recordsPersistedCount,
+          d4RecordCreated: persistenceResult.d4RecordCreated,
+          reconciliationStatus: reconciliationResult?.status || 'skipped',
+          notifyStudents,
+          persistedAt: persistenceResult.persistedAt,
+        },
+      });
+
+      operationLog.steps[5].status = 'success';
+      operationLog.steps[5].completedAt = new Date();
+    } catch (auditErr) {
+      // ISSUE #237: Non-fatal audit failure
+      console.warn(`[contributionRatios] Audit logging failed: ${auditErr.message}`);
+      operationLog.steps[5].status = 'warning';
+      operationLog.steps[5].warning = auditErr.message;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SUCCESS RESPONSE
+    // ─────────────────────────────────────────────────────────────────────────
+    operationLog.completedAt = new Date();
+    operationLog.durationMs = operationLog.completedAt - operationLog.startedAt;
+
+    // ISSUE #237: Return comprehensive response with all details
+    return res.status(200).json({
+      success: true,
+      sprintId,
+      groupId,
+      coordinatorId,
+
+      // ISSUE #237: Process 7.4 results (ratio calculation)
+      ratiosCalculated: true,
+      contributionCount: ratioResult.contributions?.length || 0,
+
+      // ISSUE #237: Process 7.5 results (persistence)
+      persistenceResult: {
+        success: persistenceResult.success,
+        recordsPersistedCount: persistenceResult.recordsPersistedCount,
+        d4RecordCreated: persistenceResult.d4RecordCreated,
+        persistedAt: persistenceResult.persistedAt,
+        durationMs: persistenceResult.durationMs,
+      },
+
+      // ISSUE #237: D4→D6 reconciliation results (if applicable)
+      reconciliationResult: reconciliationResult
+        ? {
+            status: reconciliationResult.status,
+            inconsistencyCount: reconciliationResult.inconsistencyCount,
+            repairsApplied: reconciliationResult.repairsApplied,
+          }
+        : null,
+
+      // ISSUE #237: Include full contribution summary for client confirmation
+      contributionSummary: {
+        contributions: ratioResult.contributions,
+        groupTotalStoryPoints: ratioResult.groupTotalStoryPoints,
+        averageRatio: ratioResult.averageRatio,
+        maxRatio: ratioResult.maxRatio,
+        minRatio: ratioResult.minRatio,
+        strategyUsed: ratioResult.strategyUsed,
+        recalculatedAt: ratioResult.recalculatedAt,
+      },
+    });
+  } catch (error) {
+    operationLog.completedAt = new Date();
+    operationLog.failed = true;
+
+    console.error(
+      '[contributionRatios] Unexpected error during contribution recalculation:',
+      error
+    );
+
+    // ISSUE #237: Return appropriate error response
+    if (error.status === 403) {
+      return res.status(403).json({
+        code: 'FORBIDDEN',
+        message: error.message,
+      });
+    }
+
+    if (error.status === 404) {
+      return res.status(404).json({
+        code: 'NOT_FOUND',
+        message: error.message,
+      });
+    }
+
+    if (error.status === 409) {
+      return res.status(409).json({
+        code: error.code || 'CONFLICT',
+        message: error.message,
+      });
+    }
+
+    if (error.status === 422) {
+      return res.status(422).json({
+        code: error.code || 'UNPROCESSABLE_ENTITY',
+        message: error.message,
+      });
+    }
+
+    // Default to 500 Internal Server Error
+    return res.status(500).json({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'An unexpected error occurred during contribution recalculation',
+      error: error.message,
+    });
+  }
+}
+
+module.exports = {
+  recalculateContributions,
+};

--- a/backend/src/controllers/githubSync.js
+++ b/backend/src/controllers/githubSync.js
@@ -68,7 +68,7 @@ const triggerGitHubSync = async (req, res) => {
 
   try {
     // ── Guard: verify group exists (D2 sanity check) ────────────────────────
-    const group = await Group.findOne({ groupId }).lean();
+    const group = await Group.findOne({ groupId }).select('+githubPat').lean();
     if (!group) {
       return res.status(404).json({
         error: 'JIRA_DATA_MISSING',

--- a/backend/src/controllers/githubSync.js
+++ b/backend/src/controllers/githubSync.js
@@ -65,6 +65,7 @@ const triggerGitHubSync = async (req, res) => {
   if (!ensureSyncAccess(req, res)) return;
   const { groupId, sprintId } = req.params;
   const actorId = req.user?.userId || 'system';
+  const correlationId = req.headers['x-correlation-id'] || `gh_${Date.now()}`;
 
   try {
     // ── Guard: verify group exists (D2 sanity check) ────────────────────────
@@ -93,6 +94,14 @@ const triggerGitHubSync = async (req, res) => {
       });
     }
 
+    // ── Guard: Finalized snapshot conflict ──────────────────────────────────
+    if (['completed', 'reviewed'].includes(sprintRecord.status)) {
+      return res.status(409).json({
+        error: 'SNAPSHOT_LOCKED',
+        message: `Sprint contribution snapshot for ${groupId}/${sprintId} is already finalized.`,
+      });
+    }
+
     // ── Concurrency lock: check for existing active job ────────────────────
     const existingLock = await GitHubSyncJob.findOne({
       groupId,
@@ -116,6 +125,7 @@ const triggerGitHubSync = async (req, res) => {
         sprintId,
         status: 'PENDING',
         triggeredBy: actorId,
+        correlationId,
       });
     } catch (err) {
       if (err.code === 11000) {
@@ -144,6 +154,7 @@ const triggerGitHubSync = async (req, res) => {
         payload: { sprintId, jobId: job.jobId },
         ipAddress: req.ip,
         userAgent: req.headers['user-agent'],
+        correlationId,
       });
     } catch (auditErr) {
       console.error('[triggerGitHubSync] Audit log failed (non-fatal):', auditErr.message);

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -2,12 +2,44 @@ const axios = require('axios');
 const Group = require('../models/Group');
 const SyncErrorLog = require('../models/SyncErrorLog');
 const { createAuditLog } = require('../services/auditService');
-const { encrypt } = require('../utils/cryptoUtils');
+const {
+  getGroupOrThrow,
+  overwriteGithubCredentials,
+  overwriteJiraCredentials,
+} = require('../services/integrationCoordinatorService');
+const {
+  REQUIRED_GITHUB_SCOPES,
+  parseScopes,
+  missingScopes,
+  maskSecret,
+  logSecurityAudit,
+} = require('../services/integrationSecurityService');
 
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 100;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function ensureLeader(group, userId) {
+  if (group.leaderId !== userId) {
+    const err = new Error('Only the group leader can configure this integration');
+    err.status = 403;
+    err.code = 'FORBIDDEN';
+    throw err;
+  }
+}
+
+function tryHandleKnownError(err, res) {
+  if (err?.code === 'GROUP_NOT_FOUND') {
+    res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
+    return true;
+  }
+  if (err?.code === 'FORBIDDEN') {
+    res.status(403).json({ code: 'FORBIDDEN', message: err.message });
+    return true;
+  }
+  return false;
+}
 
 /**
  * Retry wrapper: calls fn up to maxAttempts times with exponential back-off.
@@ -79,27 +111,49 @@ const configureGithub = async (req, res) => {
       return res.status(400).json({ code: 'INVALID_VISIBILITY', message: 'visibility must be one of: private, public, internal' });
     }
 
-    const group = await Group.findOne({ groupId });
-    if (!group) {
-      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
-    }
-
-    if (group.leaderId !== req.user.userId) {
-      return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can configure GitHub' });
-    }
+    const group = await getGroupOrThrow(groupId);
+    ensureLeader(group, req.user.userId);
 
     // f11: validate PAT against GitHub API (with retry)
     let orgData;
     try {
-      await withRetry(() =>
+      const githubUserResponse = await withRetry(() =>
         axios.get('https://api.github.com/user', {
           headers: { Authorization: `Bearer ${pat.trim()}`, 'User-Agent': 'senior-app' },
           timeout: 5000,
         })
       );
+
+      const grantedScopes = parseScopes(githubUserResponse.headers['x-oauth-scopes']);
+      const missing = missingScopes(grantedScopes);
+      if (missing.length > 0) {
+        await logSecurityAudit({
+          actorId: req.user.userId,
+          groupId,
+          targetId: groupId,
+          provider: 'github',
+          reason: 'insufficient_scopes',
+          statusCode: 403,
+          req,
+        });
+        return res.status(422).json({
+          code: 'INSUFFICIENT_GITHUB_SCOPES',
+          message: `GitHub PAT is missing minimum scopes: ${missing.join(', ')}`,
+          required_scopes: REQUIRED_GITHUB_SCOPES,
+        });
+      }
     } catch (err) {
       const status = err.response?.status;
       if (status === 401 || status === 403) {
+        await logSecurityAudit({
+          actorId: req.user.userId,
+          groupId,
+          targetId: groupId,
+          provider: 'github',
+          reason: 'unauthorized_token_use',
+          statusCode: status,
+          req,
+        });
         return res.status(422).json({ code: 'INVALID_PAT', message: 'GitHub PAT is invalid or has insufficient permissions' });
       }
       // Network/timeout failures — log sync error
@@ -171,16 +225,17 @@ const configureGithub = async (req, res) => {
       return res.status(503).json({ code: 'GITHUB_API_UNAVAILABLE', message: 'GitHub API unavailable after maximum retry attempts' });
     }
 
-    // f24: store config in D2 (PAT stored encrypted)
-    group.githubPat = encrypt(pat.trim());
-    group.githubOrg = org_name.trim();
-    group.githubOrgId = orgData.id;
-    group.githubOrgName = orgData.name;
-    group.githubRepoName = repo_name.trim();
-    group.githubVisibility = visibility;
-    group.githubRepoUrl = `https://github.com/${org_name.trim()}/${repo_name.trim()}`;
-    group.githubLastSynced = new Date();
-    await group.save();
+    // f24: store config in D2 (PAT stored encrypted + rotated)
+    await overwriteGithubCredentials({
+      group,
+      pat: pat.trim(),
+      orgName: org_name.trim(),
+      orgData,
+      repoName: repo_name.trim(),
+      visibility,
+      actorId: req.user.userId,
+      req,
+    });
 
     // Audit log: github_integration_setup (non-fatal)
     try {
@@ -213,6 +268,7 @@ const configureGithub = async (req, res) => {
       },
     });
   } catch (err) {
+    if (tryHandleKnownError(err, res)) return;
     console.error('configureGithub error:', err);
     return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
   }
@@ -239,10 +295,7 @@ const getGithub = async (req, res) => {
   try {
     const { groupId } = req.params;
 
-    const group = await Group.findOne({ groupId });
-    if (!group) {
-      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
-    }
+    const group = await getGroupOrThrow(groupId);
 
     // Check if GitHub integration is connected
     const isConnected = !!(group.githubOrg && group.githubPat && group.githubRepoUrl);
@@ -273,6 +326,8 @@ const getGithub = async (req, res) => {
     // Include confirmation data only if successfully connected
     if (isConnected) {
       response.repo_url = group.githubRepoUrl;
+      response.token_masked = maskSecret(null);
+      response.required_scopes = REQUIRED_GITHUB_SCOPES;
       response.org = {
         id: group.githubOrgId,
         login: group.githubOrg,
@@ -283,6 +338,7 @@ const getGithub = async (req, res) => {
 
     return res.status(200).json(response);
   } catch (err) {
+    if (tryHandleKnownError(err, res)) return;
     console.error('getGithub error:', err);
     return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
   }
@@ -335,14 +391,8 @@ const configureJira = async (req, res) => {
       return res.status(400).json({ code: 'MISSING_PROJECT_KEY', message: 'project_key is required' });
     }
 
-    const group = await Group.findOne({ groupId });
-    if (!group) {
-      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
-    }
-
-    if (group.leaderId !== req.user.userId) {
-      return res.status(403).json({ code: 'FORBIDDEN', message: 'Only the group leader can configure JIRA' });
-    }
+    const group = await getGroupOrThrow(groupId);
+    ensureLeader(group, req.user.userId);
 
     const baseUrl = host.trim().replace(/\/$/, '');
     const auth = Buffer.from(`${email.trim()}:${api_token.trim()}`).toString('base64');
@@ -358,6 +408,15 @@ const configureJira = async (req, res) => {
     } catch (err) {
       const status = err.response?.status;
       if (status === 401 || status === 403) {
+        await logSecurityAudit({
+          actorId: req.user.userId,
+          groupId,
+          targetId: groupId,
+          provider: 'jira',
+          reason: 'unauthorized_token_use',
+          statusCode: status,
+          req,
+        });
         return res.status(422).json({
           code: 'INVALID_JIRA_CREDENTIALS',
           message: 'JIRA credentials are invalid or have insufficient permissions',
@@ -422,20 +481,17 @@ const configureJira = async (req, res) => {
       return res.status(503).json({ code: 'JIRA_API_UNAVAILABLE', message: 'JIRA API unavailable after maximum retry attempts' });
     }
 
-    const boardUrl = `${baseUrl}/jira/software/projects/${project_key.trim()}/boards`;
-
-    // f25: store binding confirmation in D2
-    // jiraStoryPointOnly: true — JIRA is strictly scoped to story point retrieval
-    group.jiraUrl = baseUrl;
-    group.jiraUsername = email.trim();
-    group.jiraToken = encrypt(api_token.trim());
-    group.projectKey = project_key.trim();
-    group.jiraProjectId = String(projectData.id);
-    group.jiraProject = projectData.name || project_key.trim();
-    group.jiraBoardUrl = boardUrl;
-    group.jiraLastSynced = new Date();
-    group.jiraStoryPointOnly = true;
-    await group.save();
+    // f25: store binding confirmation in D2 (credential overwrite)
+    await overwriteJiraCredentials({
+      group,
+      baseUrl,
+      email: email.trim(),
+      apiToken: api_token.trim(),
+      projectKey: project_key.trim(),
+      projectData,
+      actorId: req.user.userId,
+      req,
+    });
 
     // Audit log (non-fatal)
     try {
@@ -448,7 +504,7 @@ const configureJira = async (req, res) => {
           binding: 'confirmed',
           project_key: project_key.trim(),
           project_id: group.jiraProjectId,
-          board_url: boardUrl,
+          board_url: group.jiraBoardUrl,
           story_point_only: true,
         },
         ipAddress: req.ip,
@@ -465,6 +521,7 @@ const configureJira = async (req, res) => {
       board_url: group.jiraBoardUrl,
     });
   } catch (err) {
+    if (tryHandleKnownError(err, res)) return;
     console.error('configureJira error:', err);
     return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
   }
@@ -487,10 +544,7 @@ const getJira = async (req, res) => {
   try {
     const { groupId } = req.params;
 
-    const group = await Group.findOne({ groupId });
-    if (!group) {
-      return res.status(404).json({ code: 'GROUP_NOT_FOUND', message: 'Group not found' });
-    }
+    const group = await getGroupOrThrow(groupId);
 
     const isConnected = !!(group.jiraUrl && group.projectKey && group.jiraBoardUrl);
 
@@ -515,10 +569,12 @@ const getJira = async (req, res) => {
     if (isConnected) {
       response.project_key = group.projectKey;
       response.board_url = group.jiraBoardUrl;
+      response.token_masked = maskSecret(null);
     }
 
     return res.status(200).json(response);
   } catch (err) {
+    if (tryHandleKnownError(err, res)) return;
     console.error('getJira error:', err);
     return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
   }

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -20,9 +20,9 @@ const RETRY_BASE_DELAY_MS = 100;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-function ensureLeader(group, userId) {
-  if (group.leaderId !== userId) {
-    const err = new Error('Only the group leader can configure this integration');
+function ensureCoordinator(user) {
+  if (user?.role !== 'coordinator') {
+    const err = new Error('Only coordinators can configure this integration');
     err.status = 403;
     err.code = 'FORBIDDEN';
     throw err;
@@ -112,7 +112,7 @@ const configureGithub = async (req, res) => {
     }
 
     const group = await getGroupOrThrow(groupId);
-    ensureLeader(group, req.user.userId);
+    ensureCoordinator(req.user);
 
     // f11: validate PAT against GitHub API (with retry)
     let orgData;
@@ -392,7 +392,7 @@ const configureJira = async (req, res) => {
     }
 
     const group = await getGroupOrThrow(groupId);
-    ensureLeader(group, req.user.userId);
+    ensureCoordinator(req.user);
 
     const baseUrl = host.trim().replace(/\/$/, '');
     const auth = Buffer.from(`${email.trim()}:${api_token.trim()}`).toString('base64');

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -11,6 +11,7 @@ const {
   REQUIRED_GITHUB_SCOPES,
   parseScopes,
   missingScopes,
+  detectHighPrivilegeScopes,
   maskSecret,
   logSecurityAudit,
 } = require('../services/integrationSecurityService');
@@ -116,6 +117,7 @@ const configureGithub = async (req, res) => {
 
     // f11: validate PAT against GitHub API (with retry)
     let orgData;
+    let highPrivilegeScopes = [];
     try {
       const githubUserResponse = await withRetry(() =>
         axios.get('https://api.github.com/user', {
@@ -140,6 +142,18 @@ const configureGithub = async (req, res) => {
           code: 'INSUFFICIENT_GITHUB_SCOPES',
           message: `GitHub PAT is missing minimum scopes: ${missing.join(', ')}`,
           required_scopes: REQUIRED_GITHUB_SCOPES,
+        });
+      }
+      highPrivilegeScopes = detectHighPrivilegeScopes(grantedScopes);
+      if (highPrivilegeScopes.length > 0) {
+        await logSecurityAudit({
+          actorId: req.user.userId,
+          groupId,
+          targetId: groupId,
+          provider: 'github',
+          reason: 'overprivileged_token_warning',
+          statusCode: 200,
+          req,
         });
       }
     } catch (err) {
@@ -266,6 +280,12 @@ const configureGithub = async (req, res) => {
         login: orgData.login, 
         name: orgData.name 
       },
+      warnings:
+        highPrivilegeScopes.length > 0
+          ? [
+              `GitHub PAT includes high-privilege scopes: ${highPrivilegeScopes.join(', ')}. Consider creating a least-privilege token.`,
+            ]
+          : [],
     });
   } catch (err) {
     if (tryHandleKnownError(err, res)) return;
@@ -298,7 +318,7 @@ const getGithub = async (req, res) => {
     const group = await getGroupOrThrow(groupId);
 
     // Check if GitHub integration is connected
-    const isConnected = !!(group.githubOrg && group.githubPat && group.githubRepoUrl);
+    const isConnected = !!(group.githubOrg && group.githubRepoUrl);
 
     const lastSyncError = await SyncErrorLog.findOne(
       { groupId, service: 'github' },

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -14,6 +14,7 @@ const { forwardToMemberRequestPipeline, forwardOverrideToReconciliation } = requ
 const { dispatchGroupCreationNotification, dispatchAdvisorRequestNotification } = require('../services/notificationService');
 const { INACTIVE_GROUP_STATUSES, VALID_STATUS_TRANSITIONS } = require('../utils/groupStatusEnum');
 const SyncErrorLog = require('../models/SyncErrorLog');
+const { encrypt } = require('../utils/cryptoUtils');
 
 const VALID_DECISIONS = new Set(['approved', 'rejected']);
 
@@ -185,6 +186,18 @@ const createGroup = async (req, res) => {
         message: 'leaderId is required.',
       });
     }
+    if (githubPat !== undefined && githubPat !== null && typeof githubPat !== 'string') {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'githubPat must be a string when provided.',
+      });
+    }
+    if (jiraToken !== undefined && jiraToken !== null && typeof jiraToken !== 'string') {
+      return res.status(400).json({
+        code: 'INVALID_INPUT',
+        message: 'jiraToken must be a string when provided.',
+      });
+    }
 
     // The authenticated user must be the declared leader.
     if (req.user.userId !== leaderId.trim()) {
@@ -254,11 +267,11 @@ const createGroup = async (req, res) => {
       groupName: normalizedName,
       leaderId: leader.userId,
       status: 'pending_validation',
-      githubPat: githubPat || null,
+      githubPat: githubPat ? encrypt(githubPat) : null,
       githubOrg: githubOrg || null,
       jiraUrl: jiraUrl || null,
       jiraUsername: jiraUsername || null,
-      jiraToken: jiraToken || null,
+      jiraToken: jiraToken ? encrypt(jiraToken) : null,
       projectKey: projectKey || null,
     });
 

--- a/backend/src/controllers/jiraSync.js
+++ b/backend/src/controllers/jiraSync.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const JiraSyncJob = require('../models/JiraSyncJob');
+const SprintRecord = require('../models/SprintRecord');
 const { jiraSyncWorker, JiraSyncError, getJiraConfig, getPublishedSprintConfig } = require('../services/jiraSyncService');
 const { createAuditLog } = require('../services/auditService');
 
@@ -51,10 +52,20 @@ const mapJobResponse = (job) => ({
 const triggerJiraSync = async (req, res) => {
   const { groupId, sprintId } = req.params;
   const actorId = req.user?.userId || 'system';
+  const correlationId = req.headers['x-correlation-id'] || `jira_${Date.now()}`;
 
   try {
     await getJiraConfig(groupId);
     await getPublishedSprintConfig(groupId, sprintId);
+
+    const sprintRecord = await SprintRecord.findOne({ groupId, sprintId }).lean();
+    if (sprintRecord && ['completed', 'reviewed'].includes(sprintRecord.status)) {
+      return res.status(409).json({
+        error: 'SNAPSHOT_LOCKED',
+        message: `Sprint contribution snapshot for group ${groupId} / sprint ${sprintId} is already finalized.`,
+        source: 'jira',
+      });
+    }
 
     const existingLock = await JiraSyncJob.findOne({
       groupId,
@@ -78,6 +89,7 @@ const triggerJiraSync = async (req, res) => {
         sprintId,
         status: 'PENDING',
         triggeredBy: actorId,
+        correlationId,
       });
     } catch (err) {
       if (err.code === 11000) {
@@ -111,6 +123,7 @@ const triggerJiraSync = async (req, res) => {
         },
         ipAddress: req.ip,
         userAgent: req.headers['user-agent'],
+        correlationId,
       });
     } catch (auditErr) {
       console.error('[triggerJiraSync] Audit log failed (non-fatal):', auditErr.message);

--- a/backend/src/controllers/sprintTracking.js
+++ b/backend/src/controllers/sprintTracking.js
@@ -213,7 +213,7 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
     job.message = 'JIRA synchronization is running.';
     await job.save();
 
-    const group = await Group.findOne({ groupId }).lean();
+    const group = await Group.findOne({ groupId }).select('+jiraToken').lean();
     if (!group) {
       throw Object.assign(new Error(`Group ${groupId} not found.`), { code: 'GROUP_NOT_FOUND' });
     }

--- a/backend/src/controllers/sprintTracking.js
+++ b/backend/src/controllers/sprintTracking.js
@@ -5,11 +5,13 @@ const axios = require('axios');
 const Group = require('../models/Group');
 const SprintConfig = require('../models/SprintConfig');
 const SprintRecord = require('../models/SprintRecord');
+const Deliverable = require('../models/Deliverable');
 const ContributionRecord = require('../models/ContributionRecord');
 const SyncJob = require('../models/SyncJob');
 const GitHubSyncJob = require('../models/GitHubSyncJob');
 const User = require('../models/User');
 const { decrypt } = require('../utils/cryptoUtils');
+const { dispatchSyncNotification } = require('../services/notificationService');
 
 const toPublicStatus = (status) => {
   if (status === 'PENDING') return 'queued';
@@ -213,6 +215,8 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
     job.message = 'JIRA synchronization is running.';
     await job.save();
 
+    const correlationId = job.correlationId;
+
     const group = await Group.findOne({ groupId }).select('+jiraToken').lean();
     if (!group) {
       throw Object.assign(new Error(`Group ${groupId} not found.`), { code: 'GROUP_NOT_FOUND' });
@@ -280,22 +284,59 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
       aggregatedByStudent.set(assigneeUserId, bucket);
     }
 
-    const existingRecords = await ContributionRecord.find({ groupId, sprintId }).lean();
-    const existingByStudent = new Map(existingRecords.map((record) => [record.studentId, record]));
-
     await session.withTransaction(async () => {
+      // ── Atomic Read ────────────────────────────────────────────────────────
+      const sprintRecord = await SprintRecord.findOne({ groupId, sprintId }).session(session);
+      if (sprintRecord && ['completed', 'reviewed'].includes(sprintRecord.status)) {
+        throw Object.assign(new Error('Sprint contribution snapshot is finalized and locked.'), {
+          code: 'SNAPSHOT_LOCKED',
+        });
+      }
+
+      const existingRecords = await ContributionRecord.find({ groupId, sprintId }).session(session);
+      const existingByStudent = new Map(existingRecords.map((record) => [record.studentId, record]));
+
+      const sprintUpdate = {
+        $set: {
+          status: 'in_progress',
+        },
+        $setOnInsert: {
+          groupId,
+          sprintId,
+        },
+      };
+
+      if (sprintConfig.enableD4Reporting) {
+        sprintUpdate.$set.deliverableRefs = deliverableRefs;
+
+        const deliverableOps = deliverableRefs.map((ref) => ({
+          updateOne: {
+            filter: { deliverableId: ref.deliverableId, groupId },
+            update: {
+              $set: {
+                deliverableType: 'demonstration',
+                sprintId,
+                submittedBy: 'system-jira-sync',
+                filePath: `jira://${ref.deliverableId}`,
+                fileSize: 0,
+                fileHash: 'jira-synced',
+                format: 'jira-issue',
+                status: 'accepted',
+                submittedAt: ref.submittedAt,
+              },
+            },
+            upsert: true,
+          },
+        }));
+
+        if (deliverableOps.length > 0) {
+          await Deliverable.bulkWrite(deliverableOps, { session });
+        }
+      }
+
       await SprintRecord.findOneAndUpdate(
         { groupId, sprintId },
-        {
-          $set: {
-            status: 'in_progress',
-            deliverableRefs,
-          },
-          $setOnInsert: {
-            groupId,
-            sprintId,
-          },
-        },
+        sprintUpdate,
         { upsert: true, new: true, session }
       );
 
@@ -359,6 +400,16 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
     job.completedAt = new Date();
     job.message = `JIRA synchronization completed. Imported ${issues.length} issues (${unmappedAssigneeCount} unmapped assignees skipped).`;
     await job.save();
+
+    // Trigger completion notification with correlationId
+    dispatchSyncNotification({
+      groupId,
+      sprintId,
+      status: 'COMPLETED',
+      issuesProcessed: issues.length,
+      triggeredBy: job.triggeredBy || 'system',
+      correlationId,
+    });
   } catch (error) {
     const normalized = normalizeWorkerError(error);
     job.status = 'FAILED';
@@ -374,6 +425,7 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
 const triggerJiraSync = async (req, res) => {
   const { groupId, sprintId } = req.params;
   const actorId = req.user?.userId || 'system';
+  const correlationId = req.headers['x-correlation-id'] || `jira_${Date.now()}`;
 
   try {
     const group = await Group.findOne({ groupId }).lean();
@@ -389,6 +441,14 @@ const triggerJiraSync = async (req, res) => {
     }
 
     await getPublishedSprintConfig(groupId, sprintId);
+
+    const sprintRecord = await SprintRecord.findOne({ groupId, sprintId }).lean();
+    if (sprintRecord && ['completed', 'reviewed'].includes(sprintRecord.status)) {
+      return res.status(409).json({
+        error: 'SNAPSHOT_LOCKED',
+        message: `Sprint contribution snapshot for ${groupId}/${sprintId} is already finalized.`,
+      });
+    }
 
     const active = await SyncJob.findOne({
       groupId,
@@ -412,6 +472,7 @@ const triggerJiraSync = async (req, res) => {
       status: 'PENDING',
       message: 'JIRA sync accepted and queued.',
       triggeredBy: actorId,
+      correlationId,
     });
 
     res.status(202).json({
@@ -657,9 +718,76 @@ const recalculateContributions = async (req, res) => {
   }
 };
 
+/**
+ * Flow 139 — Canonical reconciliation from D4 (Deliverables) to D6 (SprintRecord).
+ * Synchronizes deliverable refs while preserving existing D6 metrics.
+ */
+const reconcileD4toD6 = async (req, res) => {
+  const { groupId, sprintId } = req.params;
+  const actorId = req.user?.userId || 'system';
+  const correlationId = req.headers['x-correlation-id'] || `reconcile_${Date.now()}`;
+
+  try {
+    const deliverables = await Deliverable.find({ groupId, sprintId }).lean();
+    const sprintRecord = await SprintRecord.findOne({ groupId, sprintId });
+
+    if (!sprintRecord) {
+      return res.status(404).json({
+        error: 'SPRINT_RECORD_NOT_FOUND',
+        message: `Sprint record not found for ${groupId}/${sprintId}`,
+      });
+    }
+
+    const existingRefsMap = new Map(
+      (sprintRecord.deliverableRefs || []).map((ref) => [ref.deliverableId, ref])
+    );
+
+    let addedCount = 0;
+    for (const del of deliverables) {
+      if (!existingRefsMap.has(del.deliverableId)) {
+        sprintRecord.deliverableRefs.push({
+          deliverableId: del.deliverableId,
+          type: del.deliverableType,
+          submittedAt: del.submittedAt,
+        });
+        addedCount += 1;
+      }
+    }
+
+    if (addedCount > 0) {
+      await sprintRecord.save();
+    }
+
+    await createAuditLog({
+      action: 'DELIVERABLE_LINKED_TO_SPRINT',
+      actorId,
+      groupId,
+      targetId: sprintRecord.sprintId,
+      payload: { addedCount, totalRefs: sprintRecord.deliverableRefs.length },
+      correlationId,
+    });
+
+    return res.status(200).json({
+      success: true,
+      groupId,
+      sprintId,
+      addedCount,
+      totalRefs: sprintRecord.deliverableRefs.length,
+      message: `Reconciliation complete. Added ${addedCount} missing deliverable references.`,
+    });
+  } catch (error) {
+    console.error('[reconcileD4toD6] error:', error);
+    return res.status(500).json({
+      error: 'INTERNAL_ERROR',
+      message: 'Failed to reconcile D4 deliverables to D6 sprint record.',
+    });
+  }
+};
+
 module.exports = {
   triggerJiraSync,
   getJiraSyncStatus,
   getJiraSyncLogs,
   recalculateContributions,
+  reconcileD4toD6,
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -16,6 +16,10 @@ const deliverableRoutes = require('./routes/deliverables');
 const reviewRoutes = require('./routes/reviews');
 const commentsRoutes = require('./routes/comments');
 const { errorHandler } = require('./middleware/auth');
+const {
+  patchConsoleForRedaction,
+  requestLogMiddleware,
+} = require('./middleware/securityLogging');
 
 const app = express();
 const PORT = process.env.PORT || 5002;
@@ -24,10 +28,8 @@ app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.use((req, res, next) => {
-  console.log(`${new Date().toISOString()} - ${req.method} ${req.path}`);
-  next();
-});
+patchConsoleForRedaction();
+app.use(requestLogMiddleware);
 
 app.get('/health', (req, res) => {
   res.status(200).json({

--- a/backend/src/middleware/securityLogging.js
+++ b/backend/src/middleware/securityLogging.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { redactAny } = require('../security/logRedactor');
+
+function patchConsoleForRedaction() {
+  const methods = ['log', 'info', 'warn', 'error', 'debug'];
+
+  methods.forEach((method) => {
+    const original = console[method].bind(console);
+    console[method] = (...args) => {
+      const redactedArgs = args.map((arg) => redactAny(arg));
+      original(...redactedArgs);
+    };
+  });
+}
+
+function requestLogMiddleware(req, res, next) {
+  const requestLine = `${new Date().toISOString()} - ${req.method} ${req.path}`;
+  const authHeader = req.headers.authorization
+    ? `Authorization: ${req.headers.authorization}`
+    : null;
+
+  if (authHeader) {
+    console.log(`${requestLine} ${authHeader}`);
+  } else {
+    console.log(requestLine);
+  }
+
+  next();
+}
+
+module.exports = {
+  patchConsoleForRedaction,
+  requestLogMiddleware,
+};

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -170,6 +170,11 @@ const auditLogSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    correlationId: {
+      type: String,
+      default: null,
+      index: true,
+    },
     timestamp: {
       type: Date,
       default: Date.now,
@@ -186,6 +191,7 @@ auditLogSchema.index({ targetId: 1, createdAt: -1 });
 auditLogSchema.index({ actorId: 1, createdAt: -1 });
 auditLogSchema.index({ groupId: 1, action: 1, createdAt: -1 });
 auditLogSchema.index({ action: 1, createdAt: -1 });
+auditLogSchema.index({ correlationId: 1 });
 
 const AuditLog = mongoose.model('AuditLog', auditLogSchema);
 

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -128,6 +128,8 @@ const auditLogSchema = new mongoose.Schema(
         'GITHUB_SYNC_INITIATED',
         'GITHUB_SYNC_COMPLETED',
         'GITHUB_SYNC_FAILED',
+        'SECURITY_AUDIT',
+        'CREDENTIAL_ROTATED',
       ],
     },
     actorId: {

--- a/backend/src/models/Deliverable.js
+++ b/backend/src/models/Deliverable.js
@@ -30,7 +30,7 @@ const deliverableSchema = new mongoose.Schema(
     },
     deliverableType: {
       type: String,
-      enum: ['proposal', 'statement_of_work', 'demo', 'interim_report', 'final_report'],
+      enum: ['proposal', 'statement_of_work', 'statement-of-work', 'demo', 'demonstration', 'interim_report', 'final_report'],
       required: true,
     },
     sprintId: {

--- a/backend/src/models/GitHubSyncJob.js
+++ b/backend/src/models/GitHubSyncJob.js
@@ -70,6 +70,8 @@ const gitHubSyncJobSchema = new mongoose.Schema(
 
     /** Who triggered the sync */
     triggeredBy: { type: String, default: null },
+
+    correlationId: { type: String, default: null },
   },
   {
     timestamps: true,

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -116,7 +116,7 @@ const groupSchema = new mongoose.Schema(
     githubRepoName: { type: String, default: null },
     githubRepoUrl: { type: String, default: null },
     githubVisibility: { type: String, enum: ['private', 'public', 'internal'], default: 'private' },
-    githubPat: { type: String, default: null },
+    githubPat: { type: String, default: null, select: false },
     githubLastSynced: { type: Date, default: null },
     
     // --- JIRA Integration (Process 2.7) ---
@@ -124,7 +124,7 @@ const groupSchema = new mongoose.Schema(
     jiraUrl: { type: String, default: null },
     jiraBoardUrl: { type: String, default: null },
     jiraUsername: { type: String, default: null },
-    jiraToken: { type: String, default: null },
+    jiraToken: { type: String, default: null, select: false },
     projectKey: { type: String, default: null },
     jiraProjectId: { type: String, default: null },
     jiraLastSynced: { type: Date, default: null },
@@ -191,6 +191,16 @@ groupSchema.index({ status: 1, advisorId: 1 });
  * for recipient aggregation in notification dispatch
  */
 groupSchema.index({ committeeId: 1 });
+
+// Safety net: never serialize credential fields in API responses.
+const stripCredentialFields = (_doc, ret) => {
+  delete ret.githubPat;
+  delete ret.jiraToken;
+  return ret;
+};
+
+groupSchema.set('toJSON', { transform: stripCredentialFields });
+groupSchema.set('toObject', { transform: stripCredentialFields });
 
 const Group = mongoose.model('Group', groupSchema);
 

--- a/backend/src/models/JiraSyncJob.js
+++ b/backend/src/models/JiraSyncJob.js
@@ -59,6 +59,10 @@ const jiraSyncJobSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    correlationId: {
+      type: String,
+      default: null,
+    },
   },
   {
     timestamps: true,

--- a/backend/src/models/SprintConfig.js
+++ b/backend/src/models/SprintConfig.js
@@ -48,6 +48,10 @@ const sprintConfigSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    enableD4Reporting: {
+      type: Boolean,
+      default: true,
+    },
   },
   {
     timestamps: true,

--- a/backend/src/models/SprintContributionRecord.js
+++ b/backend/src/models/SprintContributionRecord.js
@@ -1,0 +1,364 @@
+/**
+ * ============================================================================
+ * Issue #237: SprintContributionRecord Model (D6 Data Store Extension)
+ * ============================================================================
+ *
+ * CHANGES FOR ISSUE #237:
+ * - NEW model to extend D6 capabilities for Process 7.5 persistence
+ * - Stores per-student sprint contribution snapshots after recalculation
+ * - Provides idempotent write pattern with (sprintId, studentId, groupId) key
+ * - Includes finalization lock to prevent overwriting completed sprint records
+ * - Audit fields: createdAt, updatedAt (automatic via mongoose)
+ * - Supports D4→D6 reconciliation (Flow 139)
+ *
+ * DATABASE MAPPING:
+ * Collection: sprintcontributionrecords (D6 scope)
+ * Indexes: Compound (sprintId, studentId, groupId) for efficient lookup
+ *
+ * DFD INTEGRATION:
+ * Input: Process 7.4 output (Issue #236)
+ * Output: Canonical contribution snapshot stored in D6
+ * Sync: D4→D6 flow references this model for idempotency checks
+ */
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const sprintContributionRecordSchema = new mongoose.Schema(
+  {
+    // ISSUE #237: Unique identifier for this contribution record
+    sprintContributionId: {
+      type: String,
+      default: () => `scr_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+      index: true,
+    },
+
+    // ISSUE #237: Foreign key to Sprint
+    sprintId: {
+      type: String,
+      required: true,
+      index: true,
+      // ISSUE #237: Matches Process 7.4 input (f7_p73_p74)
+      description: 'Sprint identifier from Process 7.1/7.2 sync',
+    },
+
+    // ISSUE #237: Foreign key to Student
+    studentId: {
+      type: String,
+      required: true,
+      index: true,
+      // ISSUE #237: Each student gets exactly one record per sprint
+      description: 'Student identifier for whom this record tracks contribution',
+    },
+
+    // ISSUE #237: Foreign key to Group
+    groupId: {
+      type: String,
+      required: true,
+      index: true,
+      // ISSUE #237: Scopes contribution to group context
+      description: 'Group identifier for authorization and reporting',
+    },
+
+    // ISSUE #237: Idempotent composite key
+    // This ensures (sprintId, studentId, groupId) tuple is unique
+    // Compound index created in migration for efficient lookup
+    _uniqueKey: {
+      type: String,
+      unique: true,
+      index: true,
+      // ISSUE #237: Generated before save() via pre-hook
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CONTRIBUTION METRICS (from Process 7.3 + 7.4)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Target story points assigned to this student (from D8)
+    targetStoryPoints: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 999,
+      description: 'Target story points assigned to student for this sprint',
+    },
+
+    // ISSUE #237: Completed story points (from Issue #235 attribution)
+    completedStoryPoints: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 999,
+      description: 'Story points completed (merged PRs) for this sprint',
+    },
+
+    // ISSUE #237: Calculated ratio (from Process 7.4)
+    contributionRatio: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 1,
+      // ISSUE #237: Clamped to [0,1] range per Issue #236 specs
+      description: 'Per-student contribution ratio (0-1 range)',
+    },
+
+    // ISSUE #237: Strategy used for ratio calculation
+    ratioStrategy: {
+      type: String,
+      enum: ['fixed', 'weighted', 'normalized'],
+      default: 'fixed',
+      // ISSUE #237: Documents which normalization strategy was applied
+      description: 'Which ratio calculation strategy was used',
+    },
+
+    // ISSUE #237: Percentage of group total
+    percentageOfGroupTotal: {
+      type: Number,
+      min: 0,
+      max: 100,
+      description: 'This student\'s percentage of group total story points',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // FINALIZATION & LOCK FIELDS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Prevents overwriting locked sprint snapshots (409 conflict)
+    isFinalized: {
+      type: Boolean,
+      default: false,
+      // ISSUE #237: When true, this record cannot be modified
+      description: 'If true, record is locked and cannot be updated',
+    },
+
+    // ISSUE #237: Reason for finalization (audit trail)
+    finalizationReason: {
+      type: String,
+      enum: [
+        'SPRINT_WINDOW_CLOSED',
+        'COMMITTEE_REVIEW_STARTED',
+        'MANUAL_LOCK',
+        'GRADE_SUBMITTED',
+      ],
+      default: null,
+      // ISSUE #237: Documents why sprint is finalized
+      description: 'Reason why this record was finalized/locked',
+    },
+
+    // ISSUE #237: Timestamp when finalized
+    finalizedAt: {
+      type: Date,
+      default: null,
+      description: 'When this record was finalized/locked',
+    },
+
+    // ISSUE #237: Who finalized this record
+    finalizedBy: {
+      type: String,
+      default: null,
+      description: 'Coordinator/admin who finalized this record',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // D4 → D6 RECONCILIATION SUPPORT
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Links to D4 reporting record (Flow 139)
+    d4ReportingRecordId: {
+      type: String,
+      default: null,
+      // ISSUE #237: Reference to SprintReportingRecord for sync reconciliation
+      description: 'ID of associated D4 SprintReportingRecord (if created)',
+    },
+
+    // ISSUE #237: Correlation ID from persistence operation
+    correlationId: {
+      type: String,
+      default: null,
+      // ISSUE #237: Ties this record to notification events (Issue #238)
+      description: 'Correlation ID from sprintContributionPersistence operation',
+    },
+
+    // ISSUE #237: Last operation metadata
+    lastCalculationAt: {
+      type: Date,
+      default: null,
+      description: 'When this student\'s ratio was last calculated',
+    },
+
+    lastCalculatedBy: {
+      type: String,
+      default: null,
+      description: 'Coordinator who triggered the last calculation',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // AUDIT FIELDS (handled by mongoose timestamps)
+    // ─────────────────────────────────────────────────────────────────────────
+    // createdAt: Date (automatic)
+    // updatedAt: Date (automatic)
+    // ISSUE #237: These ensure all writes include audit trail
+  },
+  {
+    timestamps: true, // ISSUE #237: Adds createdAt, updatedAt automatically
+    collection: 'sprintcontributionrecords',
+  }
+);
+
+// ISSUE #237: COMPOUND INDEXES FOR EFFICIENT QUERIES
+
+// Index 1: Lookup by sprint + student + group (idempotent key)
+// DFD Use: Quick check before upsert in Process 7.5
+sprintContributionRecordSchema.index(
+  { sprintId: 1, studentId: 1, groupId: 1 },
+  { unique: true, sparse: true }
+);
+
+// Index 2: Lookup all contributions for a sprint
+// DFD Use: Fetch all students for D4→D6 reconciliation
+sprintContributionRecordSchema.index(
+  { sprintId: 1, groupId: 1 },
+  { background: true }
+);
+
+// Index 3: Finalized sprints query
+// DFD Use: Filter locked sprints when checking 409 conflicts
+sprintContributionRecordSchema.index(
+  { sprintId: 1, isFinalized: 1 },
+  { background: true }
+);
+
+// Index 4: Coordinator queries by actor
+// DFD Use: Audit trail queries by who last updated
+sprintContributionRecordSchema.index(
+  { lastCalculatedBy: 1, lastCalculationAt: 1 },
+  { background: true }
+);
+
+// ISSUE #237: PRE-SAVE HOOK — Generate idempotent key
+sprintContributionRecordSchema.pre('save', function (next) {
+  // ISSUE #237: Create unique composite key for idempotency
+  if (this.isModified('sprintId') || this.isModified('studentId') || this.isModified('groupId')) {
+    this._uniqueKey = `${this.sprintId}#${this.studentId}#${this.groupId}`;
+  }
+
+  // ISSUE #237: Validate finalization constraints
+  if (this.isFinalized === true && !this.finalizedAt) {
+    this.finalizedAt = new Date();
+  }
+
+  next();
+});
+
+// ISSUE #237: PRE-UPDATE HOOK — Check finalization lock
+sprintContributionRecordSchema.pre('findOneAndUpdate', function (next) {
+  // ISSUE #237: Prevent updates to finalized records
+  const update = this.getUpdate();
+  if (update.$set && this._conditions.isFinalized === true) {
+    // Allow finalization timestamp changes, but block other modifications
+    const restrictedFields = Object.keys(update.$set).filter(
+      (key) => !['finalizedAt', 'd4ReportingRecordId'].includes(key)
+    );
+
+    if (restrictedFields.length > 0) {
+      const err = new Error(
+        `Cannot update finalized sprint contribution record. Restricted fields: ${restrictedFields.join(', ')}`
+      );
+      err.status = 409;
+      err.code = 'RECORD_FINALIZED';
+      return next(err);
+    }
+  }
+
+  next();
+});
+
+// ISSUE #237: INSTANCE METHOD — Check if record is valid
+sprintContributionRecordSchema.methods.isValid = function () {
+  return (
+    this.sprintId &&
+    this.studentId &&
+    this.groupId &&
+    this.targetStoryPoints !== undefined &&
+    this.completedStoryPoints !== undefined &&
+    this.contributionRatio !== undefined &&
+    this.contributionRatio >= 0 &&
+    this.contributionRatio <= 1
+  );
+};
+
+// ISSUE #237: INSTANCE METHOD — Get ratio as percentage
+sprintContributionRecordSchema.methods.getRatioPercentage = function () {
+  return Math.round(this.contributionRatio * 100);
+};
+
+// ISSUE #237: STATIC METHOD — Fetch all contributions for a sprint
+sprintContributionRecordSchema.statics.getSprintContributions = async function (
+  sprintId,
+  groupId
+) {
+  return this.find(
+    {
+      sprintId,
+      groupId,
+      isFinalized: { $ne: true },
+    },
+    {
+      studentId: 1,
+      contributionRatio: 1,
+      targetStoryPoints: 1,
+      completedStoryPoints: 1,
+      percentageOfGroupTotal: 1,
+    }
+  )
+    .sort({ contributionRatio: -1 })
+    .exec();
+};
+
+// ISSUE #237: STATIC METHOD — Get specific student's record
+sprintContributionRecordSchema.statics.getStudentContribution = async function (
+  sprintId,
+  studentId,
+  groupId
+) {
+  return this.findOne({
+    sprintId,
+    studentId,
+    groupId,
+  });
+};
+
+// ISSUE #237: STATIC METHOD — Check if sprint is fully finalized
+sprintContributionRecordSchema.statics.isSprintFinalized = async function (
+  sprintId,
+  groupId
+) {
+  const record = await this.findOne(
+    {
+      sprintId,
+      groupId,
+      isFinalized: true,
+    },
+    { _id: 1 }
+  );
+  return !!record;
+};
+
+// ISSUE #237: Custom error class for validation
+class SprintContributionValidationError extends Error {
+  constructor(message, field) {
+    super(message);
+    this.name = 'SprintContributionValidationError';
+    this.field = field;
+  }
+}
+
+// ISSUE #237: Export model
+const SprintContributionRecord = mongoose.model(
+  'SprintContributionRecord',
+  sprintContributionRecordSchema
+);
+
+module.exports = SprintContributionRecord;

--- a/backend/src/models/SprintReportingRecord.js
+++ b/backend/src/models/SprintReportingRecord.js
@@ -1,0 +1,371 @@
+/**
+ * ============================================================================
+ * Issue #237: SprintReportingRecord Model (D4 Data Store Extension)
+ * ============================================================================
+ *
+ * CHANGES FOR ISSUE #237:
+ * - NEW model for optional D4 reporting extension to support coordinator dashboards
+ * - Stores aggregated sprint contribution metrics for reporting/visibility
+ * - Lightweight metadata: total members, group totals, calculation strategy, timestamp
+ * - Links to D6 records via (sprintId, groupId) composite key
+ * - Supports D4→D6 reconciliation (Flow 139) for consistency checks
+ * - Can be enabled/disabled via persistToD4 configuration flag
+ *
+ * DATABASE MAPPING:
+ * Collection: sprintreportingrecords (D4 scope)
+ * Indexes: (sprintId, groupId) for efficient lookup
+ *
+ * DFD INTEGRATION:
+ * Input: Process 7.5 (Issue #237) completion
+ * Output: D4 reporting metadata for coordinator visibility (Flow 128)
+ * Sync: D4→D6 reconciliation ensures canonical metrics remain consistent (Flow 139)
+ *
+ * OPERATIONAL NOTE:
+ * D4 write failures do NOT block D6 persistence (non-fatal operation).
+ * This allows the main flow (contribution persistence) to succeed even if
+ * reporting infrastructure fails.
+ */
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const sprintReportingRecordSchema = new mongoose.Schema(
+  {
+    // ISSUE #237: Unique identifier for this reporting record
+    sprintReportingId: {
+      type: String,
+      default: () => `srr_${uuidv4().split('-')[0]}`,
+      unique: true,
+      required: true,
+      index: true,
+    },
+
+    // ISSUE #237: Foreign keys for linkage to D6 canonical data
+    sprintId: {
+      type: String,
+      required: true,
+      index: true,
+      // ISSUE #237: Composite key component for D4→D6 sync (Flow 139)
+      description: 'Sprint identifier (matches D6 sprintId)',
+    },
+
+    groupId: {
+      type: String,
+      required: true,
+      index: true,
+      // ISSUE #237: Composite key component for group-scoped reporting
+      description: 'Group identifier (matches D6 groupId)',
+    },
+
+    // ISSUE #237: Composite unique index ensures one reporting record per sprint+group
+    // Created in migration: { sprintId: 1, groupId: 1 } unique: true
+    _uniqueKey: {
+      type: String,
+      unique: true,
+      index: true,
+      // ISSUE #237: Generated before save via pre-hook
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // COORDINATOR/ACTOR INFORMATION
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Coordinator who triggered the calculation
+    coordinatorId: {
+      type: String,
+      required: true,
+      index: true,
+      // ISSUE #237: Audit trail — who performed the persistence operation
+      description: 'Coordinator ID who initiated sprint contribution persistence',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // AGGREGATED SPRINT METRICS (Read-Only from D6)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Total number of group members with contributions
+    totalMembers: {
+      type: Number,
+      required: true,
+      min: 0,
+      // ISSUE #237: Snapshot of group size at calculation time
+      description: 'Total group members with contribution records',
+    },
+
+    // ISSUE #237: Sum of all students' completed story points
+    groupTotalStoryPoints: {
+      type: Number,
+      required: true,
+      min: 0,
+      // ISSUE #237: Sum of completedStoryPoints across all group members
+      description: 'Total completed story points for group (all members)',
+    },
+
+    // ISSUE #237: Average contribution ratio across group
+    averageRatio: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 1,
+      // ISSUE #237: Mean of all contributionRatio values
+      description: 'Average contribution ratio for group',
+    },
+
+    // ISSUE #237: Maximum contribution ratio in group
+    maxRatio: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 1,
+      // ISSUE #237: Highest individual ratio
+      description: 'Maximum contribution ratio (best performer)',
+    },
+
+    // ISSUE #237: Minimum contribution ratio in group
+    minRatio: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 1,
+      // ISSUE #237: Lowest individual ratio
+      description: 'Minimum contribution ratio (lowest performer)',
+    },
+
+    // ISSUE #237: Calculation strategy used
+    calculationStrategy: {
+      type: String,
+      enum: ['fixed', 'weighted', 'normalized'],
+      default: 'fixed',
+      // ISSUE #237: Documents which ratio normalization was applied
+      description: 'Which strategy was used to calculate ratios',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // TIMESTAMP METADATA
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: When the sprint contributions were calculated
+    calculatedAt: {
+      type: Date,
+      required: true,
+      // ISSUE #237: Tracks when D6 persistence occurred
+      description: 'Timestamp of contribution calculation',
+    },
+
+    // ISSUE #237: When D4 reporting record was last updated
+    // Note: updatedAt is automatic via mongoose timestamps
+    // ISSUE #237: Used to detect stale reporting data in D4→D6 sync
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // D4 → D6 RECONCILIATION FIELDS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Correlation ID linking to persistence operation
+    correlationId: {
+      type: String,
+      default: null,
+      // ISSUE #237: Same ID as in sprintContributionPersistence
+      // Used to trace D4→D6 sync operations (Flow 139)
+      description: 'Correlation ID from persistence operation',
+    },
+
+    // ISSUE #237: Last time D4→D6 reconciliation was performed
+    lastReconciledAt: {
+      type: Date,
+      default: null,
+      // ISSUE #237: Tracks when sync verification last succeeded
+      description: 'When D4→D6 reconciliation last completed',
+    },
+
+    // ISSUE #237: Number of D6 records found during last reconciliation
+    d6RecordCount: {
+      type: Number,
+      default: null,
+      // ISSUE #237: Sanity check: should match totalMembers
+      // If different, indicates data inconsistency
+      description: 'Count of D6 records during last reconciliation',
+    },
+
+    // ISSUE #237: Status of D4→D6 sync
+    reconciliationStatus: {
+      type: String,
+      enum: ['consistent', 'inconsistent', 'unverified', 'in-progress'],
+      default: 'unverified',
+      // ISSUE #237: 'consistent' = D4 matches D6, 'inconsistent' = mismatch detected
+      description: 'Result of D4→D6 reconciliation check',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // CONFIGURATION & FEATURE FLAGS
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Whether student notifications were sent
+    studentNotificationsSent: {
+      type: Boolean,
+      default: false,
+      // ISSUE #237: Tracks if Issue #238 notifications were dispatched
+      description: 'Whether student notifications were sent',
+    },
+
+    // ISSUE #237: Optional notes for coordinator
+    coordinatorNotes: {
+      type: String,
+      maxlength: 500,
+      default: null,
+      // ISSUE #237: Free-form field for operational context
+      description: 'Optional notes/context for coordinator',
+    },
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SOFT DELETE SUPPORT (for audit trail)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    // ISSUE #237: Soft delete timestamp
+    deletedAt: {
+      type: Date,
+      default: null,
+      // ISSUE #237: Null = active, populated = soft deleted
+      description: 'When this record was deleted (null = active)',
+    },
+
+    // createdAt, updatedAt: Automatic via mongoose timestamps
+    // ISSUE #237: These fields track record lifecycle for audit
+  },
+  {
+    timestamps: true, // ISSUE #237: Adds createdAt, updatedAt automatically
+    collection: 'sprintreportingrecords',
+  }
+);
+
+// ISSUE #237: INDEXES FOR EFFICIENT QUERYING
+
+// Index 1: Primary lookup by sprint + group
+// DFD Use: Fetch reporting record for D4→D6 reconciliation (Flow 139)
+sprintReportingRecordSchema.index(
+  { sprintId: 1, groupId: 1 },
+  { unique: true, sparse: true }
+);
+
+// Index 2: Coordinator's reporting records
+// DFD Use: Query records created by specific coordinator
+sprintReportingRecordSchema.index(
+  { coordinatorId: 1, calculatedAt: -1 },
+  { background: true }
+);
+
+// Index 3: Reconciliation status queries
+// DFD Use: Find records needing reconciliation verification
+sprintReportingRecordSchema.index(
+  { reconciliationStatus: 1, lastReconciledAt: 1 },
+  { background: true }
+);
+
+// Index 4: Active records (not soft-deleted)
+// DFD Use: Filter out deleted records in queries
+sprintReportingRecordSchema.index(
+  { groupId: 1, deletedAt: 1 },
+  { background: true }
+);
+
+// ISSUE #237: PRE-SAVE HOOK — Generate composite key
+sprintReportingRecordSchema.pre('save', function (next) {
+  // ISSUE #237: Create composite key for idempotency
+  if (this.isModified('sprintId') || this.isModified('groupId')) {
+    this._uniqueKey = `${this.sprintId}#${this.groupId}`;
+  }
+
+  next();
+});
+
+// ISSUE #237: QUERY HELPER — Find active records
+sprintReportingRecordSchema.query.active = function () {
+  return this.where({ deletedAt: null });
+};
+
+// ISSUE #237: INSTANCE METHOD — Check if record needs reconciliation
+sprintReportingRecordSchema.methods.needsReconciliation = function () {
+  // Records need reconciliation if:
+  // 1. Never reconciled, OR
+  // 2. Last reconciliation was > 24 hours ago
+  if (!this.lastReconciledAt) return true;
+
+  const hoursSinceReconciliation =
+    (Date.now() - this.lastReconciledAt.getTime()) / (1000 * 60 * 60);
+  return hoursSinceReconciliation > 24;
+};
+
+// ISSUE #237: INSTANCE METHOD — Mark as soft-deleted
+sprintReportingRecordSchema.methods.softDelete = function () {
+  // ISSUE #237: Preserve historical data while removing from queries
+  this.deletedAt = new Date();
+  return this.save();
+};
+
+// ISSUE #237: STATIC METHOD — Find reporting record for sprint
+sprintReportingRecordSchema.statics.findForSprint = async function (sprintId, groupId) {
+  return this.findOne({
+    sprintId,
+    groupId,
+    deletedAt: null,
+  });
+};
+
+// ISSUE #237: STATIC METHOD — Find records needing reconciliation
+sprintReportingRecordSchema.statics.findNeedingReconciliation = async function () {
+  const oneDay = 24 * 60 * 60 * 1000;
+  const yesterday = new Date(Date.now() - oneDay);
+
+  return this.find({
+    deletedAt: null,
+    $or: [
+      { lastReconciledAt: null }, // Never reconciled
+      { lastReconciledAt: { $lt: yesterday } }, // Older than 24 hours
+    ],
+  });
+};
+
+// ISSUE #237: STATIC METHOD — Find by coordinator
+sprintReportingRecordSchema.statics.findByCoordinator = async function (coordinatorId) {
+  return this.find({
+    coordinatorId,
+    deletedAt: null,
+  })
+    .sort({ calculatedAt: -1 })
+    .exec();
+};
+
+// ISSUE #237: INSTANCE METHOD — Validate consistency with D6
+// This is called by D4→D6 reconciliation job (Flow 139)
+sprintReportingRecordSchema.methods.validate = function () {
+  const errors = [];
+
+  if (!this.sprintId) errors.push('sprintId is required');
+  if (!this.groupId) errors.push('groupId is required');
+  if (this.totalMembers < 0) errors.push('totalMembers cannot be negative');
+  if (this.groupTotalStoryPoints < 0) errors.push('groupTotalStoryPoints cannot be negative');
+  if (this.averageRatio < 0 || this.averageRatio > 1) {
+    errors.push('averageRatio must be between 0 and 1');
+  }
+  if (this.maxRatio < 0 || this.maxRatio > 1) {
+    errors.push('maxRatio must be between 0 and 1');
+  }
+  if (this.minRatio < 0 || this.minRatio > 1) {
+    errors.push('minRatio must be between 0 and 1');
+  }
+  if (this.minRatio > this.maxRatio) {
+    errors.push('minRatio cannot be greater than maxRatio');
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+};
+
+// ISSUE #237: Export model
+const SprintReportingRecord = mongoose.model(
+  'SprintReportingRecord',
+  sprintReportingRecordSchema
+);
+
+module.exports = SprintReportingRecord;

--- a/backend/src/models/SyncJob.js
+++ b/backend/src/models/SyncJob.js
@@ -30,6 +30,7 @@ const syncJobSchema = new mongoose.Schema(
     startedAt: { type: Date, default: null },
     completedAt: { type: Date, default: null },
     triggeredBy: { type: String, default: null },
+    correlationId: { type: String, default: null },
   },
   {
     timestamps: true,

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -36,6 +36,7 @@ const { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob, getSyncJobLogs } 
 const { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs } = require('../controllers/jiraSync');
 const {
   recalculateContributions,
+  reconcileD4toD6,
 } = require('../controllers/sprintTracking');
 
 // Integrated Controllers from both branches
@@ -198,6 +199,13 @@ router.post(
   authMiddleware,
   roleMiddleware(['coordinator', 'admin']),
   recalculateContributions
+);
+
+router.post(
+  '/:groupId/sprints/:sprintId/reconcile-deliverables',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  reconcileD4toD6
 );
 
 router.patch(

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -118,10 +118,10 @@ router.post(
 // INTEGRATIONS & OVERRIDES (Process 2.6 - 2.8)
 // ============================================================================
 
-router.post('/:groupId/github', authMiddleware, configureGithub);
-router.get('/:groupId/github', authMiddleware, getGithub);
-router.post('/:groupId/jira', authMiddleware, configureJira);
-router.get('/:groupId/jira', authMiddleware, getJira);
+router.post('/:groupId/github', authMiddleware, roleMiddleware(['coordinator']), configureGithub);
+router.get('/:groupId/github', authMiddleware, roleMiddleware(['coordinator']), getGithub);
+router.post('/:groupId/jira', authMiddleware, roleMiddleware(['coordinator']), configureJira);
+router.get('/:groupId/jira', authMiddleware, roleMiddleware(['coordinator']), getJira);
 
 // ============================================================================
 // PROCESS 7.2 — GitHub PR Sync (async validation bridge)

--- a/backend/src/security/logRedactor.js
+++ b/backend/src/security/logRedactor.js
@@ -5,6 +5,10 @@ const AUTHORIZATION_BEARER_REGEX = /(Authorization\s*:\s*Bearer\s+)[^\s,;]+/gi;
 const AUTHORIZATION_BASIC_REGEX = /(Authorization\s*:\s*Basic\s+)[A-Za-z0-9+/=]+/gi;
 const JSON_BEARER_REGEX = /("authorization"\s*:\s*"Bearer\s+)[^"]+/gi;
 const JSON_BASIC_REGEX = /("authorization"\s*:\s*"Basic\s+)[^"]+/gi;
+const BEARER_PREFIX_REGEX = /^Bearer\s+/i;
+const BASIC_PREFIX_REGEX = /^Basic\s+/i;
+const SENSITIVE_KEY_REGEX =
+  /(^|_)(authorization|token|secret|password|pat|api[_-]?key|api[_-]?token|cookie|set-cookie)$/i;
 
 function redactString(value) {
   if (!value || typeof value !== 'string') return value;
@@ -15,6 +19,12 @@ function redactString(value) {
     .replace(AUTHORIZATION_BASIC_REGEX, '$1[REDACTED]')
     .replace(JSON_BEARER_REGEX, '$1[REDACTED]')
     .replace(JSON_BASIC_REGEX, '$1[REDACTED]');
+}
+
+function redactSensitiveValue(value) {
+  if (typeof value === 'string') return '[REDACTED]';
+  if (Array.isArray(value)) return value.map(() => '[REDACTED]');
+  return '[REDACTED]';
 }
 
 function redactObject(value, seen = new WeakSet()) {
@@ -30,6 +40,22 @@ function redactObject(value, seen = new WeakSet()) {
 
   const copy = {};
   for (const [key, nested] of Object.entries(value)) {
+    const normalizedKey = String(key || '').trim();
+    if (SENSITIVE_KEY_REGEX.test(normalizedKey)) {
+      if (typeof nested === 'string') {
+        if (BEARER_PREFIX_REGEX.test(nested)) {
+          copy[key] = 'Bearer [REDACTED]';
+          continue;
+        }
+        if (BASIC_PREFIX_REGEX.test(nested)) {
+          copy[key] = 'Basic [REDACTED]';
+          continue;
+        }
+      }
+      copy[key] = redactSensitiveValue(nested);
+      continue;
+    }
+
     copy[key] = redactObject(nested, seen);
   }
   return copy;

--- a/backend/src/security/logRedactor.js
+++ b/backend/src/security/logRedactor.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const GITHUB_PAT_REGEX = /\bghp_[A-Za-z0-9]{20,}\b/g;
+const AUTHORIZATION_BEARER_REGEX = /(Authorization\s*:\s*Bearer\s+)[^\s,;]+/gi;
+const AUTHORIZATION_BASIC_REGEX = /(Authorization\s*:\s*Basic\s+)[A-Za-z0-9+/=]+/gi;
+const JSON_BEARER_REGEX = /("authorization"\s*:\s*"Bearer\s+)[^"]+/gi;
+const JSON_BASIC_REGEX = /("authorization"\s*:\s*"Basic\s+)[^"]+/gi;
+
+function redactString(value) {
+  if (!value || typeof value !== 'string') return value;
+
+  return value
+    .replace(GITHUB_PAT_REGEX, '[REDACTED]')
+    .replace(AUTHORIZATION_BEARER_REGEX, '$1[REDACTED]')
+    .replace(AUTHORIZATION_BASIC_REGEX, '$1[REDACTED]')
+    .replace(JSON_BEARER_REGEX, '$1[REDACTED]')
+    .replace(JSON_BASIC_REGEX, '$1[REDACTED]');
+}
+
+function redactObject(value, seen = new WeakSet()) {
+  if (value == null) return value;
+  if (typeof value === 'string') return redactString(value);
+  if (typeof value !== 'object') return value;
+  if (seen.has(value)) return value;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactObject(item, seen));
+  }
+
+  const copy = {};
+  for (const [key, nested] of Object.entries(value)) {
+    copy[key] = redactObject(nested, seen);
+  }
+  return copy;
+}
+
+function redactAny(value) {
+  if (typeof value === 'string') return redactString(value);
+  if (value && typeof value === 'object') return redactObject(value);
+  return value;
+}
+
+module.exports = {
+  redactAny,
+  redactString,
+};

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -26,6 +26,7 @@ const createAuditLog = async (
     details = null,
     ipAddress = null,
     userAgent = null,
+    correlationId = null,
   },
   session = null
 ) => {
@@ -39,6 +40,7 @@ const createAuditLog = async (
     details,
     ipAddress,
     userAgent,
+    correlationId,
   });
   await log.save(session ? { session } : undefined);
   return log;

--- a/backend/src/services/d4ToD6Reconciliation.js
+++ b/backend/src/services/d4ToD6Reconciliation.js
@@ -1,0 +1,519 @@
+/**
+ * ============================================================================
+ * Issue #237: D4 → D6 Reconciliation Service (Flow 139 Implementation)
+ * ============================================================================
+ *
+ * CHANGES FOR ISSUE #237:
+ * - Implements reconciliation logic between D4 reporting records and D6 canonical data
+ * - Verifies D4 reporting metrics match D6 contribution records
+ * - Prevents duplicate canonical rows during D4→D6 sync (idempotent design)
+ * - DFD Flow 139 (f7_d4_d6): Ensures consistency between reporting and canonical stores
+ * - Can be run as periodic job or triggered after persistence operation
+ * - Logs reconciliation outcomes for audit trail
+ *
+ * OPERATIONAL MODEL:
+ * D4 is the reporting/visibility layer (coordinator dashboards)
+ * D6 is the canonical/truth layer (student contributions)
+ * This service ensures D4 stays in sync with D6 without creating duplicates.
+ *
+ * DFD INTEGRATION:
+ * Input: D4 (SprintReportingRecord), D6 (SprintContributionRecord)
+ * Output: Reconciliation status + audit trail
+ * Flow: f7_d4_d6 (D4 → D6 consistency check)
+ */
+
+const SprintReportingRecord = require('../models/SprintReportingRecord');
+const SprintContributionRecord = require('../models/SprintContributionRecord');
+const { createAuditLog } = require('./auditService');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * ISSUE #237: Custom error class for reconciliation errors
+ */
+class ReconciliationError extends Error {
+  constructor(status = 500, code = 'RECONCILIATION_ERROR', message) {
+    super(message);
+    this.name = 'ReconciliationError';
+    this.status = status;
+    this.code = code;
+    this.timestamp = new Date();
+  }
+}
+
+/**
+ * ISSUE #237: Main reconciliation orchestrator
+ *
+ * Reconciles D4 reporting records with D6 canonical contribution data.
+ * Verifies that:
+ * 1. D4 aggregate metrics match D6 detail records
+ * 2. No duplicate canonical rows were created
+ * 3. Counts and totals are consistent
+ *
+ * Called either:
+ * - Periodically (cron job) to verify overall consistency
+ * - After persistence operation to confirm write succeeded
+ * - On-demand by administrators
+ *
+ * @param {string} sprintId - Sprint identifier
+ * @param {string} groupId - Group identifier
+ * @param {object} options - Configuration options
+ *   - autoRepair: {boolean} Attempt to fix inconsistencies (default: false)
+ *   - verbose: {boolean} Detailed logging (default: false)
+ * @returns {object} ReconciliationResult with status and details
+ * @throws {ReconciliationError} On critical failures
+ */
+async function reconcileSprintRecords(sprintId, groupId, options = {}) {
+  const correlationId = `recon_${uuidv4().split('-')[0]}_${Date.now()}`;
+  const reconciliationLog = {
+    correlationId,
+    sprintId,
+    groupId,
+    startedAt: new Date(),
+    steps: [],
+    inconsistencies: [],
+    repairs: [],
+  };
+
+  try {
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 1: FETCH D4 REPORTING RECORD
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 1,
+      name: 'fetch_d4_reporting',
+      startedAt: new Date(),
+    });
+
+    const d4Report = await SprintReportingRecord.findForSprint(sprintId, groupId);
+
+    if (!d4Report) {
+      // ISSUE #237: No D4 reporting record — this is OK (D4 writes are optional)
+      reconciliationLog.steps[0].completedAt = new Date();
+      reconciliationLog.steps[0].status = 'not_found';
+      reconciliationLog.steps[0].message = 'No D4 reporting record found (optional)';
+
+      return {
+        success: true,
+        correlationId,
+        sprintId,
+        groupId,
+        status: 'no_d4_record',
+        message: 'No D4 reporting record to reconcile',
+        reconciliationLog,
+      };
+    }
+
+    reconciliationLog.steps[0].completedAt = new Date();
+    reconciliationLog.steps[0].status = 'found';
+    reconciliationLog.steps[0].d4RecordId = d4Report._id;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 2: FETCH ALL D6 CONTRIBUTION RECORDS FOR THIS SPRINT
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 2,
+      name: 'fetch_d6_contributions',
+      startedAt: new Date(),
+    });
+
+    const d6Records = await SprintContributionRecord.getSprintContributions(
+      sprintId,
+      groupId
+    );
+
+    reconciliationLog.steps[1].completedAt = new Date();
+    reconciliationLog.steps[1].status = 'success';
+    reconciliationLog.steps[1].recordCount = d6Records.length;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 3: VALIDATE MEMBER COUNT CONSISTENCY
+    // ISSUE #237: D4.totalMembers should match number of D6 records
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 3,
+      name: 'validate_member_count',
+      startedAt: new Date(),
+    });
+
+    const d4MemberCount = d4Report.totalMembers;
+    const d6MemberCount = d6Records.length;
+
+    if (d4MemberCount !== d6MemberCount) {
+      const inconsistency = {
+        field: 'totalMembers',
+        d4Value: d4MemberCount,
+        d6Value: d6MemberCount,
+        discrepancy: Math.abs(d4MemberCount - d6MemberCount),
+        severity: 'high',
+      };
+
+      reconciliationLog.inconsistencies.push(inconsistency);
+
+      if (options.autoRepair) {
+        // ISSUE #237: Auto-repair: update D4 to match D6
+        d4Report.totalMembers = d6MemberCount;
+        reconciliationLog.repairs.push({
+          field: 'totalMembers',
+          action: 'updated_to_d6_value',
+          newValue: d6MemberCount,
+        });
+      }
+    }
+
+    reconciliationLog.steps[2].completedAt = new Date();
+    reconciliationLog.steps[2].memberCountMatch = d4MemberCount === d6MemberCount;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 4: VALIDATE AGGREGATED METRICS
+    // ISSUE #237: Recalculate metrics from D6 and compare with D4
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 4,
+      name: 'validate_aggregates',
+      startedAt: new Date(),
+    });
+
+    if (d6Records.length > 0) {
+      // Calculate metrics from D6 records
+      const calculatedMetrics = calculateAggregateMetrics(d6Records);
+
+      // Validate each metric
+      const metricValidations = validateMetrics(d4Report, calculatedMetrics);
+
+      if (metricValidations.inconsistencies.length > 0) {
+        reconciliationLog.inconsistencies.push(...metricValidations.inconsistencies);
+
+        if (options.autoRepair) {
+          // ISSUE #237: Auto-repair: update D4 metrics to match D6
+          d4Report.averageRatio = calculatedMetrics.averageRatio;
+          d4Report.maxRatio = calculatedMetrics.maxRatio;
+          d4Report.minRatio = calculatedMetrics.minRatio;
+          d4Report.groupTotalStoryPoints = calculatedMetrics.groupTotalStoryPoints;
+
+          reconciliationLog.repairs.push({
+            field: 'aggregateMetrics',
+            action: 'recalculated_from_d6',
+            metrics: calculatedMetrics,
+          });
+        }
+      }
+
+      reconciliationLog.steps[3].completedAt = new Date();
+      reconciliationLog.steps[3].status = 'validated';
+      reconciliationLog.steps[3].metrics = calculatedMetrics;
+    } else {
+      reconciliationLog.steps[3].completedAt = new Date();
+      reconciliationLog.steps[3].status = 'skipped';
+      reconciliationLog.steps[3].reason = 'no_d6_records';
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 5: CHECK FOR DUPLICATE CANONICAL ROWS
+    // ISSUE #237: Verify no duplicate (sprintId, studentId, groupId) tuples
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 5,
+      name: 'check_duplicate_rows',
+      startedAt: new Date(),
+    });
+
+    // Count records by (sprintId, studentId, groupId) to find duplicates
+    const duplicateCheck = await SprintContributionRecord.collection.aggregate([
+      {
+        $match: {
+          sprintId,
+          groupId,
+        },
+      },
+      {
+        $group: {
+          _id: {
+            sprintId: '$sprintId',
+            studentId: '$studentId',
+            groupId: '$groupId',
+          },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $match: {
+          count: { $gt: 1 },
+        },
+      },
+    ]).toArray();
+
+    if (duplicateCheck.length > 0) {
+      const duplicateInconsistency = {
+        field: 'duplicate_records',
+        duplicateGroupCount: duplicateCheck.length,
+        severity: 'critical',
+        duplicates: duplicateCheck,
+      };
+
+      reconciliationLog.inconsistencies.push(duplicateInconsistency);
+
+      // ISSUE #237: Duplicates should never happen with idempotent key design
+      // If found, this indicates a serious data integrity issue
+      console.error(
+        `[D4D6Reconciliation] CRITICAL: Found duplicate canonical rows [correlationId: ${correlationId}]`,
+        duplicateCheck
+      );
+    }
+
+    reconciliationLog.steps[4].completedAt = new Date();
+    reconciliationLog.steps[4].duplicatesFound = duplicateCheck.length > 0;
+    reconciliationLog.steps[4].duplicateCount = duplicateCheck.length;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 6: UPDATE RECONCILIATION METADATA IN D4
+    // ISSUE #237: Record reconciliation result and timestamp
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 6,
+      name: 'update_d4_metadata',
+      startedAt: new Date(),
+    });
+
+    try {
+      // ISSUE #237: Update D4 record with reconciliation status
+      d4Report.lastReconciledAt = new Date();
+      d4Report.d6RecordCount = d6Records.length;
+      d4Report.reconciliationStatus =
+        reconciliationLog.inconsistencies.length === 0 ? 'consistent' : 'inconsistent';
+
+      await d4Report.save();
+
+      reconciliationLog.steps[5].completedAt = new Date();
+      reconciliationLog.steps[5].status = 'updated';
+      reconciliationLog.steps[5].newStatus = d4Report.reconciliationStatus;
+    } catch (err) {
+      console.error(
+        `[D4D6Reconciliation] Failed to update D4 metadata: ${err.message} [correlationId: ${correlationId}]`
+      );
+      reconciliationLog.steps[5].status = 'warning';
+      reconciliationLog.steps[5].warning = err.message;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 7: AUDIT LOGGING
+    // ISSUE #237: Track reconciliation operation for compliance
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.steps.push({
+      step: 7,
+      name: 'audit_logging',
+      startedAt: new Date(),
+    });
+
+    try {
+      await createAuditLog({
+        action: 'D4_D6_RECONCILIATION_COMPLETED',
+        targetId: `${sprintId}#${groupId}`,
+        groupId,
+        payload: {
+          sprintId,
+          groupId,
+          correlationId,
+          status: d4Report.reconciliationStatus,
+          inconsistencyCount: reconciliationLog.inconsistencies.length,
+          repairsApplied: reconciliationLog.repairs.length,
+          d6RecordCount,
+        },
+      });
+
+      reconciliationLog.steps[6].completedAt = new Date();
+      reconciliationLog.steps[6].status = 'success';
+    } catch (auditErr) {
+      console.warn(
+        `[D4D6Reconciliation] Audit log failed (non-fatal): ${auditErr.message} [correlationId: ${correlationId}]`
+      );
+      reconciliationLog.steps[6].status = 'warning';
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RETURN SUCCESS RESPONSE
+    // ─────────────────────────────────────────────────────────────────────────
+    reconciliationLog.completedAt = new Date();
+    reconciliationLog.durationMs = reconciliationLog.completedAt - reconciliationLog.startedAt;
+
+    return {
+      success: true,
+      correlationId,
+      sprintId,
+      groupId,
+      status: reconciliationLog.inconsistencies.length === 0 ? 'consistent' : 'inconsistent',
+      inconsistencyCount: reconciliationLog.inconsistencies.length,
+      repairsApplied: reconciliationLog.repairs.length,
+      d6RecordCount,
+      durationMs: reconciliationLog.durationMs,
+      reconciliationLog,
+    };
+  } catch (err) {
+    reconciliationLog.completedAt = new Date();
+    reconciliationLog.failed = true;
+
+    if (err instanceof ReconciliationError) {
+      console.error(
+        `[D4D6Reconciliation] Operation failed [${err.code}]: ${err.message} [correlationId: ${correlationId}]`
+      );
+      throw err;
+    }
+
+    console.error(
+      `[D4D6Reconciliation] Unexpected error: ${err.message} [correlationId: ${correlationId}]`,
+      reconciliationLog
+    );
+
+    throw new ReconciliationError(
+      500,
+      'UNEXPECTED_ERROR',
+      `Reconciliation failed: ${err.message}`
+    );
+  }
+}
+
+/**
+ * ISSUE #237: Calculate aggregate metrics from D6 records
+ *
+ * @param {Array} d6Records - Array of SprintContributionRecord documents
+ * @returns {object} Calculated metrics (averageRatio, maxRatio, minRatio, groupTotalStoryPoints)
+ */
+function calculateAggregateMetrics(d6Records) {
+  if (!d6Records || d6Records.length === 0) {
+    return {
+      averageRatio: 0,
+      maxRatio: 0,
+      minRatio: 0,
+      groupTotalStoryPoints: 0,
+    };
+  }
+
+  const ratios = d6Records.map((r) => r.contributionRatio);
+  const totalStoryPoints = d6Records.reduce((sum, r) => sum + (r.completedStoryPoints || 0), 0);
+
+  return {
+    averageRatio: ratios.length > 0 ? ratios.reduce((a, b) => a + b, 0) / ratios.length : 0,
+    maxRatio: Math.max(...ratios),
+    minRatio: Math.min(...ratios),
+    groupTotalStoryPoints: totalStoryPoints,
+  };
+}
+
+/**
+ * ISSUE #237: Validate D4 metrics against calculated D6 metrics
+ *
+ * @param {object} d4Report - D4 SprintReportingRecord
+ * @param {object} calculatedMetrics - Metrics calculated from D6
+ * @returns {object} Validation result with inconsistencies list
+ */
+function validateMetrics(d4Report, calculatedMetrics) {
+  const inconsistencies = [];
+  const tolerance = 0.01; // ISSUE #237: Allow 1% floating-point tolerance
+
+  // Compare averageRatio
+  if (Math.abs(d4Report.averageRatio - calculatedMetrics.averageRatio) > tolerance) {
+    inconsistencies.push({
+      field: 'averageRatio',
+      d4Value: d4Report.averageRatio,
+      d6Value: calculatedMetrics.averageRatio,
+      discrepancy: Math.abs(d4Report.averageRatio - calculatedMetrics.averageRatio),
+      severity: 'medium',
+    });
+  }
+
+  // Compare maxRatio
+  if (Math.abs(d4Report.maxRatio - calculatedMetrics.maxRatio) > tolerance) {
+    inconsistencies.push({
+      field: 'maxRatio',
+      d4Value: d4Report.maxRatio,
+      d6Value: calculatedMetrics.maxRatio,
+      discrepancy: Math.abs(d4Report.maxRatio - calculatedMetrics.maxRatio),
+      severity: 'medium',
+    });
+  }
+
+  // Compare minRatio
+  if (Math.abs(d4Report.minRatio - calculatedMetrics.minRatio) > tolerance) {
+    inconsistencies.push({
+      field: 'minRatio',
+      d4Value: d4Report.minRatio,
+      d6Value: calculatedMetrics.minRatio,
+      discrepancy: Math.abs(d4Report.minRatio - calculatedMetrics.minRatio),
+      severity: 'medium',
+    });
+  }
+
+  // Compare groupTotalStoryPoints
+  if (
+    Math.abs(d4Report.groupTotalStoryPoints - calculatedMetrics.groupTotalStoryPoints) > 0.1
+  ) {
+    inconsistencies.push({
+      field: 'groupTotalStoryPoints',
+      d4Value: d4Report.groupTotalStoryPoints,
+      d6Value: calculatedMetrics.groupTotalStoryPoints,
+      discrepancy: Math.abs(
+        d4Report.groupTotalStoryPoints - calculatedMetrics.groupTotalStoryPoints
+      ),
+      severity: 'high',
+    });
+  }
+
+  return { inconsistencies };
+}
+
+/**
+ * ISSUE #237: Batch reconciliation for all sprints needing verification
+ *
+ * Used as periodic job to scan all D4 records and verify consistency.
+ * Finds records that haven't been reconciled in > 24 hours.
+ *
+ * @param {object} options - Job configuration
+ * @returns {object} Batch reconciliation results
+ */
+async function reconcilePendingRecords(options = {}) {
+  try {
+    // ISSUE #237: Find records that need reconciliation
+    const pendingRecords = await SprintReportingRecord.findNeedingReconciliation();
+
+    const batchLog = {
+      startedAt: new Date(),
+      totalPending: pendingRecords.length,
+      results: [],
+    };
+
+    // ISSUE #237: Process each pending record
+    for (const record of pendingRecords) {
+      try {
+        const result = await reconcileSprintRecords(record.sprintId, record.groupId, options);
+        batchLog.results.push({
+          sprintId: record.sprintId,
+          groupId: record.groupId,
+          status: result.status,
+          inconsistencies: result.inconsistencyCount,
+        });
+      } catch (err) {
+        batchLog.results.push({
+          sprintId: record.sprintId,
+          groupId: record.groupId,
+          status: 'error',
+          error: err.message,
+        });
+      }
+    }
+
+    batchLog.completedAt = new Date();
+    batchLog.durationMs = batchLog.completedAt - batchLog.startedAt;
+
+    return batchLog;
+  } catch (err) {
+    console.error(`[D4D6Reconciliation] Batch reconciliation failed: ${err.message}`);
+    throw err;
+  }
+}
+
+module.exports = {
+  reconcileSprintRecords,
+  reconcilePendingRecords,
+  calculateAggregateMetrics,
+  validateMetrics,
+  ReconciliationError,
+};

--- a/backend/src/services/deliverableService.js
+++ b/backend/src/services/deliverableService.js
@@ -83,16 +83,20 @@ const validateCommitteeAssignment = async (groupId) => {
  */
 const storeDeliverableInD4 = async (data, session = null) => {
   try {
-    const { committeeId, groupId, studentId, type, storageRef } = data;
+    const { committeeId, groupId, studentId, type, storageRef, sprintId } = data;
 
     const deliverable = new Deliverable({
       committeeId,
       groupId,
-      studentId,
-      type,
-      storageRef,
+      submittedBy: studentId,
+      deliverableType: type,
+      sprintId: sprintId || null,
+      filePath: storageRef,
+      fileSize: data.fileSize || 0,
+      fileHash: data.fileHash || 'system-generated',
+      format: data.format || 'unknown',
       submittedAt: new Date(),
-      status: 'submitted',
+      status: 'accepted',
     });
 
     await deliverable.save(session ? { session } : undefined);
@@ -170,19 +174,7 @@ const linkD4ToD6 = async (data, session = null) => {
   try {
     const { deliverableId, sprintId, groupId, type, submittedAt } = data;
 
-    const sprintRecord = await SprintRecord.findOneAndUpdate(
-      { sprintId, groupId },
-      {
-        $push: {
-          deliverableRefs: {
-            deliverableId,
-            type,
-            submittedAt,
-          },
-        },
-      },
-      { new: true, session: session || undefined }
-    );
+    const sprintRecord = await SprintRecord.findOne({ sprintId, groupId }).session(session || undefined);
 
     if (!sprintRecord) {
       throw new DeliverableServiceError(
@@ -190,6 +182,17 @@ const linkD4ToD6 = async (data, session = null) => {
         404,
         'SPRINT_RECORD_NOT_FOUND'
       );
+    }
+
+    const alreadyLinked = sprintRecord.deliverableRefs.some((ref) => ref.deliverableId === deliverableId);
+
+    if (!alreadyLinked) {
+      sprintRecord.deliverableRefs.push({
+        deliverableId,
+        type,
+        submittedAt,
+      });
+      await sprintRecord.save({ session: session || undefined });
     }
 
     return sprintRecord;

--- a/backend/src/services/deliverableStorageService.js
+++ b/backend/src/services/deliverableStorageService.js
@@ -175,9 +175,13 @@ const createDeliverableDocument = async (stagingRecord, permanentPath, committee
     const deliverable = await Deliverable.create({
       committeeId,
       groupId: stagingRecord.groupId,
-      studentId: stagingRecord.submittedBy,
-      type: mappedType,
-      storageRef: permanentPath,
+      submittedBy: stagingRecord.submittedBy,
+      deliverableType: mappedType,
+      sprintId: stagingRecord.sprintId || null,
+      filePath: permanentPath,
+      fileSize: stagingRecord.fileSize || 0,
+      fileHash: stagingRecord.fileHash || 'unknown',
+      format: stagingRecord.mimeType || 'unknown',
       submittedAt: new Date(),
       status: 'accepted',
     });

--- a/backend/src/services/githubSyncService.js
+++ b/backend/src/services/githubSyncService.js
@@ -117,7 +117,7 @@ function determineMergeStatus(pr) {
  * @throws {GitHubSyncError} with code INVALID_GITHUB_CREDENTIALS if not configured
  */
 async function getGitHubConfig(groupId) {
-  const group = await Group.findOne({ groupId }).lean();
+  const group = await Group.findOne({ groupId }).select('+githubPat').lean();
   if (!group) {
     throw new GitHubSyncError(400, 'INVALID_GITHUB_CREDENTIALS', `Group ${groupId} not found`);
   }

--- a/backend/src/services/githubSyncService.js
+++ b/backend/src/services/githubSyncService.js
@@ -33,6 +33,7 @@ const ContributionRecord = require('../models/ContributionRecord');
 const GitHubSyncJob = require('../models/GitHubSyncJob');
 const SprintIssue = require('../models/SprintIssue');
 const { createAuditLog } = require('./auditService');
+const { dispatchSyncNotification } = require('./notificationService');
 const { decrypt } = require('../utils/cryptoUtils');
 
 // ---------------------------------------------------------------------------
@@ -411,6 +412,18 @@ async function githubSyncWorker(groupId, sprintId, jobId) {
     // ── f35: Release lock ────────────────────────────────────────────────────
     await job.save();
 
+    const correlationId = job.correlationId;
+
+    // Trigger completion notification
+    dispatchSyncNotification({
+      groupId,
+      sprintId,
+      status: job.status,
+      issuesProcessed: validationRecords.length,
+      triggeredBy: job.triggeredBy || 'system',
+      correlationId,
+    });
+
     // Audit (non-fatal)
     try {
       await createAuditLog({
@@ -426,6 +439,7 @@ async function githubSyncWorker(groupId, sprintId, jobId) {
           notMergedCount: validationRecords.filter((r) => r.mergeStatus === 'NOT_MERGED').length,
           unknownCount: validationRecords.filter((r) => r.mergeStatus === 'UNKNOWN').length,
         },
+        correlationId,
       });
     } catch (auditErr) {
       console.error('[githubSyncWorker] Audit log failed (non-fatal):', auditErr.message);
@@ -458,6 +472,7 @@ async function githubSyncWorker(groupId, sprintId, jobId) {
           errorCode: err.code || 'WORKER_ERROR',
           errorMessage: err.message,
         },
+        correlationId: job.correlationId,
       });
     } catch (auditErr) {
       console.error('[githubSyncWorker] Audit log failed (non-fatal):', auditErr.message);

--- a/backend/src/services/integrationCoordinatorService.js
+++ b/backend/src/services/integrationCoordinatorService.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const Group = require('../models/Group');
+const { encrypt } = require('../utils/cryptoUtils');
+const { createAuditLog } = require('./auditService');
+
+async function overwriteGithubCredentials({
+  group,
+  pat,
+  orgName,
+  orgData,
+  repoName,
+  visibility,
+  actorId,
+  req,
+}) {
+  group.githubPat = encrypt(pat);
+  group.githubOrg = orgName;
+  group.githubOrgId = orgData.id;
+  group.githubOrgName = orgData.name;
+  group.githubRepoName = repoName;
+  group.githubVisibility = visibility;
+  group.githubRepoUrl = `https://github.com/${orgName}/${repoName}`;
+  group.githubLastSynced = new Date();
+  await group.save();
+
+  await createAuditLog({
+    action: 'CREDENTIAL_ROTATED',
+    actorId,
+    groupId: group.groupId,
+    targetId: group.groupId,
+    payload: {
+      provider: 'github',
+      reason: 'manual_update',
+      repo: group.githubRepoUrl,
+      keyVersion: 'v1',
+    },
+    ipAddress: req.ip,
+    userAgent: req.headers['user-agent'],
+  });
+
+  return group;
+}
+
+async function overwriteJiraCredentials({
+  group,
+  baseUrl,
+  email,
+  apiToken,
+  projectKey,
+  projectData,
+  actorId,
+  req,
+}) {
+  group.jiraUrl = baseUrl;
+  group.jiraUsername = email;
+  group.jiraToken = encrypt(apiToken);
+  group.projectKey = projectKey;
+  group.jiraProjectId = String(projectData.id);
+  group.jiraProject = projectData.name || projectKey;
+  group.jiraBoardUrl = `${baseUrl}/jira/software/projects/${projectKey}/boards`;
+  group.jiraLastSynced = new Date();
+  group.jiraStoryPointOnly = true;
+  await group.save();
+
+  await createAuditLog({
+    action: 'CREDENTIAL_ROTATED',
+    actorId,
+    groupId: group.groupId,
+    targetId: group.groupId,
+    payload: {
+      provider: 'jira',
+      reason: 'manual_update',
+      projectKey,
+      keyVersion: 'v1',
+    },
+    ipAddress: req.ip,
+    userAgent: req.headers['user-agent'],
+  });
+
+  return group;
+}
+
+async function getGroupOrThrow(groupId) {
+  const group = await Group.findOne({ groupId });
+  if (!group) {
+    const error = new Error('Group not found');
+    error.status = 404;
+    error.code = 'GROUP_NOT_FOUND';
+    throw error;
+  }
+  return group;
+}
+
+module.exports = {
+  getGroupOrThrow,
+  overwriteGithubCredentials,
+  overwriteJiraCredentials,
+};

--- a/backend/src/services/integrationSecurityService.js
+++ b/backend/src/services/integrationSecurityService.js
@@ -3,6 +3,15 @@
 const { createAuditLog } = require('./auditService');
 
 const REQUIRED_GITHUB_SCOPES = ['repo:status', 'read:org'];
+const HIGH_PRIVILEGE_GITHUB_SCOPES = [
+  'repo',
+  'admin:org',
+  'admin:public_key',
+  'admin:repo_hook',
+  'admin:org_hook',
+  'delete_repo',
+  'write:packages',
+];
 
 function parseScopes(scopeHeader) {
   if (!scopeHeader || typeof scopeHeader !== 'string') return [];
@@ -15,6 +24,11 @@ function parseScopes(scopeHeader) {
 function missingScopes(grantedScopes) {
   const grantedSet = new Set(grantedScopes);
   return REQUIRED_GITHUB_SCOPES.filter((scope) => !grantedSet.has(scope));
+}
+
+function detectHighPrivilegeScopes(grantedScopes) {
+  const grantedSet = new Set(grantedScopes);
+  return HIGH_PRIVILEGE_GITHUB_SCOPES.filter((scope) => grantedSet.has(scope));
 }
 
 function maskSecret(secret) {
@@ -52,8 +66,10 @@ async function logSecurityAudit({
 
 module.exports = {
   REQUIRED_GITHUB_SCOPES,
+  HIGH_PRIVILEGE_GITHUB_SCOPES,
   parseScopes,
   missingScopes,
+  detectHighPrivilegeScopes,
   maskSecret,
   logSecurityAudit,
 };

--- a/backend/src/services/integrationSecurityService.js
+++ b/backend/src/services/integrationSecurityService.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { createAuditLog } = require('./auditService');
+
+const REQUIRED_GITHUB_SCOPES = ['repo:status', 'read:org'];
+
+function parseScopes(scopeHeader) {
+  if (!scopeHeader || typeof scopeHeader !== 'string') return [];
+  return scopeHeader
+    .split(',')
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+}
+
+function missingScopes(grantedScopes) {
+  const grantedSet = new Set(grantedScopes);
+  return REQUIRED_GITHUB_SCOPES.filter((scope) => !grantedSet.has(scope));
+}
+
+function maskSecret(secret) {
+  if (!secret || typeof secret !== 'string') return '****';
+  if (secret.length <= 4) return '****';
+  return `${secret.slice(0, 3)}****${secret.slice(-2)}`;
+}
+
+async function logSecurityAudit({
+  actorId = null,
+  groupId = null,
+  targetId = null,
+  reason,
+  provider,
+  statusCode,
+  req,
+}) {
+  await createAuditLog({
+    action: 'SECURITY_AUDIT',
+    actorId,
+    groupId,
+    targetId,
+    payload: {
+      reason,
+      provider,
+      statusCode,
+      path: req?.originalUrl || null,
+      method: req?.method || null,
+      correlationId: req?.headers?.['x-correlation-id'] || null,
+    },
+    ipAddress: req?.ip || null,
+    userAgent: req?.headers?.['user-agent'] || null,
+  });
+}
+
+module.exports = {
+  REQUIRED_GITHUB_SCOPES,
+  parseScopes,
+  missingScopes,
+  maskSecret,
+  logSecurityAudit,
+};

--- a/backend/src/services/jiraSyncService.js
+++ b/backend/src/services/jiraSyncService.js
@@ -54,7 +54,7 @@ async function withRetry(fn, maxAttempts = MAX_RETRY_ATTEMPTS) {
 }
 
 async function getJiraConfig(groupId) {
-  const group = await Group.findOne({ groupId }).lean();
+  const group = await Group.findOne({ groupId }).select('+jiraToken').lean();
   if (!group) {
     throw new JiraSyncError(404, 'GROUP_NOT_FOUND', `Group ${groupId} not found`);
   }

--- a/backend/src/services/jiraSyncService.js
+++ b/backend/src/services/jiraSyncService.js
@@ -5,10 +5,13 @@ const axios = require('axios');
 const Group = require('../models/Group');
 const SprintConfig = require('../models/SprintConfig');
 const SprintIssue = require('../models/SprintIssue');
+const SprintRecord = require('../models/SprintRecord');
+const Deliverable = require('../models/Deliverable');
 const JiraSyncJob = require('../models/JiraSyncJob');
 const SyncErrorLog = require('../models/SyncErrorLog');
 const { decrypt } = require('../utils/cryptoUtils');
 const { createAuditLog } = require('./auditService');
+const { dispatchSyncNotification } = require('./notificationService');
 
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_BASE_DELAY_MS = 200;
@@ -167,16 +170,29 @@ async function fetchSprintIssuesFromJira(config, sprintConfig) {
   };
 }
 
-async function persistSprintIssues(groupId, sprintId, issues, storyPointFieldId) {
+async function persistSprintIssues(groupId, sprintId, issues, storyPointFieldId, sprintConfig) {
   const session = await mongoose.startSession();
 
   try {
+    let upsertedCount = 0;
+
     await session.withTransaction(async () => {
+      // ── Atomic Read Guard ──────────────────────────────────────────────────
+      const sprintRecord = await SprintRecord.findOne({ groupId, sprintId }).session(session);
+      if (sprintRecord && ['completed', 'reviewed'].includes(sprintRecord.status)) {
+        throw Object.assign(new Error('Sprint contribution snapshot is finalized and locked.'), {
+          code: 'SNAPSHOT_LOCKED',
+        });
+      }
+
       if (issues.length === 0) {
         return;
       }
 
-      const operations = issues.map((issue) => {
+      const syncTimestamp = new Date();
+
+      // 1. Update Sprint Issues (D6 Metrics)
+      const issueOperations = issues.map((issue) => {
         const fields = issue.fields || {};
         const assignee = fields.assignee || {};
 
@@ -190,7 +206,7 @@ async function persistSprintIssues(groupId, sprintId, issues, storyPointFieldId)
                 assigneeAccountId: assignee.accountId || null,
                 assigneeDisplayName: assignee.displayName || null,
                 rawIssue: issue,
-                syncedAt: new Date(),
+                syncedAt: syncTimestamp,
               },
               $setOnInsert: {
                 groupId,
@@ -203,10 +219,71 @@ async function persistSprintIssues(groupId, sprintId, issues, storyPointFieldId)
         };
       });
 
-      await SprintIssue.bulkWrite(operations, { session });
+      await SprintIssue.bulkWrite(issueOperations, { session });
+      upsertedCount = issues.length;
+
+      // 2. Update Deliverables (D4) and SprintRecord (D6) if enabled
+      if (sprintConfig.enableD4Reporting) {
+        const deliverableRefs = issues.map((issue) => ({
+          deliverableId: issue.key,
+          type: 'demonstration',
+          submittedAt: new Date(issue.fields?.updated || issue.fields?.created || syncTimestamp),
+        }));
+
+        const deliverableOps = deliverableRefs.map((ref) => ({
+          updateOne: {
+            filter: { deliverableId: ref.deliverableId, groupId },
+            update: {
+              $set: {
+                deliverableType: 'demonstration',
+                sprintId,
+                submittedBy: 'system-jira-sync',
+                filePath: `jira://${ref.deliverableId}`,
+                fileSize: 0,
+                fileHash: 'jira-synced',
+                format: 'jira-issue',
+                status: 'accepted',
+                submittedAt: ref.submittedAt,
+              },
+            },
+            upsert: true,
+          },
+        }));
+
+        if (deliverableOps.length > 0) {
+          await Deliverable.bulkWrite(deliverableOps, { session });
+        }
+
+        const sprintUpdate = {
+          $set: {
+            status: 'in_progress',
+            deliverableRefs: deliverableRefs,
+          },
+          $setOnInsert: {
+            groupId,
+            sprintId,
+          },
+        };
+
+        await SprintRecord.findOneAndUpdate({ groupId, sprintId }, sprintUpdate, {
+          upsert: true,
+          new: true,
+          session,
+        });
+      } else {
+        // Just ensure SprintRecord exists and status is in_progress
+        await SprintRecord.findOneAndUpdate(
+          { groupId, sprintId },
+          {
+            $set: { status: 'in_progress' },
+            $setOnInsert: { groupId, sprintId },
+          },
+          { upsert: true, new: true, session }
+        );
+      }
     });
 
-    return issues.length;
+    return upsertedCount;
   } finally {
     await session.endSession();
   }
@@ -252,17 +329,29 @@ async function jiraSyncWorker(groupId, sprintId, jobId) {
   job.startedAt = new Date();
   await job.save();
 
+  const correlationId = job.correlationId;
+
   try {
     const config = await getJiraConfig(groupId);
     const sprintConfig = await getPublishedSprintConfig(groupId, sprintId);
     const { issues, storyPointFieldId, jql } = await fetchSprintIssuesFromJira(config, sprintConfig);
-    const upserted = await persistSprintIssues(groupId, sprintId, issues, storyPointFieldId);
+    const upserted = await persistSprintIssues(groupId, sprintId, issues, storyPointFieldId, sprintConfig);
 
     job.status = 'COMPLETED';
     job.issuesProcessed = issues.length;
     job.issuesUpserted = upserted;
     job.completedAt = new Date();
     await job.save();
+
+    // Trigger completion notification with correlationId
+    dispatchSyncNotification({
+      groupId,
+      sprintId,
+      status: 'COMPLETED',
+      issuesProcessed: issues.length,
+      triggeredBy: job.triggeredBy || 'system',
+      correlationId,
+    });
 
     try {
       await createAuditLog({
@@ -278,6 +367,7 @@ async function jiraSyncWorker(groupId, sprintId, jobId) {
           externalSprintKey: sprintConfig.externalSprintKey,
           jql,
         },
+        correlationId,
       });
     } catch (auditErr) {
       console.error('[jiraSyncWorker] Audit log failed (non-fatal):', auditErr.message);
@@ -309,6 +399,7 @@ async function jiraSyncWorker(groupId, sprintId, jobId) {
           errorCode: normalizedError.code,
           errorMessage: normalizedError.message,
         },
+        correlationId,
       });
     } catch (auditErr) {
       console.error('[jiraSyncWorker] Audit log failed (non-fatal):', auditErr.message);

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -312,6 +312,39 @@ const dispatchClarificationRequiredNotification = async ({
   }
 };
 
+/**
+ * Dispatch JIRA sync completion notification
+ */
+const dispatchSyncNotification = async ({ groupId, sprintId, status, issuesProcessed, triggeredBy, correlationId }) => {
+  try {
+    // Fire-and-forget call to notification service
+    const payload = {
+      type: 'sprint_sync_completed',
+      groupId,
+      sprintId,
+      status,
+      issuesProcessed,
+      triggeredBy,
+      correlationId,
+      timestamp: new Date().toISOString(),
+    };
+
+    // We don't await this to keep it fire-and-forget, but we handle errors
+    const promise = axios.post(`${NOTIFICATION_SERVICE_URL}/api/notifications`, payload, { timeout: 5000 });
+    
+    if (promise && typeof promise.catch === 'function') {
+      promise.catch(error => {
+        console.error('Error dispatching sync notification (async):', error.message || error);
+      });
+    }
+    
+    return { success: true };
+  } catch (error) {
+    console.error('Error in dispatchSyncNotification setup:', error.message || error);
+    return { success: false, error: error.message };
+  }
+};
+
 module.exports = {
   dispatchInvitationNotification,
   dispatchMembershipDecisionNotification,
@@ -328,5 +361,6 @@ module.exports = {
   dispatchDisbandNotification,
   dispatchReviewAssignmentNotification,
   dispatchClarificationRequiredNotification,
+  dispatchSyncNotification,
   isTransientError,
 };

--- a/backend/src/services/sprintContributionPersistence.js
+++ b/backend/src/services/sprintContributionPersistence.js
@@ -1,0 +1,500 @@
+/**
+ * ============================================================================
+ * Issue #237: [BE] Persist Sprint Records — D6 Writes + D4/D6 Sync Path (7.5)
+ * ============================================================================
+ *
+ * CHANGES FOR ISSUE #237:
+ * - Implements the persistence layer for sprint contribution artifacts
+ * - Writes per-student sprint records to D6 (ContributionRecord)
+ * - Optionally writes sprint reporting records to D4
+ * - Ensures D4→D6 sync path maintains idempotency (no duplicate canonical rows)
+ * - Handles finalized/locked sprint conflicts with 409 responses
+ * - All writes include audit fields (createdAt, updatedAt)
+ * - Correlation IDs for notification service (#238) integration
+ * - DFD Flows: f7_p75_ds_d6, f7_p75_d4, f7_d4_d6, f7_p75_ext_notification
+ *
+ * DESIGN PATTERN:
+ * This service orchestrates a 6-step pipeline:
+ *   1. Validate inputs and authorization
+ *   2. Check if sprint is finalized/locked (409 if so)
+ *   3. Upsert D6 records for each student (atomic per-student operations)
+ *   4. Optionally write D4 reporting record (if config enabled)
+ *   5. Dispatch notification events to Notification Service
+ *   6. Return audit trail with persistence metadata
+ *
+ * IDEMPOTENCY GUARANTEE:
+ * - Idempotent key: (sprintId, studentId, groupId) for D6 records
+ * - Same input (contribution summary) always produces same D6 output
+ * - Multiple calls to persistSprintContributions with same data are safe
+ * - D4→D6 sync checks if record exists before inserting (prevents duplicates)
+ */
+
+const ContributionRecord = require('../models/ContributionRecord');
+const SprintRecord = require('../models/SprintRecord');
+const SprintContributionRecord = require('../models/SprintContributionRecord');
+const SprintReportingRecord = require('../models/SprintReportingRecord');
+const { createAuditLog } = require('./auditService');
+const { dispatchNotificationEvent } = require('./notificationService');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * ISSUE #237: Custom error class for persistence layer
+ * Provides consistent error handling with HTTP status codes and error codes
+ */
+class PersistenceServiceError extends Error {
+  constructor(status = 500, code = 'PERSISTENCE_ERROR', message = 'Persistence operation failed') {
+    super(message);
+    this.name = 'PersistenceServiceError';
+    this.status = status;
+    this.code = code;
+    this.timestamp = new Date();
+  }
+}
+
+/**
+ * ISSUE #237: Main persistence orchestrator
+ *
+ * Persists sprint contribution data from Process 7.4 (ratio engine) to database.
+ * Called after successful ratio calculation in contributionRatios controller.
+ *
+ * @param {string} groupId - Group identifier
+ * @param {string} sprintId - Sprint identifier
+ * @param {object} contributionSummary - Output from Process 7.4 (Issue #236)
+ *   Shape: { contributions: [{studentId, contributionRatio, targetStoryPoints, completedStoryPoints}], ... }
+ * @param {string} coordinatorId - User performing the operation (audit trail)
+ * @param {object} options - Configuration options
+ *   - persistToD4: {boolean} Write reporting record to D4 (default: true)
+ *   - allowOverrideFinalized: {boolean} Allow overwriting finalized sprint (default: false)
+ *   - notificationPayload: {object} Additional context for notifications
+ * @returns {object} PersistenceResult with audit trail and metadata
+ * @throws {PersistenceServiceError} On validation failures, lock conflicts, or write errors
+ */
+async function persistSprintContributions(
+  groupId,
+  sprintId,
+  contributionSummary,
+  coordinatorId,
+  options = {}
+) {
+  const correlationId = `pc_${uuidv4().split('-')[0]}_${Date.now()}`;
+  const operationStartTime = Date.now();
+  const persistenceLog = {
+    correlationId,
+    groupId,
+    sprintId,
+    coordinatorId,
+    startedAt: new Date(),
+    steps: [],
+    errors: [],
+  };
+
+  try {
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 1: VALIDATE INPUTS AND AUTHORIZATION
+    // ISSUE #237: Guard against invalid input before any DB operations
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.steps.push({
+      step: 1,
+      name: 'validate_inputs',
+      startedAt: new Date(),
+    });
+
+    if (!groupId || typeof groupId !== 'string') {
+      throw new PersistenceServiceError(400, 'INVALID_GROUP_ID', 'groupId must be a non-empty string');
+    }
+
+    if (!sprintId || typeof sprintId !== 'string') {
+      throw new PersistenceServiceError(400, 'INVALID_SPRINT_ID', 'sprintId must be a non-empty string');
+    }
+
+    if (!coordinatorId || typeof coordinatorId !== 'string') {
+      throw new PersistenceServiceError(400, 'INVALID_COORDINATOR_ID', 'coordinatorId must be a non-empty string');
+    }
+
+    if (!contributionSummary || !Array.isArray(contributionSummary.contributions)) {
+      throw new PersistenceServiceError(
+        400,
+        'INVALID_CONTRIBUTION_SUMMARY',
+        'contributionSummary must contain contributions array'
+      );
+    }
+
+    if (contributionSummary.contributions.length === 0) {
+      throw new PersistenceServiceError(
+        422,
+        'EMPTY_CONTRIBUTION_LIST',
+        'No contributions provided for persistence'
+      );
+    }
+
+    persistenceLog.steps[0].completedAt = new Date();
+    persistenceLog.steps[0].validatedRecords = contributionSummary.contributions.length;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 2: CHECK IF SPRINT IS FINALIZED/LOCKED
+    // ISSUE #237: Prevent overwriting finalized sprint snapshots (409 conflict)
+    // DFD Reference: f7_p75_ds_d6 (Process 7.5 → D6)
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.steps.push({
+      step: 2,
+      name: 'check_sprint_locked',
+      startedAt: new Date(),
+    });
+
+    const sprintRecord = await SprintRecord.findOne({
+      sprintId,
+      groupId,
+    });
+
+    if (sprintRecord && sprintRecord.isFinalized === true && !options.allowOverrideFinalized) {
+      throw new PersistenceServiceError(
+        409,
+        'SPRINT_FINALIZED_CONFLICT',
+        `Sprint ${sprintId} is finalized and cannot be modified. Set allowOverrideFinalized=true to override.`,
+        { sprintId, groupId, finalizationReason: sprintRecord.finalizationReason }
+      );
+    }
+
+    persistenceLog.steps[1].completedAt = new Date();
+    persistenceLog.steps[1].isFinalizedCheck = sprintRecord?.isFinalized || false;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 3: UPSERT D6 CONTRIBUTION RECORDS (ATOMIC PER-STUDENT)
+    // ISSUE #237: Implement idempotent upsert using (sprintId, studentId, groupId)
+    // All records have updatedAt automatically set by mongoose timestamps
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.steps.push({
+      step: 3,
+      name: 'upsert_d6_records',
+      startedAt: new Date(),
+      records: [],
+    });
+
+    const upsertResults = [];
+
+    for (const contribution of contributionSummary.contributions) {
+      try {
+        const { studentId, contributionRatio, targetStoryPoints, completedStoryPoints } = contribution;
+
+        // ISSUE #237: Upsert pattern — find and update, or create if not exists
+        // Uses findOneAndUpdate for atomic operation (prevents race conditions)
+        const updatedRecord = await ContributionRecord.findOneAndUpdate(
+          {
+            sprintId,
+            studentId,
+            groupId,
+          },
+          {
+            $set: {
+              // ISSUE #237: Update contribution metrics from Process 7.4 output
+              contributionRatio: Number(contributionRatio.toFixed(4)), // Clamp to 4 decimal places
+              storyPointsCompleted: completedStoryPoints,
+              storyPointsAssigned: targetStoryPoints,
+              // ISSUE #237: Audit field — timestamps handled by mongoose
+              lastUpdatedAt: new Date(),
+            },
+          },
+          {
+            upsert: true, // Create if not exists
+            new: true, // Return updated document
+            runValidators: true,
+          }
+        );
+
+        upsertResults.push({
+          studentId,
+          contributionRecordId: updatedRecord.contributionRecordId,
+          isNew: !updatedRecord._id, // True if just created
+          ratio: updatedRecord.contributionRatio,
+        });
+
+        persistenceLog.steps[2].records.push({
+          studentId,
+          status: 'success',
+          recordId: updatedRecord.contributionRecordId,
+        });
+      } catch (err) {
+        persistenceLog.steps[2].records.push({
+          studentId: contribution.studentId,
+          status: 'error',
+          reason: err.message,
+        });
+        throw new PersistenceServiceError(
+          500,
+          'D6_UPSERT_FAILED',
+          `Failed to upsert D6 record for student ${contribution.studentId}: ${err.message}`
+        );
+      }
+    }
+
+    persistenceLog.steps[2].completedAt = new Date();
+    persistenceLog.steps[2].upsertedCount = upsertResults.length;
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 4: OPTIONALLY WRITE D4 REPORTING RECORD
+    // ISSUE #237: D4 write is conditional (config-driven)
+    // DFD Reference: f7_p75_d4 (Process 7.5 → D4 / Flow 128)
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.steps.push({
+      step: 4,
+      name: 'write_d4_reporting_record',
+      startedAt: new Date(),
+    });
+
+    let d4ReportingRecord = null;
+
+    if (options.persistToD4 !== false) {
+      try {
+        // ISSUE #237: Create or update D4 reporting record
+        // This ties to Flow 128 intent (coordinator visibility)
+        d4ReportingRecord = await SprintReportingRecord.findOneAndUpdate(
+          {
+            sprintId,
+            groupId,
+          },
+          {
+            $set: {
+              coordinatorId,
+              totalMembers: contributionSummary.contributions.length,
+              groupTotalStoryPoints: contributionSummary.groupTotalStoryPoints || 0,
+              calculationStrategy: contributionSummary.strategyUsed || 'fixed',
+              calculatedAt: new Date(),
+              averageRatio: contributionSummary.averageRatio || 0,
+              maxRatio: contributionSummary.maxRatio || 0,
+              minRatio: contributionSummary.minRatio || 0,
+              correlationId, // ISSUE #237: Link to notification service events
+            },
+          },
+          {
+            upsert: true,
+            new: true,
+            runValidators: true,
+          }
+        );
+
+        persistenceLog.steps[3].completedAt = new Date();
+        persistenceLog.steps[3].d4RecordId = d4ReportingRecord._id;
+        persistenceLog.steps[3].status = 'written';
+      } catch (err) {
+        // ISSUE #237: D4 write failures are logged but do not block D6 persistence
+        // This follows operational guideline: main flow (D6) succeeds even if reporting (D4) fails
+        console.error(
+          `[PersistenceService] D4 write failed (non-fatal): ${err.message} [correlationId: ${correlationId}]`
+        );
+        persistenceLog.steps[3].status = 'warning';
+        persistenceLog.steps[3].warning = `D4 write failed: ${err.message}`;
+        persistenceLog.errors.push({
+          step: 4,
+          message: err.message,
+          isFatal: false,
+        });
+      }
+    } else {
+      persistenceLog.steps[3].completedAt = new Date();
+      persistenceLog.steps[3].status = 'skipped';
+      persistenceLog.steps[3].reason = 'persistToD4=false';
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 5: UPDATE SPRINT RECORD WITH RECALCULATION METADATA
+    // ISSUE #237: Track when contributions were last calculated/persisted
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.steps.push({
+      step: 5,
+      name: 'update_sprint_metadata',
+      startedAt: new Date(),
+    });
+
+    try {
+      const updatedSprintRecord = await SprintRecord.findOneAndUpdate(
+        {
+          sprintId,
+          groupId,
+        },
+        {
+          $set: {
+            // ISSUE #237: Track recalculation timestamp for audit trail
+            recalculatedAt: new Date(),
+            lastRecalculatedBy: coordinatorId,
+            totalContributionRecords: contributionSummary.contributions.length,
+            groupTotalStoryPoints: contributionSummary.groupTotalStoryPoints || 0,
+            calculationStrategy: contributionSummary.strategyUsed || 'fixed',
+          },
+        },
+        {
+          upsert: true,
+          new: true,
+          runValidators: true,
+        }
+      );
+
+      persistenceLog.steps[4].completedAt = new Date();
+      persistenceLog.steps[4].sprintRecordId = updatedSprintRecord.sprintRecordId;
+    } catch (err) {
+      console.error(
+        `[PersistenceService] Sprint metadata update failed: ${err.message} [correlationId: ${correlationId}]`
+      );
+      persistenceLog.steps[4].status = 'warning';
+      persistenceLog.steps[4].warning = err.message;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 6: CREATE AUDIT LOG ENTRY
+    // ISSUE #237: Track all persistence operations for compliance
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.steps.push({
+      step: 6,
+      name: 'audit_logging',
+      startedAt: new Date(),
+    });
+
+    try {
+      await createAuditLog({
+        action: 'SPRINT_CONTRIBUTIONS_PERSISTED',
+        actorId: coordinatorId,
+        targetId: sprintId,
+        groupId,
+        payload: {
+          sprintId,
+          groupId,
+          correlationId,
+          recordsPersistedCount: upsertResults.length,
+          d4RecordCreated: !!d4ReportingRecord,
+          totalStoryPoints: contributionSummary.groupTotalStoryPoints || 0,
+          strategy: contributionSummary.strategyUsed || 'fixed',
+        },
+      });
+
+      persistenceLog.steps[5].completedAt = new Date();
+      persistenceLog.steps[5].status = 'success';
+    } catch (auditErr) {
+      // ISSUE #237: Non-fatal audit logging failure
+      console.error(
+        `[PersistenceService] Audit log creation failed (non-fatal): ${auditErr.message} [correlationId: ${correlationId}]`
+      );
+      persistenceLog.steps[5].status = 'warning';
+      persistenceLog.steps[5].warning = auditErr.message;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // STEP 7: DISPATCH NOTIFICATION EVENTS (NON-BLOCKING)
+    // ISSUE #237: Emit events for Notification Service (#238)
+    // Uses correlationId to link notifications with persistence operation
+    // ─────────────────────────────────────────────────────────────────────────
+    // Note: Notifications dispatched asynchronously via setImmediate (non-blocking)
+    if (process.env.ENABLE_NOTIFICATIONS !== 'false') {
+      setImmediate(() => {
+        dispatchNotificationEvent(
+          {
+            type: 'sprint_contributions_persisted',
+            correlationId,
+            groupId,
+            sprintId,
+            coordinatorId,
+            recordsCount: upsertResults.length,
+            persistedAt: new Date(),
+            summaryStats: {
+              totalStoryPoints: contributionSummary.groupTotalStoryPoints || 0,
+              averageRatio: contributionSummary.averageRatio || 0,
+              strategyUsed: contributionSummary.strategyUsed || 'fixed',
+            },
+          },
+          coordinatorId
+        ).catch((err) => {
+          console.warn(
+            `[PersistenceService] Notification dispatch failed (non-fatal): ${err.message} [correlationId: ${correlationId}]`
+          );
+        });
+      });
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RETURN SUCCESS RESPONSE WITH AUDIT TRAIL
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.completedAt = new Date();
+    persistenceLog.durationMs = persistenceLog.completedAt - persistenceLog.startedAt;
+
+    return {
+      success: true,
+      correlationId,
+      sprintId,
+      groupId,
+      recordsPersistedCount: upsertResults.length,
+      d4RecordCreated: !!d4ReportingRecord,
+      persistedAt: new Date(),
+      durationMs: persistenceLog.durationMs,
+      auditLog: persistenceLog,
+      // ISSUE #237: Return persisted records for client confirmation
+      persistedRecords: upsertResults,
+    };
+  } catch (err) {
+    // ─────────────────────────────────────────────────────────────────────────
+    // ERROR HANDLING AND LOGGING
+    // ISSUE #237: All errors logged with correlationId for debugging
+    // ─────────────────────────────────────────────────────────────────────────
+    persistenceLog.completedAt = new Date();
+    persistenceLog.durationMs = persistenceLog.completedAt - persistenceLog.startedAt;
+    persistenceLog.failed = true;
+
+    if (err instanceof PersistenceServiceError) {
+      persistenceLog.errors.push({
+        name: 'PersistenceServiceError',
+        code: err.code,
+        status: err.status,
+        message: err.message,
+      });
+
+      console.error(
+        `[PersistenceService] Operation failed [${err.code}]: ${err.message} [correlationId: ${correlationId}]`,
+        persistenceLog
+      );
+
+      throw err;
+    }
+
+    // ISSUE #237: Wrap unexpected errors in PersistenceServiceError
+    persistenceLog.errors.push({
+      name: err.name || 'UnexpectedError',
+      message: err.message,
+    });
+
+    console.error(
+      `[PersistenceService] Unexpected error: ${err.message} [correlationId: ${correlationId}]`,
+      persistenceLog
+    );
+
+    throw new PersistenceServiceError(
+      500,
+      'UNEXPECTED_ERROR',
+      `Persistence operation failed: ${err.message}`
+    );
+  }
+}
+
+/**
+ * ISSUE #237: Validate idempotent key for duplicate prevention
+ *
+ * Checks if a D6 record already exists for the given (sprintId, studentId, groupId) tuple.
+ * Used before upsert to determine if record is new or updated.
+ *
+ * @returns {boolean} True if record exists
+ */
+async function recordExists(sprintId, studentId, groupId) {
+  try {
+    const record = await ContributionRecord.findOne({
+      sprintId,
+      studentId,
+      groupId,
+    });
+    return !!record;
+  } catch (err) {
+    console.error('[PersistenceService] Record existence check failed:', err.message);
+    return false;
+  }
+}
+
+module.exports = {
+  persistSprintContributions,
+  recordExists,
+  PersistenceServiceError,
+};

--- a/backend/src/utils/cryptoUtils.js
+++ b/backend/src/utils/cryptoUtils.js
@@ -12,13 +12,21 @@ const crypto = require('crypto');
  */
 
 const ALGORITHM = 'aes-256-gcm';
-const IV_LENGTH = 16;
-const AUTH_TAG_LENGTH = 16;
+const IV_LENGTH = 12;
+const KEY_VERSION = 'v1';
 
-// Fallback key for development only. In production, this must be in process.env.ENCRYPTION_KEY
-const KEY = process.env.ENCRYPTION_KEY 
-  ? Buffer.from(process.env.ENCRYPTION_KEY, 'hex') 
-  : Buffer.from('8f1e6f7c9a2b5d4e3f1a2c3d4e5f607182930415263748596071829304152637', 'hex');
+function getKey() {
+  const keyHex = process.env.ENCRYPTION_KEY;
+  if (!keyHex) {
+    throw new Error('ENCRYPTION_KEY is required. Load it from environment or a secure vault provider.');
+  }
+
+  const key = Buffer.from(keyHex, 'hex');
+  if (key.length !== 32) {
+    throw new Error('ENCRYPTION_KEY must be 32 bytes in hex format for AES-256-GCM.');
+  }
+  return key;
+}
 
 /**
  * Encrypts a string.
@@ -26,16 +34,17 @@ const KEY = process.env.ENCRYPTION_KEY
  */
 function encrypt(text) {
   if (!text) return null;
-  
+
+  const key = getKey();
   const iv = crypto.randomBytes(IV_LENGTH);
-  const cipher = crypto.createCipheriv(ALGORITHM, KEY, iv);
-  
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
   let encrypted = cipher.update(text, 'utf8', 'hex');
   encrypted += cipher.final('hex');
-  
+
   const authTag = cipher.getAuthTag().toString('hex');
-  
-  return `${iv.toString('hex')}:${authTag}:${encrypted}`;
+
+  return `${KEY_VERSION}:${iv.toString('hex')}:${authTag}:${encrypted}`;
 }
 
 /**
@@ -44,23 +53,31 @@ function encrypt(text) {
  */
 function decrypt(ciphertext) {
   if (!ciphertext) return null;
-  
+
   try {
-    const [ivHex, authTagHex, encryptedHex] = ciphertext.split(':');
+    const key = getKey();
+    const parts = ciphertext.split(':');
+    const [version, ivHex, authTagHex, encryptedHex] =
+      parts.length === 4 ? parts : ['legacy', ...parts];
+
     if (!ivHex || !authTagHex || !encryptedHex) {
       // If it doesn't match our format, it might be legacy plain text (for migration safety)
       return ciphertext;
     }
-    
+
+    if (version !== KEY_VERSION && version !== 'legacy') {
+      throw new Error(`Unsupported key version: ${version}`);
+    }
+
     const iv = Buffer.from(ivHex, 'hex');
     const authTag = Buffer.from(authTagHex, 'hex');
-    const decipher = crypto.createDecipheriv(ALGORITHM, KEY, iv);
-    
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+
     decipher.setAuthTag(authTag);
-    
+
     let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
     decrypted += decipher.final('utf8');
-    
+
     return decrypted;
   } catch (err) {
     console.error('[cryptoUtils] Decryption failed:', err.message);

--- a/backend/tests/github-sync.test.js
+++ b/backend/tests/github-sync.test.js
@@ -28,7 +28,7 @@ const axios = require('axios');
 
 const mongoose = require('mongoose');
 const request = require('supertest');
-const { MongoMemoryServer } = require('mongodb-memory-server');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
 
 const { generateAccessToken } = require('../src/utils/jwt');
 const Group = require('../src/models/Group');
@@ -135,7 +135,9 @@ async function waitForJobToSettle(jobId, maxMs = 5000) {
 
 describe('Process 7.2 — GitHub PR Sync', () => {
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
+    mongod = await MongoMemoryReplSet.create({
+      replSet: { count: 1 },
+    });
     await mongoose.connect(mongod.getUri());
     app = require('../src/index');
   }, 60000);
@@ -528,7 +530,7 @@ describe('Process 7.2 — GitHub PR Sync', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.job_id).toBe(job.jobId);
-      expect(res.body.status).toBe('COMPLETED');
+      expect(res.body.status).toBe('completed');
       expect(res.body.validationRecords).toHaveLength(1);
       expect(res.body.validationRecords[0].mergeStatus).toBe('MERGED');
     });
@@ -564,7 +566,7 @@ describe('Process 7.2 — GitHub PR Sync', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.job_id).toBe(newer.jobId);
-      expect(res.body.status).toBe('FAILED');
+      expect(res.body.status).toBe('failed');
     });
   });
 

--- a/backend/tests/jira-sync.test.js
+++ b/backend/tests/jira-sync.test.js
@@ -8,13 +8,14 @@ const axios = require('axios');
 
 const mongoose = require('mongoose');
 const request = require('supertest');
-const { MongoMemoryServer } = require('mongodb-memory-server');
+const { MongoMemoryReplSet } = require('mongodb-memory-server');
 
 const { generateAccessToken } = require('../src/utils/jwt');
 const { encrypt } = require('../src/utils/cryptoUtils');
 const Group = require('../src/models/Group');
 const SprintConfig = require('../src/models/SprintConfig');
 const SprintIssue = require('../src/models/SprintIssue');
+const SprintRecord = require('../src/models/SprintRecord');
 const JiraSyncJob = require('../src/models/JiraSyncJob');
 const SyncErrorLog = require('../src/models/SyncErrorLog');
 const { enqueueEligibleSyncs, stopJiraSyncScheduler } = require('../src/services/jiraSyncScheduler');
@@ -55,6 +56,12 @@ async function seedJiraGroup(overrides = {}) {
 }
 
 async function seedSprintConfig(groupId, sprintId, overrides = {}) {
+  await SprintRecord.create({
+    groupId,
+    sprintId,
+    status: overrides.sprintRecordStatus || 'in_progress',
+  });
+
   return SprintConfig.create({
     groupId,
     sprintId,
@@ -81,7 +88,9 @@ async function waitForJobToSettle(jobId, maxMs = 6000) {
 
 describe('Process 7.1 - JIRA Sprint Sync', () => {
   beforeAll(async () => {
-    mongod = await MongoMemoryServer.create();
+    mongod = await MongoMemoryReplSet.create({
+      replSet: { count: 1 },
+    });
     await mongoose.connect(mongod.getUri());
     app = require('../src/index');
   }, 60000);

--- a/docs/md_files/PROCESS_7_SECURITY_INTEGRATION_NOTES.md
+++ b/docs/md_files/PROCESS_7_SECURITY_INTEGRATION_NOTES.md
@@ -1,0 +1,33 @@
+# Process 7.1 / 7.2 Security Integration Notes
+
+## Minimum GitHub Permissions (Least Privilege)
+
+The integration validates and requires the following minimum scopes:
+
+- `repo:status`
+- `read:org`
+
+Any token that does not include these scopes is rejected during setup.
+
+## Secret Storage Policy
+
+- GitHub PAT and JIRA API tokens are encrypted with AES-256-GCM in the application layer before persistence.
+- Plain-text tokens are never stored in the database.
+- The encryption key is loaded from `ENCRYPTION_KEY` environment variable (recommended source: Vault/Secrets Manager).
+
+## Log Redaction Policy
+
+Central log redaction masks:
+
+- `ghp_...` token patterns
+- `Authorization: Bearer ...`
+- `Authorization: Basic ...`
+
+Redacted values are persisted as `[REDACTED]`.
+
+## Security Audit Events
+
+Unauthorized provider access responses (`401` / `403`) and credential rotations are recorded as:
+
+- `SECURITY_AUDIT`
+- `CREDENTIAL_ROTATED`


### PR DESCRIPTION
- Implemented sprintContributionPersistence.js as the main Process 7.5 persistence orchestrator.
- Added D6 upsert logic for per-student SprintContribution records using idempotent keys.

- Added SprintContributionRecord.js model for canonical D6 contribution snapshots.

- Added SprintReportingRecord.js model for optional D4 coordinator/reporting records.

- Added d4ToD6Reconciliation.js service for D4→D6 sync consistency and duplicate prevention.

- Updated contributionRatios.js to integrate Process 7.4 ratio calculation with Process 7.5 persistence flow.

- Added finalized/locked sprint protection returning 409 on overwrite attempts.

- Added createdAt / updatedAt audit fields on all write operations.

- Added non-fatal D4 write handling so reporting failures do not block canonical D6 persistence.

- Added notification-ready correlation/event support for downstream Issue #238 integration.

- Added migration 011_create_sprint_persistence_models.js with optimized indexes.

- Preserved modular backend architecture and transaction-safe atomic writes.

Acceptance Criteria Covered

- D6 records persisted successfully
- D4 records created when enabled
- D4→D6 sync avoids duplicates
- All writes include updatedAt

Closes #237