### PR TITLE
Implement JIRA sprint sync job and canonical sprint issue persistence

### DIFF
--- a/backend/src/controllers/githubSync.js
+++ b/backend/src/controllers/githubSync.js
@@ -11,7 +11,7 @@
  *   - Returns 409 Conflict if a sync is already IN_PROGRESS for the same key
  *
  * Error mapping (see spec §3):
- *   202  — job_id + status: "PENDING"    → Job accepted and worker dispatched
+ *   202  — jobId + status: "queued"      → Job accepted and worker dispatched
  *   409  — SYNC_ALREADY_RUNNING          → Lock already held
  *   400  — INVALID_GITHUB_CREDENTIALS    → D2 missing/invalid PAT or repo binding
  *   404  — JIRA_DATA_MISSING             → D6 empty for this sprint (Process 7.1 hasn't run)
@@ -19,7 +19,7 @@
  *   504  — GATEWAY_TIMEOUT              → GitHub API timed-out after all retries (worker-side)
  *
  * Auth:
- *   Requires coordinator or advisor role (group members cannot self-trigger a mass sync)
+ *   Requires coordinator/admin role (group members cannot self-trigger a mass sync)
  *
  * DFD flows:
  *   f29 — Coordinator → 7.2 (trigger sync)
@@ -32,6 +32,14 @@ const Group = require('../models/Group');
 const SprintRecord = require('../models/SprintRecord');
 const { githubSyncWorker, GitHubSyncError } = require('../services/githubSyncService');
 const { createAuditLog } = require('../services/auditService');
+
+const toPublicStatus = (status) => {
+  if (status === 'PENDING') return 'queued';
+  if (status === 'IN_PROGRESS') return 'running';
+  if (status === 'COMPLETED') return 'completed';
+  if (status === 'FAILED') return 'failed';
+  return 'queued';
+};
 
 /**
  * POST /groups/:groupId/sprints/:sprintId/github-sync
@@ -82,7 +90,7 @@ const triggerGitHubSync = async (req, res) => {
       return res.status(409).json({
         error: 'SYNC_ALREADY_RUNNING',
         message: `A GitHub sync is already in progress for group ${groupId} / sprint ${sprintId}`,
-        job_id: existingLock.jobId,
+        jobId: existingLock.jobId,
       });
     }
 
@@ -106,7 +114,7 @@ const triggerGitHubSync = async (req, res) => {
         return res.status(409).json({
           error: 'SYNC_ALREADY_RUNNING',
           message: `A GitHub sync was just triggered for group ${groupId} / sprint ${sprintId}`,
-          job_id: racingJob?.jobId,
+          jobId: racingJob?.jobId,
         });
       }
       throw err; // rethrow other DB errors
@@ -129,8 +137,9 @@ const triggerGitHubSync = async (req, res) => {
 
     // ── Respond 202 immediately ──────────────────────────────────────────────
     res.status(202).json({
-      job_id: job.jobId,
-      status: 'PENDING',
+      jobId: job.jobId,
+      status: 'queued',
+      source: 'github',
       message: 'GitHub sync job accepted. PR validation will run asynchronously.',
     });
 
@@ -195,8 +204,9 @@ const getSyncJobStatus = async (req, res) => {
     }
 
     return res.status(200).json({
-      job_id: job.jobId,
-      status: job.status,
+      jobId: job.jobId,
+      status: toPublicStatus(job.status),
+      source: 'github',
       mappedHttpStatus: mapJobToHttpStatus(job.status, job.errorCode),
       groupId: job.groupId,
       sprintId: job.sprintId,
@@ -240,8 +250,9 @@ const getLatestSyncJob = async (req, res) => {
     }
 
     return res.status(200).json({
-      job_id: job.jobId,
-      status: job.status,
+      jobId: job.jobId,
+      status: toPublicStatus(job.status),
+      source: 'github',
       mappedHttpStatus: mapJobToHttpStatus(job.status, job.errorCode),
       groupId: job.groupId,
       sprintId: job.sprintId,
@@ -261,4 +272,50 @@ const getLatestSyncJob = async (req, res) => {
   }
 };
 
-module.exports = { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob };
+const getSyncJobLogs = async (req, res) => {
+  const { groupId, sprintId, jobId } = req.params;
+  try {
+    const job = await GitHubSyncJob.findOne({ jobId, groupId, sprintId }).lean();
+    if (!job) {
+      return res.status(404).json({
+        error: 'JOB_NOT_FOUND',
+        message: `Sync job ${jobId} not found for group ${groupId} / sprint ${sprintId}`,
+      });
+    }
+
+    const logs = [
+      { level: 'info', at: job.createdAt, message: 'GitHub sync job created.' },
+      job.startedAt ? { level: 'info', at: job.startedAt, message: 'GitHub sync worker started.' } : null,
+      Array.isArray(job.validationRecords)
+        ? {
+            level: 'info',
+            at: job.completedAt || job.updatedAt || job.createdAt,
+            message: `Validation records processed: ${job.validationRecords.length}`,
+          }
+        : null,
+      job.errorMessage ? { level: 'error', at: job.completedAt || job.updatedAt, message: job.errorMessage } : null,
+      job.completedAt
+        ? {
+            level: 'info',
+            at: job.completedAt,
+            message: `GitHub sync finished with status ${toPublicStatus(job.status)}.`,
+          }
+        : null,
+    ].filter(Boolean);
+
+    return res.status(200).json({
+      jobId: job.jobId,
+      source: 'github',
+      status: toPublicStatus(job.status),
+      logs,
+    });
+  } catch (err) {
+    console.error('[getSyncJobLogs] Error:', err);
+    return res.status(500).json({
+      error: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    });
+  }
+};
+
+module.exports = { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob, getSyncJobLogs };

--- a/backend/src/controllers/githubSync.js
+++ b/backend/src/controllers/githubSync.js
@@ -141,6 +141,7 @@ const triggerGitHubSync = async (req, res) => {
       status: 'queued',
       source: 'github',
       message: 'GitHub sync job accepted. PR validation will run asynchronously.',
+      createdAt: job.createdAt,
     });
 
     // ── Fire async worker (detached — does NOT await response) ──────────────

--- a/backend/src/controllers/githubSync.js
+++ b/backend/src/controllers/githubSync.js
@@ -71,11 +71,11 @@ const triggerGitHubSync = async (req, res) => {
       });
     }
 
-    // ── Concurrency lock: check for existing IN_PROGRESS job ────────────────
+    // ── Concurrency lock: check for existing active job ────────────────────
     const existingLock = await GitHubSyncJob.findOne({
       groupId,
       sprintId,
-      status: 'IN_PROGRESS',
+      status: { $in: ['PENDING', 'IN_PROGRESS'] },
     }).lean();
 
     if (existingLock) {
@@ -87,12 +87,30 @@ const triggerGitHubSync = async (req, res) => {
     }
 
     // ── Acquire lock: create PENDING job ────────────────────────────────────
-    const job = await GitHubSyncJob.create({
-      groupId,
-      sprintId,
-      status: 'PENDING',
-      triggeredBy: actorId,
-    });
+    let job;
+    try {
+      job = await GitHubSyncJob.create({
+        groupId,
+        sprintId,
+        status: 'PENDING',
+        triggeredBy: actorId,
+      });
+    } catch (err) {
+      if (err.code === 11000) {
+        // Race condition: another request created the job between our findOne and create
+        const racingJob = await GitHubSyncJob.findOne({
+          groupId,
+          sprintId,
+          status: { $in: ['PENDING', 'IN_PROGRESS'] },
+        }).lean();
+        return res.status(409).json({
+          error: 'SYNC_ALREADY_RUNNING',
+          message: `A GitHub sync was just triggered for group ${groupId} / sprint ${sprintId}`,
+          job_id: racingJob?.jobId,
+        });
+      }
+      throw err; // rethrow other DB errors
+    }
 
     // ── Audit: sync initiated (non-fatal) ───────────────────────────────────
     try {
@@ -145,6 +163,20 @@ const triggerGitHubSync = async (req, res) => {
 };
 
 /**
+ * mapJobToHttpStatus — helper to derive a frontend-friendly HTTP status
+ */
+const mapJobToHttpStatus = (status, errorCode) => {
+  if (status === 'COMPLETED') return 200;
+  if (status === 'PENDING' || status === 'IN_PROGRESS') return 202;
+  if (status === 'FAILED') {
+    if (errorCode === 'UPSTREAM_PROVIDER_ERROR') return 502;
+    if (errorCode === 'GATEWAY_TIMEOUT') return 504;
+    return 500;
+  }
+  return 200;
+};
+
+/**
  * GET /groups/:groupId/sprints/:sprintId/github-sync/:jobId
  *
  * Returns the current status and validation records for a specific sync job.
@@ -165,6 +197,7 @@ const getSyncJobStatus = async (req, res) => {
     return res.status(200).json({
       job_id: job.jobId,
       status: job.status,
+      mappedHttpStatus: mapJobToHttpStatus(job.status, job.errorCode),
       groupId: job.groupId,
       sprintId: job.sprintId,
       startedAt: job.startedAt,
@@ -209,6 +242,7 @@ const getLatestSyncJob = async (req, res) => {
     return res.status(200).json({
       job_id: job.jobId,
       status: job.status,
+      mappedHttpStatus: mapJobToHttpStatus(job.status, job.errorCode),
       groupId: job.groupId,
       sprintId: job.sprintId,
       startedAt: job.startedAt,

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -530,6 +530,37 @@ const getSprintContributionSummary = async (req, res) => {
   }
 };
 
+const getGroupCommitteeStatus = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+
+    const group = await Group.findOne({ groupId }).lean();
+    if (!group) {
+      return res.status(404).json({
+        code: 'GROUP_NOT_FOUND',
+        message: 'Group not found',
+      });
+    }
+
+    const committee = group.committeeId
+      ? await Committee.findOne({ committeeId: group.committeeId }).lean()
+      : null;
+
+    return res.status(200).json({
+      groupId,
+      committeeId: group.committeeId || null,
+      committeeStatus: committee?.status || null,
+      publishedAt: committee?.publishedAt || null,
+    });
+  } catch (error) {
+    console.error('getGroupCommitteeStatus error:', error);
+    return res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'An unexpected error occurred while retrieving committee status.',
+    });
+  }
+};
+
 /**
  * Formats a Group document into the API response shape.
  * @param {object} extras - Optional advisor enrichment from getGroup (advisorName, advisorRequest)
@@ -1693,4 +1724,5 @@ module.exports = {
   transferAdvisor,
   createAdvisorRequest,
   getSprintContributionSummary,
+  getGroupCommitteeStatus,
 };

--- a/backend/src/controllers/jiraSync.js
+++ b/backend/src/controllers/jiraSync.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const JiraSyncJob = require('../models/JiraSyncJob');
+const { jiraSyncWorker, JiraSyncError, getJiraConfig, getPublishedSprintConfig } = require('../services/jiraSyncService');
+const { createAuditLog } = require('../services/auditService');
+
+const triggerJiraSync = async (req, res) => {
+  const { groupId, sprintId } = req.params;
+  const actorId = req.user?.userId || 'system';
+
+  try {
+    await getJiraConfig(groupId);
+    await getPublishedSprintConfig(groupId, sprintId);
+
+    const existingLock = await JiraSyncJob.findOne({
+      groupId,
+      sprintId,
+      status: { $in: ['PENDING', 'IN_PROGRESS'] },
+    }).lean();
+
+    if (existingLock) {
+      return res.status(409).json({
+        error: 'SYNC_ALREADY_RUNNING',
+        message: `A JIRA sync is already in progress for group ${groupId} / sprint ${sprintId}`,
+        jobId: existingLock.jobId,
+        source: 'jira',
+      });
+    }
+
+    let job;
+    try {
+      job = await JiraSyncJob.create({
+        groupId,
+        sprintId,
+        status: 'PENDING',
+        triggeredBy: actorId,
+      });
+    } catch (err) {
+      if (err.code === 11000) {
+        const racingJob = await JiraSyncJob.findOne({
+          groupId,
+          sprintId,
+          status: { $in: ['PENDING', 'IN_PROGRESS'] },
+        }).lean();
+
+        return res.status(409).json({
+          error: 'SYNC_ALREADY_RUNNING',
+          message: `A JIRA sync was just triggered for group ${groupId} / sprint ${sprintId}`,
+          jobId: racingJob?.jobId,
+          source: 'jira',
+        });
+      }
+
+      throw err;
+    }
+
+    try {
+      await createAuditLog({
+        action: 'JIRA_SYNC_INITIATED',
+        actorId,
+        groupId,
+        targetId: job.jobId,
+        payload: {
+          sprintId,
+          jobId: job.jobId,
+          source: 'jira',
+        },
+        ipAddress: req.ip,
+        userAgent: req.headers['user-agent'],
+      });
+    } catch (auditErr) {
+      console.error('[triggerJiraSync] Audit log failed (non-fatal):', auditErr.message);
+    }
+
+    res.status(202).json({
+      jobId: job.jobId,
+      status: 'queued',
+      source: 'jira',
+      message: 'JIRA sync job accepted. Sprint issues will be fetched asynchronously.',
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+    });
+
+    setImmediate(() => {
+      jiraSyncWorker(groupId, sprintId, job.jobId).catch((err) => {
+        console.error('[triggerJiraSync] Unhandled worker error:', err.message);
+      });
+    });
+  } catch (err) {
+    if (err instanceof JiraSyncError) {
+      return res.status(err.status).json({
+        error: err.code,
+        message: err.message,
+      });
+    }
+
+    console.error('[triggerJiraSync] Unexpected error:', err);
+    return res.status(500).json({
+      error: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    });
+  }
+};
+
+module.exports = { triggerJiraSync };

--- a/backend/src/controllers/jiraSync.js
+++ b/backend/src/controllers/jiraSync.js
@@ -4,6 +4,50 @@ const JiraSyncJob = require('../models/JiraSyncJob');
 const { jiraSyncWorker, JiraSyncError, getJiraConfig, getPublishedSprintConfig } = require('../services/jiraSyncService');
 const { createAuditLog } = require('../services/auditService');
 
+const toPublicStatus = (status) => {
+  if (status === 'PENDING') return 'queued';
+  if (status === 'IN_PROGRESS') return 'running';
+  if (status === 'COMPLETED') return 'completed';
+  if (status === 'FAILED') return 'failed';
+  return 'queued';
+};
+
+const toHttpStatus = (status, errorCode = null) => {
+  if (status === 'COMPLETED') return 200;
+  if (status === 'FAILED') {
+    if (errorCode === 'GATEWAY_TIMEOUT') return 504;
+    if (errorCode === 'UPSTREAM_PROVIDER_ERROR') return 502;
+    return 500;
+  }
+  return 202;
+};
+
+const mapJobResponse = (job) => ({
+  jobId: job.jobId,
+  job_id: job.jobId,
+  status: toPublicStatus(job.status),
+  source: 'jira',
+  message: job.errorMessage || null,
+  groupId: job.groupId,
+  group_id: job.groupId,
+  sprintId: job.sprintId,
+  sprint_id: job.sprintId,
+  startedAt: job.startedAt,
+  started_at: job.startedAt,
+  completedAt: job.completedAt,
+  completed_at: job.completedAt,
+  errorCode: job.errorCode,
+  error_code: job.errorCode,
+  errorMessage: job.errorMessage,
+  error_message: job.errorMessage,
+  createdAt: job.createdAt,
+  created_at: job.createdAt,
+  updatedAt: job.updatedAt,
+  updated_at: job.updatedAt,
+  mappedHttpStatus: toHttpStatus(job.status, job.errorCode),
+  mapped_http_status: toHttpStatus(job.status, job.errorCode),
+});
+
 const triggerJiraSync = async (req, res) => {
   const { groupId, sprintId } = req.params;
   const actorId = req.user?.userId || 'system';
@@ -102,4 +146,64 @@ const triggerJiraSync = async (req, res) => {
   }
 };
 
-module.exports = { triggerJiraSync };
+const getJiraSyncStatus = async (req, res) => {
+  const { groupId, sprintId, jobId } = req.params;
+
+  try {
+    const query = jobId ? { groupId, sprintId, jobId } : { groupId, sprintId };
+    const options = jobId ? {} : { sort: { createdAt: -1 } };
+    const job = await JiraSyncJob.findOne(query, null, options).lean();
+
+    if (!job) {
+      return res.status(404).json({
+        error: 'JOB_NOT_FOUND',
+        message: `No JIRA sync job found for ${groupId}/${sprintId}.`,
+      });
+    }
+
+    return res.status(toHttpStatus(job.status, job.errorCode)).json(mapJobResponse(job));
+  } catch (err) {
+    console.error('[getJiraSyncStatus] Unexpected error:', err);
+    return res.status(500).json({
+      error: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    });
+  }
+};
+
+const getJiraSyncLogs = async (req, res) => {
+  const { groupId, sprintId, jobId } = req.params;
+
+  try {
+    const job = await JiraSyncJob.findOne({ groupId, sprintId, jobId }).lean();
+    if (!job) {
+      return res.status(404).json({
+        error: 'JOB_NOT_FOUND',
+        message: `No JIRA sync job found for ${groupId}/${sprintId}/${jobId}.`,
+      });
+    }
+
+    const logs = [
+      { level: 'info', at: job.createdAt, message: 'JIRA sync job created.' },
+      job.startedAt ? { level: 'info', at: job.startedAt, message: 'JIRA sync worker started.' } : null,
+      job.errorMessage ? { level: 'error', at: job.completedAt || job.updatedAt, message: job.errorMessage } : null,
+      job.completedAt ? { level: 'info', at: job.completedAt, message: `JIRA sync finished with status ${toPublicStatus(job.status)}.` } : null,
+    ].filter(Boolean);
+
+    return res.status(200).json({
+      jobId: job.jobId,
+      job_id: job.jobId,
+      source: 'jira',
+      status: toPublicStatus(job.status),
+      logs,
+    });
+  } catch (err) {
+    console.error('[getJiraSyncLogs] Unexpected error:', err);
+    return res.status(500).json({
+      error: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    });
+  }
+};
+
+module.exports = { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs };

--- a/backend/src/controllers/sprintTracking.js
+++ b/backend/src/controllers/sprintTracking.js
@@ -241,16 +241,13 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
         storyPointsCompleted: 0,
         issuesResolved: 0,
       };
-      const primaryIssueKey =
-        aggregate.issueKeys.length === 1 ? aggregate.issueKeys[0] : aggregate.issueKeys[0] || null;
-
       const existing = existingByStudent.get(studentId);
       if (!existing) {
         await ContributionRecord.create({
           groupId,
           sprintId,
           studentId,
-          jiraIssueKey: primaryIssueKey,
+          jiraIssueKeys: aggregate.issueKeys,
           storyPointsAssigned: aggregate.storyPointsAssigned,
           storyPointsCompleted: aggregate.storyPointsCompleted,
           issuesResolved: aggregate.issuesResolved,
@@ -263,7 +260,7 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
         { contributionRecordId: existing.contributionRecordId },
         {
           $set: {
-            jiraIssueKey: primaryIssueKey,
+            jiraIssueKeys: aggregate.issueKeys,
             storyPointsAssigned: aggregate.storyPointsAssigned,
             storyPointsCompleted: aggregate.storyPointsCompleted,
             issuesResolved: aggregate.issuesResolved,
@@ -472,16 +469,32 @@ const recalculateContributions = async (req, res) => {
     const usersById = new Map(users.map((user) => [user.userId, user]));
 
     const projectedRows = allRecords.map((record) => {
-      const completedFromMerge = mergedIssueKeys.has(record.jiraIssueKey)
-        ? Number(record.storyPointsAssigned || record.storyPointsCompleted || 0)
-        : 0;
+      const keys = record.jiraIssueKeys || [];
+      const mergedKeys = keys.filter((key) => mergedIssueKeys.has(key));
+      const unmergedKeys = keys.filter((key) => !mergedIssueKeys.has(key));
+
+      let completedFromMerge = 0;
+      if (keys.length > 0) {
+        // Heuristic: proportional credit if per-issue SP isn't stored
+        completedFromMerge =
+          (mergedKeys.length / keys.length) *
+          Number(record.storyPointsAssigned || record.storyPointsCompleted || 0);
+      }
+
       const warnings = [];
-      if (!record.jiraIssueKey) warnings.push('No JIRA issue mapping found for student record.');
-      if (record.jiraIssueKey && validationRecords.length > 0 && !mergedIssueKeys.has(record.jiraIssueKey)) {
-        warnings.push(`Mapped issue ${record.jiraIssueKey} is not merged in latest GitHub sync.`);
+      if (keys.length === 0) {
+        warnings.push('No JIRA issue mapping found for student record.');
+      }
+      if (validationRecords.length > 0) {
+        unmergedKeys.forEach((key) => {
+          warnings.push(`Mapped issue ${key} is not merged in latest GitHub sync.`);
+        });
       }
       if (validationRecords.length === 0) {
-        warnings.push('No completed GitHub sync validation found; using zero completed SP from merge mapping.');
+        warnings.push(
+          'No completed GitHub sync validation found; using zero completed SP from merge mapping.'
+        );
+        completedFromMerge = 0;
       }
       return {
         record,

--- a/backend/src/controllers/sprintTracking.js
+++ b/backend/src/controllers/sprintTracking.js
@@ -31,18 +31,28 @@ const toHttpStatus = (status, errorCode = null) => {
 
 const mapJobResponse = (job) => ({
   jobId: job.jobId,
+  job_id: job.jobId,
   status: toPublicStatus(job.status),
   source: job.source,
   message: job.message,
   groupId: job.groupId,
+  group_id: job.groupId,
   sprintId: job.sprintId,
+  sprint_id: job.sprintId,
   startedAt: job.startedAt,
+  started_at: job.startedAt,
   completedAt: job.completedAt,
+  completed_at: job.completedAt,
   errorCode: job.errorCode,
+  error_code: job.errorCode,
   errorMessage: job.errorMessage,
+  error_message: job.errorMessage,
   createdAt: job.createdAt,
+  created_at: job.createdAt,
   updatedAt: job.updatedAt,
+  updated_at: job.updatedAt,
   mappedHttpStatus: toHttpStatus(job.status, job.errorCode),
+  mapped_http_status: toHttpStatus(job.status, job.errorCode),
 });
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -406,10 +416,12 @@ const triggerJiraSync = async (req, res) => {
 
     res.status(202).json({
       jobId: job.jobId,
+      job_id: job.jobId,
       status: 'queued',
       source: 'jira',
       message: 'JIRA sync job accepted.',
       createdAt: job.createdAt,
+      created_at: job.createdAt,
     });
 
     setImmediate(() => {
@@ -472,6 +484,7 @@ const getJiraSyncLogs = async (req, res) => {
 
     return res.status(200).json({
       jobId: job.jobId,
+      job_id: job.jobId,
       source: 'jira',
       status: toPublicStatus(job.status),
       logs,

--- a/backend/src/controllers/sprintTracking.js
+++ b/backend/src/controllers/sprintTracking.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const mongoose = require('mongoose');
 const axios = require('axios');
 const Group = require('../models/Group');
+const SprintConfig = require('../models/SprintConfig');
 const SprintRecord = require('../models/SprintRecord');
 const ContributionRecord = require('../models/ContributionRecord');
 const SyncJob = require('../models/SyncJob');
@@ -17,9 +19,13 @@ const toPublicStatus = (status) => {
   return 'queued';
 };
 
-const toHttpStatus = (status) => {
+const toHttpStatus = (status, errorCode = null) => {
   if (status === 'COMPLETED') return 200;
-  if (status === 'FAILED') return 500;
+  if (status === 'FAILED') {
+    if (errorCode === 'GATEWAY_TIMEOUT') return 504;
+    if (errorCode === 'UPSTREAM_PROVIDER_ERROR') return 502;
+    return 500;
+  }
   return 202;
 };
 
@@ -36,7 +42,7 @@ const mapJobResponse = (job) => ({
   errorMessage: job.errorMessage,
   createdAt: job.createdAt,
   updatedAt: job.updatedAt,
-  mappedHttpStatus: toHttpStatus(job.status),
+  mappedHttpStatus: toHttpStatus(job.status, job.errorCode),
 });
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -78,6 +84,31 @@ const inferStoryPoints = (issue = {}) => {
   return 0;
 };
 
+const getPublishedSprintConfig = async (groupId, sprintId) => {
+  const config = await SprintConfig.findOne({
+    groupId,
+    sprintId,
+    configurationStatus: 'published',
+    deadline: { $gte: new Date() },
+  }).lean();
+
+  if (!config) {
+    const error = new Error(`No published sprint configuration found for ${groupId}/${sprintId}.`);
+    error.status = 422;
+    error.code = 'SPRINT_CONFIG_NOT_PUBLISHED';
+    throw error;
+  }
+
+  if (!config.externalSprintKey) {
+    const error = new Error(`Published sprint configuration for ${sprintId} is missing externalSprintKey.`);
+    error.status = 422;
+    error.code = 'SPRINT_CONFIG_INCOMPLETE';
+    throw error;
+  }
+
+  return config;
+};
+
 const fetchJiraIssues = async ({ group, sprintKey, sprintId }) => {
   const baseUrl = String(group.jiraUrl || '').replace(/\/$/, '');
   const jiraToken = decrypt(group.jiraToken);
@@ -91,7 +122,6 @@ const fetchJiraIssues = async ({ group, sprintKey, sprintId }) => {
   const jqlCandidates = [
     `project = "${group.projectKey}" AND sprint = "${sprintKey || sprintId}"`,
     `project = "${group.projectKey}" AND sprint = ${sprintKey || sprintId}`,
-    `project = "${group.projectKey}" AND sprint in openSprints()`,
   ];
 
   for (const jql of jqlCandidates) {
@@ -140,9 +170,32 @@ const resolveAssigneeUserId = ({ issue, acceptedMemberIds, usersByEmail }) => {
   return null;
 };
 
+const normalizeWorkerError = (error) => {
+  if (error?.code === 'ECONNABORTED') {
+    return {
+      errorCode: 'GATEWAY_TIMEOUT',
+      errorMessage: 'JIRA API timed out after maximum retry attempts.',
+    };
+  }
+
+  if (error?.response?.status >= 500) {
+    return {
+      errorCode: 'UPSTREAM_PROVIDER_ERROR',
+      errorMessage: error.message || 'JIRA API returned an upstream provider error.',
+    };
+  }
+
+  return {
+    errorCode: error?.code || 'JIRA_SYNC_FAILED',
+    errorMessage: error?.message || 'JIRA sync failed unexpectedly.',
+  };
+};
+
 const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
   const job = await SyncJob.findOne({ jobId });
   if (!job) return;
+
+  const session = await mongoose.startSession();
 
   try {
     job.status = 'IN_PROGRESS';
@@ -161,7 +214,9 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
       });
     }
 
-    const issues = await fetchJiraIssues({ group, sprintKey, sprintId });
+    const sprintConfig = await getPublishedSprintConfig(groupId, sprintId);
+    const effectiveSprintKey = sprintConfig.externalSprintKey || sprintKey || sprintId;
+    const issues = await fetchJiraIssues({ group, sprintKey: effectiveSprintKey, sprintId });
 
     const deliverableRefs = issues.map((issue) => ({
       deliverableId: issue.key,
@@ -169,21 +224,6 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
       type: 'demonstration',
       submittedAt: new Date(issue.fields?.updated || issue.fields?.created || Date.now()),
     }));
-
-    await SprintRecord.findOneAndUpdate(
-      { groupId, sprintId },
-      {
-        $set: {
-          status: 'in_progress',
-          deliverableRefs,
-        },
-        $setOnInsert: {
-          groupId,
-          sprintId,
-        },
-      },
-      { upsert: true, new: true }
-    );
 
     const acceptedMembers = Array.isArray(group.members)
       ? group.members.filter((member) => member.status === 'accepted')
@@ -233,59 +273,91 @@ const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
     const existingRecords = await ContributionRecord.find({ groupId, sprintId }).lean();
     const existingByStudent = new Map(existingRecords.map((record) => [record.studentId, record]));
 
-    // Idempotent write: set absolute values for each accepted member.
-    for (const studentId of acceptedMemberIds) {
-      const aggregate = aggregatedByStudent.get(studentId) || {
-        issueKeys: [],
-        storyPointsAssigned: 0,
-        storyPointsCompleted: 0,
-        issuesResolved: 0,
-      };
-      const existing = existingByStudent.get(studentId);
-      if (!existing) {
-        await ContributionRecord.create({
-          groupId,
-          sprintId,
-          studentId,
-          jiraIssueKeys: aggregate.issueKeys,
-          storyPointsAssigned: aggregate.storyPointsAssigned,
-          storyPointsCompleted: aggregate.storyPointsCompleted,
-          issuesResolved: aggregate.issuesResolved,
-          lastUpdatedAt: new Date(),
-        });
-        continue;
-      }
-
-      await ContributionRecord.updateOne(
-        { contributionRecordId: existing.contributionRecordId },
+    await session.withTransaction(async () => {
+      await SprintRecord.findOneAndUpdate(
+        { groupId, sprintId },
         {
           $set: {
-            jiraIssueKeys: aggregate.issueKeys,
-            storyPointsAssigned: aggregate.storyPointsAssigned,
-            storyPointsCompleted: aggregate.storyPointsCompleted,
-            issuesResolved: aggregate.issuesResolved,
-            lastUpdatedAt: new Date(),
+            status: 'in_progress',
+            deliverableRefs,
           },
-        }
+          $setOnInsert: {
+            groupId,
+            sprintId,
+          },
+        },
+        { upsert: true, new: true, session }
       );
-    }
+
+      const contributionOps = Array.from(acceptedMemberIds).map((studentId) => {
+        const aggregate = aggregatedByStudent.get(studentId) || {
+          issueKeys: [],
+          storyPointsAssigned: 0,
+          storyPointsCompleted: 0,
+          issuesResolved: 0,
+        };
+        const existing = existingByStudent.get(studentId);
+
+        if (existing) {
+          return {
+            updateOne: {
+              filter: { contributionRecordId: existing.contributionRecordId },
+              update: {
+                $set: {
+                  jiraIssueKeys: aggregate.issueKeys,
+                  jiraIssueKey: aggregate.issueKeys[0] || null,
+                  storyPointsAssigned: aggregate.storyPointsAssigned,
+                  storyPointsCompleted: aggregate.storyPointsCompleted,
+                  issuesResolved: aggregate.issuesResolved,
+                  lastUpdatedAt: new Date(),
+                },
+              },
+            },
+          };
+        }
+
+        return {
+          updateOne: {
+            filter: { groupId, sprintId, studentId },
+            update: {
+              $set: {
+                jiraIssueKeys: aggregate.issueKeys,
+                jiraIssueKey: aggregate.issueKeys[0] || null,
+                storyPointsAssigned: aggregate.storyPointsAssigned,
+                storyPointsCompleted: aggregate.storyPointsCompleted,
+                issuesResolved: aggregate.issuesResolved,
+                lastUpdatedAt: new Date(),
+              },
+              $setOnInsert: {
+                contributionRecordId: `ctr_${new mongoose.Types.ObjectId().toString().slice(-8)}`,
+                groupId,
+                sprintId,
+                studentId,
+              },
+            },
+            upsert: true,
+          },
+        };
+      });
+
+      if (contributionOps.length > 0) {
+        await ContributionRecord.bulkWrite(contributionOps, { session });
+      }
+    });
 
     job.status = 'COMPLETED';
     job.completedAt = new Date();
     job.message = `JIRA synchronization completed. Imported ${issues.length} issues (${unmappedAssigneeCount} unmapped assignees skipped).`;
     await job.save();
   } catch (error) {
+    const normalized = normalizeWorkerError(error);
     job.status = 'FAILED';
     job.completedAt = new Date();
-    if (error?.code === 'ECONNABORTED') {
-      job.errorCode = 'GATEWAY_TIMEOUT';
-    } else if (error?.response?.status >= 500) {
-      job.errorCode = 'UPSTREAM_PROVIDER_ERROR';
-    } else {
-      job.errorCode = error.code || 'JIRA_SYNC_FAILED';
-    }
-    job.errorMessage = error.message || 'JIRA sync failed unexpectedly.';
+    job.errorCode = normalized.errorCode;
+    job.errorMessage = normalized.errorMessage;
     await job.save();
+  } finally {
+    await session.endSession();
   }
 };
 
@@ -305,6 +377,8 @@ const triggerJiraSync = async (req, res) => {
         message: 'JIRA integration is not configured for this group.',
       });
     }
+
+    await getPublishedSprintConfig(groupId, sprintId);
 
     const active = await SyncJob.findOne({
       groupId,
@@ -345,6 +419,12 @@ const triggerJiraSync = async (req, res) => {
       });
     });
   } catch (error) {
+    if (error?.status === 422) {
+      return res.status(422).json({
+        error: error.code || 'SPRINT_CONFIG_NOT_PUBLISHED',
+        message: error.message,
+      });
+    }
     console.error('[triggerJiraSync] error:', error);
     return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to trigger JIRA sync.' });
   }
@@ -364,7 +444,7 @@ const getJiraSyncStatus = async (req, res) => {
         message: `No JIRA sync job found for ${groupId}/${sprintId}.`,
       });
     }
-    return res.status(200).json(mapJobResponse(job));
+    return res.status(toHttpStatus(job.status, job.errorCode)).json(mapJobResponse(job));
   } catch (error) {
     console.error('[getJiraSyncStatus] error:', error);
     return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to fetch JIRA sync status.' });

--- a/backend/src/controllers/sprintTracking.js
+++ b/backend/src/controllers/sprintTracking.js
@@ -1,0 +1,559 @@
+'use strict';
+
+const axios = require('axios');
+const Group = require('../models/Group');
+const SprintRecord = require('../models/SprintRecord');
+const ContributionRecord = require('../models/ContributionRecord');
+const SyncJob = require('../models/SyncJob');
+const GitHubSyncJob = require('../models/GitHubSyncJob');
+const User = require('../models/User');
+const { decrypt } = require('../utils/cryptoUtils');
+
+const toPublicStatus = (status) => {
+  if (status === 'PENDING') return 'queued';
+  if (status === 'IN_PROGRESS') return 'running';
+  if (status === 'COMPLETED') return 'completed';
+  if (status === 'FAILED') return 'failed';
+  return 'queued';
+};
+
+const toHttpStatus = (status) => {
+  if (status === 'COMPLETED') return 200;
+  if (status === 'FAILED') return 500;
+  return 202;
+};
+
+const mapJobResponse = (job) => ({
+  jobId: job.jobId,
+  status: toPublicStatus(job.status),
+  source: job.source,
+  message: job.message,
+  groupId: job.groupId,
+  sprintId: job.sprintId,
+  startedAt: job.startedAt,
+  completedAt: job.completedAt,
+  errorCode: job.errorCode,
+  errorMessage: job.errorMessage,
+  createdAt: job.createdAt,
+  updatedAt: job.updatedAt,
+  mappedHttpStatus: toHttpStatus(job.status),
+});
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const withRetry = async (fn, maxAttempts = 3) => {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      const status = error?.response?.status;
+      const isClientError = status >= 400 && status < 500;
+      if (isClientError && status !== 429) {
+        throw error;
+      }
+      if (attempt < maxAttempts) {
+        await sleep(200 * Math.pow(2, attempt - 1));
+      }
+    }
+  }
+  throw lastError;
+};
+
+const inferStoryPoints = (issue = {}) => {
+  const fields = issue.fields || {};
+  const directCandidates = ['storyPoints', 'story_point', 'story_points'];
+  for (const candidate of directCandidates) {
+    const value = Number(fields[candidate]);
+    if (Number.isFinite(value)) return value;
+  }
+  for (const [key, value] of Object.entries(fields)) {
+    if (!key.toLowerCase().includes('customfield')) continue;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && key.toLowerCase().includes('story')) {
+      return numeric;
+    }
+  }
+  return 0;
+};
+
+const fetchJiraIssues = async ({ group, sprintKey, sprintId }) => {
+  const baseUrl = String(group.jiraUrl || '').replace(/\/$/, '');
+  const jiraToken = decrypt(group.jiraToken);
+  const authToken = Buffer.from(`${group.jiraUsername}:${jiraToken}`).toString('base64');
+
+  const headers = {
+    Authorization: `Basic ${authToken}`,
+    'Content-Type': 'application/json',
+  };
+
+  const jqlCandidates = [
+    `project = "${group.projectKey}" AND sprint = "${sprintKey || sprintId}"`,
+    `project = "${group.projectKey}" AND sprint = ${sprintKey || sprintId}`,
+    `project = "${group.projectKey}" AND sprint in openSprints()`,
+  ];
+
+  for (const jql of jqlCandidates) {
+    try {
+      const response = await withRetry(() =>
+        axios.get(`${baseUrl}/rest/api/3/search`, {
+          headers,
+          timeout: 8000,
+          params: {
+            jql,
+            maxResults: 100,
+            fields: '*all',
+          },
+        })
+      );
+      if (Array.isArray(response.data?.issues) && response.data.issues.length > 0) {
+        return response.data.issues;
+      }
+    } catch (error) {
+      if (error?.response?.status === 400) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return [];
+};
+
+const resolveAssigneeUserId = ({ issue, acceptedMemberIds, usersByEmail }) => {
+  const assignee = issue?.fields?.assignee;
+  if (!assignee) return null;
+
+  // 1) If JIRA accountId already matches an internal userId, use it.
+  const accountId = assignee.accountId ? String(assignee.accountId) : null;
+  if (accountId && acceptedMemberIds.has(accountId)) {
+    return accountId;
+  }
+
+  // 2) Fallback to email match when available.
+  const email = assignee.emailAddress ? String(assignee.emailAddress).trim().toLowerCase() : null;
+  if (email && usersByEmail.has(email)) {
+    return usersByEmail.get(email);
+  }
+
+  return null;
+};
+
+const runJiraSyncWorker = async ({ jobId, groupId, sprintId, sprintKey }) => {
+  const job = await SyncJob.findOne({ jobId });
+  if (!job) return;
+
+  try {
+    job.status = 'IN_PROGRESS';
+    job.startedAt = new Date();
+    job.message = 'JIRA synchronization is running.';
+    await job.save();
+
+    const group = await Group.findOne({ groupId }).lean();
+    if (!group) {
+      throw Object.assign(new Error(`Group ${groupId} not found.`), { code: 'GROUP_NOT_FOUND' });
+    }
+
+    if (!group.jiraUrl || !group.jiraUsername || !group.jiraToken || !group.projectKey) {
+      throw Object.assign(new Error('JIRA integration credentials are missing.'), {
+        code: 'INVALID_JIRA_CONFIGURATION',
+      });
+    }
+
+    const issues = await fetchJiraIssues({ group, sprintKey, sprintId });
+
+    const deliverableRefs = issues.map((issue) => ({
+      deliverableId: issue.key,
+      // SprintRecord schema has fixed enum; we keep all imported JIRA issues under this bucket.
+      type: 'demonstration',
+      submittedAt: new Date(issue.fields?.updated || issue.fields?.created || Date.now()),
+    }));
+
+    await SprintRecord.findOneAndUpdate(
+      { groupId, sprintId },
+      {
+        $set: {
+          status: 'in_progress',
+          deliverableRefs,
+        },
+        $setOnInsert: {
+          groupId,
+          sprintId,
+        },
+      },
+      { upsert: true, new: true }
+    );
+
+    const acceptedMembers = Array.isArray(group.members)
+      ? group.members.filter((member) => member.status === 'accepted')
+      : [];
+    const acceptedMemberIds = new Set(acceptedMembers.map((member) => member.userId));
+    const memberUsers = await User.find(
+      { userId: { $in: Array.from(acceptedMemberIds) } },
+      { userId: 1, email: 1 }
+    ).lean();
+    const usersByEmail = new Map(
+      memberUsers
+        .filter((user) => Boolean(user.email))
+        .map((user) => [String(user.email).trim().toLowerCase(), user.userId])
+    );
+
+    let unmappedAssigneeCount = 0;
+    const aggregatedByStudent = new Map();
+
+    // Build deterministic per-student totals from current JIRA snapshot.
+    for (const issue of issues) {
+      const assigneeUserId = resolveAssigneeUserId({
+        issue,
+        acceptedMemberIds,
+        usersByEmail,
+      });
+      if (!assigneeUserId) {
+        unmappedAssigneeCount += 1;
+        continue;
+      }
+
+      const storyPoints = inferStoryPoints(issue);
+      const bucket =
+        aggregatedByStudent.get(assigneeUserId) || {
+          issueKeys: [],
+          storyPointsAssigned: 0,
+          storyPointsCompleted: 0,
+          issuesResolved: 0,
+        };
+
+      bucket.issueKeys.push(issue.key);
+      bucket.storyPointsAssigned += storyPoints;
+      bucket.storyPointsCompleted += storyPoints;
+      bucket.issuesResolved += 1;
+      aggregatedByStudent.set(assigneeUserId, bucket);
+    }
+
+    const existingRecords = await ContributionRecord.find({ groupId, sprintId }).lean();
+    const existingByStudent = new Map(existingRecords.map((record) => [record.studentId, record]));
+
+    // Idempotent write: set absolute values for each accepted member.
+    for (const studentId of acceptedMemberIds) {
+      const aggregate = aggregatedByStudent.get(studentId) || {
+        issueKeys: [],
+        storyPointsAssigned: 0,
+        storyPointsCompleted: 0,
+        issuesResolved: 0,
+      };
+      const primaryIssueKey =
+        aggregate.issueKeys.length === 1 ? aggregate.issueKeys[0] : aggregate.issueKeys[0] || null;
+
+      const existing = existingByStudent.get(studentId);
+      if (!existing) {
+        await ContributionRecord.create({
+          groupId,
+          sprintId,
+          studentId,
+          jiraIssueKey: primaryIssueKey,
+          storyPointsAssigned: aggregate.storyPointsAssigned,
+          storyPointsCompleted: aggregate.storyPointsCompleted,
+          issuesResolved: aggregate.issuesResolved,
+          lastUpdatedAt: new Date(),
+        });
+        continue;
+      }
+
+      await ContributionRecord.updateOne(
+        { contributionRecordId: existing.contributionRecordId },
+        {
+          $set: {
+            jiraIssueKey: primaryIssueKey,
+            storyPointsAssigned: aggregate.storyPointsAssigned,
+            storyPointsCompleted: aggregate.storyPointsCompleted,
+            issuesResolved: aggregate.issuesResolved,
+            lastUpdatedAt: new Date(),
+          },
+        }
+      );
+    }
+
+    job.status = 'COMPLETED';
+    job.completedAt = new Date();
+    job.message = `JIRA synchronization completed. Imported ${issues.length} issues (${unmappedAssigneeCount} unmapped assignees skipped).`;
+    await job.save();
+  } catch (error) {
+    job.status = 'FAILED';
+    job.completedAt = new Date();
+    if (error?.code === 'ECONNABORTED') {
+      job.errorCode = 'GATEWAY_TIMEOUT';
+    } else if (error?.response?.status >= 500) {
+      job.errorCode = 'UPSTREAM_PROVIDER_ERROR';
+    } else {
+      job.errorCode = error.code || 'JIRA_SYNC_FAILED';
+    }
+    job.errorMessage = error.message || 'JIRA sync failed unexpectedly.';
+    await job.save();
+  }
+};
+
+const triggerJiraSync = async (req, res) => {
+  const { groupId, sprintId } = req.params;
+  const actorId = req.user?.userId || 'system';
+
+  try {
+    const group = await Group.findOne({ groupId }).lean();
+    if (!group) {
+      return res.status(404).json({ error: 'GROUP_NOT_FOUND', message: `Group ${groupId} not found.` });
+    }
+
+    if (!group.jiraUrl || !group.projectKey) {
+      return res.status(400).json({
+        error: 'INVALID_JIRA_CONFIGURATION',
+        message: 'JIRA integration is not configured for this group.',
+      });
+    }
+
+    const active = await SyncJob.findOne({
+      groupId,
+      sprintId,
+      source: 'jira',
+      status: { $in: ['PENDING', 'IN_PROGRESS'] },
+    }).lean();
+
+    if (active) {
+      return res.status(409).json({
+        error: 'SYNC_ALREADY_RUNNING',
+        message: `A JIRA sync is already running for ${groupId}/${sprintId}.`,
+        jobId: active.jobId,
+      });
+    }
+
+    const job = await SyncJob.create({
+      groupId,
+      sprintId,
+      source: 'jira',
+      status: 'PENDING',
+      message: 'JIRA sync accepted and queued.',
+      triggeredBy: actorId,
+    });
+
+    res.status(202).json({
+      jobId: job.jobId,
+      status: 'queued',
+      source: 'jira',
+      message: 'JIRA sync job accepted.',
+      createdAt: job.createdAt,
+    });
+
+    setImmediate(() => {
+      runJiraSyncWorker({ jobId: job.jobId, groupId, sprintId, sprintKey: req.body?.sprintKey }).catch((err) => {
+        // Non-fatal because job record persists failure details.
+        console.error('[runJiraSyncWorker] unhandled error:', err.message);
+      });
+    });
+  } catch (error) {
+    console.error('[triggerJiraSync] error:', error);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to trigger JIRA sync.' });
+  }
+};
+
+const getJiraSyncStatus = async (req, res) => {
+  const { groupId, sprintId, jobId } = req.params;
+  try {
+    const query = jobId
+      ? { groupId, sprintId, source: 'jira', jobId }
+      : { groupId, sprintId, source: 'jira' };
+    const sort = jobId ? undefined : { createdAt: -1 };
+    const job = await SyncJob.findOne(query, null, sort ? { sort } : {}).lean();
+    if (!job) {
+      return res.status(404).json({
+        error: 'JOB_NOT_FOUND',
+        message: `No JIRA sync job found for ${groupId}/${sprintId}.`,
+      });
+    }
+    return res.status(200).json(mapJobResponse(job));
+  } catch (error) {
+    console.error('[getJiraSyncStatus] error:', error);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to fetch JIRA sync status.' });
+  }
+};
+
+const getJiraSyncLogs = async (req, res) => {
+  const { groupId, sprintId, jobId } = req.params;
+  try {
+    const job = await SyncJob.findOne({ groupId, sprintId, source: 'jira', jobId }).lean();
+    if (!job) {
+      return res.status(404).json({
+        error: 'JOB_NOT_FOUND',
+        message: `No JIRA sync job found for ${groupId}/${sprintId}/${jobId}.`,
+      });
+    }
+
+    const logs = [
+      { level: 'info', at: job.createdAt, message: 'JIRA sync job created.' },
+      job.startedAt ? { level: 'info', at: job.startedAt, message: 'JIRA sync worker started.' } : null,
+      job.message ? { level: job.status === 'FAILED' ? 'error' : 'info', at: job.updatedAt || job.createdAt, message: job.message } : null,
+      job.errorMessage ? { level: 'error', at: job.completedAt || job.updatedAt, message: job.errorMessage } : null,
+      job.completedAt ? { level: 'info', at: job.completedAt, message: `JIRA sync finished with status ${toPublicStatus(job.status)}.` } : null,
+    ].filter(Boolean);
+
+    return res.status(200).json({
+      jobId: job.jobId,
+      source: 'jira',
+      status: toPublicStatus(job.status),
+      logs,
+    });
+  } catch (error) {
+    console.error('[getJiraSyncLogs] error:', error);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to fetch JIRA sync logs.' });
+  }
+};
+
+const recalculateContributions = async (req, res) => {
+  const { groupId, sprintId } = req.params;
+
+  try {
+    const group = await Group.findOne({ groupId }).lean();
+    if (!group) {
+      return res.status(404).json({ error: 'GROUP_NOT_FOUND', message: `Group ${groupId} not found.` });
+    }
+
+    const acceptedMembers = (group.members || []).filter((member) => member.status === 'accepted');
+    if (acceptedMembers.length === 0) {
+      return res.status(200).json({
+        groupId,
+        sprintId,
+        contributions: [],
+        recalculatedAt: new Date().toISOString(),
+        basedOnTargets: false,
+        warnings: ['No accepted group members found.'],
+        summary: 'No contribution records were generated.',
+      });
+    }
+
+    const existing = await ContributionRecord.find({ groupId, sprintId }).lean();
+    const existingByStudent = new Map(existing.map((record) => [record.studentId, record]));
+
+    for (const member of acceptedMembers) {
+      if (!existingByStudent.has(member.userId)) {
+        await ContributionRecord.create({
+          groupId,
+          sprintId,
+          studentId: member.userId,
+          storyPointsAssigned: 0,
+          storyPointsCompleted: 0,
+          contributionRatio: 0,
+          gitHubHandle: null,
+        });
+      }
+    }
+
+    const acceptedMemberIds = acceptedMembers.map((member) => member.userId);
+    const allRecords = await ContributionRecord.find({
+      groupId,
+      sprintId,
+      studentId: { $in: acceptedMemberIds },
+    }).lean();
+
+    const latestGithubJob = await GitHubSyncJob.findOne(
+      { groupId, sprintId, status: 'COMPLETED' },
+      null,
+      { sort: { createdAt: -1 } }
+    ).lean();
+    const validationRecords = Array.isArray(latestGithubJob?.validationRecords)
+      ? latestGithubJob.validationRecords
+      : [];
+    const mergedIssueKeys = new Set(
+      validationRecords
+        .filter((record) => record.mergeStatus === 'MERGED')
+        .map((record) => record.issueKey)
+    );
+
+    const users = await User.find(
+      { userId: { $in: acceptedMemberIds } },
+      { userId: 1, email: 1, githubUsername: 1 }
+    ).lean();
+    const usersById = new Map(users.map((user) => [user.userId, user]));
+
+    const projectedRows = allRecords.map((record) => {
+      const completedFromMerge = mergedIssueKeys.has(record.jiraIssueKey)
+        ? Number(record.storyPointsAssigned || record.storyPointsCompleted || 0)
+        : 0;
+      const warnings = [];
+      if (!record.jiraIssueKey) warnings.push('No JIRA issue mapping found for student record.');
+      if (record.jiraIssueKey && validationRecords.length > 0 && !mergedIssueKeys.has(record.jiraIssueKey)) {
+        warnings.push(`Mapped issue ${record.jiraIssueKey} is not merged in latest GitHub sync.`);
+      }
+      if (validationRecords.length === 0) {
+        warnings.push('No completed GitHub sync validation found; using zero completed SP from merge mapping.');
+      }
+      return {
+        record,
+        completedFromMerge,
+        warnings,
+      };
+    });
+
+    const totalCompleted = projectedRows.reduce((sum, row) => sum + row.completedFromMerge, 0);
+
+    const contributions = [];
+    for (const row of projectedRows) {
+      const { record, warnings } = row;
+      const completed = row.completedFromMerge;
+      const target = Number(record.storyPointsAssigned || 0);
+      const ratio = target > 0 ? completed / target : 0;
+      const user = usersById.get(record.studentId);
+      const studentName = user?.email || record.studentId;
+      const githubUsername = record.gitHubHandle || user?.githubUsername || record.studentId;
+      if (target <= 0) {
+        warnings.push('Target story points are zero; ratio is set to 0.');
+      }
+
+      await ContributionRecord.updateOne(
+        { contributionRecordId: record.contributionRecordId },
+        {
+          $set: {
+            storyPointsCompleted: completed,
+            contributionRatio: ratio,
+            lastUpdatedAt: new Date(),
+          },
+        }
+      );
+
+      contributions.push({
+        studentId: record.studentId,
+        studentName,
+        githubUsername,
+        completedStoryPoints: completed,
+        targetStoryPoints: target,
+        groupTotalStoryPoints: totalCompleted,
+        contributionRatio: ratio,
+        mappingWarnings: warnings,
+        mappingWarningsCount: warnings.length,
+      });
+    }
+
+    const summaryWarnings = [];
+    if (!latestGithubJob) {
+      summaryWarnings.push('No completed GitHub sync job found for this sprint; completed SP values may be zero.');
+    }
+
+    return res.status(200).json({
+      groupId,
+      sprintId,
+      contributions,
+      recalculatedAt: new Date().toISOString(),
+      basedOnTargets: true,
+      warnings: summaryWarnings,
+      summary: `Recalculated contributions for ${contributions.length} students.`,
+    });
+  } catch (error) {
+    console.error('[recalculateContributions] error:', error);
+    return res
+      .status(500)
+      .json({ error: 'INTERNAL_ERROR', message: 'Failed to recalculate contributions.' });
+  }
+};
+
+module.exports = {
+  triggerJiraSync,
+  getJiraSyncStatus,
+  getJiraSyncLogs,
+  recalculateContributions,
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,8 +2,6 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
-const swaggerUi = require('swagger-ui-express');
-const swaggerSpec = require('./swagger');
 
 const authRoutes = require('./routes/auth');
 const onboardingRoutes = require('./routes/onboarding');
@@ -16,6 +14,20 @@ const deliverableRoutes = require('./routes/deliverables');
 const reviewRoutes = require('./routes/reviews');
 const commentsRoutes = require('./routes/comments');
 const { errorHandler } = require('./middleware/auth');
+const { startJiraSyncScheduler } = require('./services/jiraSyncScheduler');
+
+let swaggerUi = null;
+let swaggerSpec = null;
+try {
+  swaggerUi = require('swagger-ui-express');
+} catch (error) {
+  console.warn('[index] swagger-ui-express is not installed; /api-docs will be disabled.');
+}
+try {
+  swaggerSpec = require('./swagger');
+} catch (error) {
+  console.warn('[index] swagger spec dependencies are not installed; /api-docs will be disabled.');
+}
 
 const app = express();
 const PORT = process.env.PORT || 5002;
@@ -52,10 +64,13 @@ const connectDB = async () => {
 
 if (process.env.NODE_ENV !== 'test') {
   connectDB();
+  startJiraSyncScheduler();
 }
 
 // Swagger UI
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+if (swaggerUi && swaggerSpec) {
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+}
 
 // API Routes
 app.use('/api/v1/auth', authRoutes);

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -247,6 +247,7 @@ const errorHandler = (err, req, res, next) => {
 const serviceOrBearerAuth = (req, res, next) => {
   const expected =
     process.env.SERVICE_AUTH_TOKEN ||
+    process.env.SYSTEM_SERVICE_TOKEN ||
     process.env.X_SERVICE_AUTH_SECRET ||
     process.env.INTERNAL_API_KEY;
   const headerVal = req.headers['x-service-auth'];

--- a/backend/src/middleware/jiraSyncRateLimit.js
+++ b/backend/src/middleware/jiraSyncRateLimit.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const RECENT_TRIGGER_WINDOW_MS = 30 * 1000;
+const triggerLedger = new Map();
+
+const checkJiraSyncRateLimit = (req, res, next) => {
+  const { groupId, sprintId } = req.params;
+  const actorId = req.user?.userId || req.headers['x-service-auth'] || 'anonymous';
+  const key = `${groupId}:${sprintId}:${actorId}`;
+  const now = Date.now();
+  const previous = triggerLedger.get(key);
+
+  if (previous && now - previous < RECENT_TRIGGER_WINDOW_MS) {
+    return res.status(429).json({
+      error: 'RATE_LIMITED',
+      message: 'JIRA sync was triggered too recently for this sprint. Please wait before retrying.',
+      retryAfterSeconds: Math.ceil((RECENT_TRIGGER_WINDOW_MS - (now - previous)) / 1000),
+    });
+  }
+
+  triggerLedger.set(key, now);
+
+  if (triggerLedger.size > 500) {
+    for (const [ledgerKey, ts] of triggerLedger.entries()) {
+      if (now - ts > RECENT_TRIGGER_WINDOW_MS) {
+        triggerLedger.delete(ledgerKey);
+      }
+    }
+  }
+
+  return next();
+};
+
+module.exports = { checkJiraSyncRateLimit };

--- a/backend/src/models/AuditLog.js
+++ b/backend/src/models/AuditLog.js
@@ -128,6 +128,11 @@ const auditLogSchema = new mongoose.Schema(
         'GITHUB_SYNC_INITIATED',
         'GITHUB_SYNC_COMPLETED',
         'GITHUB_SYNC_FAILED',
+
+        // --- JIRA Sync (Process 7.1) ---
+        'JIRA_SYNC_INITIATED',
+        'JIRA_SYNC_COMPLETED',
+        'JIRA_SYNC_FAILED',
       ],
     },
     actorId: {

--- a/backend/src/models/ContributionRecord.js
+++ b/backend/src/models/ContributionRecord.js
@@ -58,9 +58,9 @@ const contributionRecordSchema = new mongoose.Schema(
       type: Number,
       default: 0,
     },
-    jiraIssueKey: {
-      type: String,
-      default: null,
+    jiraIssueKeys: {
+      type: [String],
+      default: [],
       indexed: true,
     },
     contributionRatio: {

--- a/backend/src/models/ContributionRecord.js
+++ b/backend/src/models/ContributionRecord.js
@@ -58,6 +58,11 @@ const contributionRecordSchema = new mongoose.Schema(
       type: Number,
       default: 0,
     },
+    jiraIssueKey: {
+      type: String,
+      default: null,
+      indexed: true,
+    },
     contributionRatio: {
       type: Number,
       default: 0,

--- a/backend/src/models/GitHubSyncJob.js
+++ b/backend/src/models/GitHubSyncJob.js
@@ -77,8 +77,15 @@ const gitHubSyncJobSchema = new mongoose.Schema(
   }
 );
 
-// Compound lock key: only one IN_PROGRESS job per (group, sprint)
-gitHubSyncJobSchema.index({ groupId: 1, sprintId: 1, status: 1 });
+// Compound lock key: only one PENDING or IN_PROGRESS job per (group, sprint)
+gitHubSyncJobSchema.index(
+  { groupId: 1, sprintId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: { $in: ['PENDING', 'IN_PROGRESS'] } },
+    name: 'uniq_active_sync_lock',
+  }
+);
 // Fast job retrieval by jobId
 gitHubSyncJobSchema.index({ jobId: 1 }, { unique: true });
 

--- a/backend/src/models/JiraSyncJob.js
+++ b/backend/src/models/JiraSyncJob.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const jiraSyncJobSchema = new mongoose.Schema(
+  {
+    jobId: {
+      type: String,
+      required: true,
+      unique: true,
+      default: () => `jirasync_${uuidv4().replace(/-/g, '').slice(0, 16)}`,
+    },
+    groupId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    sprintId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    source: {
+      type: String,
+      enum: ['jira'],
+      default: 'jira',
+    },
+    status: {
+      type: String,
+      enum: ['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED'],
+      default: 'PENDING',
+    },
+    issuesProcessed: {
+      type: Number,
+      default: 0,
+    },
+    issuesUpserted: {
+      type: Number,
+      default: 0,
+    },
+    errorCode: {
+      type: String,
+      default: null,
+    },
+    errorMessage: {
+      type: String,
+      default: null,
+    },
+    startedAt: {
+      type: Date,
+      default: null,
+    },
+    completedAt: {
+      type: Date,
+      default: null,
+    },
+    triggeredBy: {
+      type: String,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'jira_sync_jobs',
+  }
+);
+
+jiraSyncJobSchema.index(
+  { groupId: 1, sprintId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: { $in: ['PENDING', 'IN_PROGRESS'] } },
+    name: 'uniq_active_jira_sync_lock',
+  }
+);
+
+module.exports = mongoose.model('JiraSyncJob', jiraSyncJobSchema);

--- a/backend/src/models/SprintConfig.js
+++ b/backend/src/models/SprintConfig.js
@@ -16,6 +16,11 @@ const sprintConfigSchema = new mongoose.Schema(
       required: true,
       index: true,
     },
+    groupId: {
+      type: String,
+      default: null,
+      index: true,
+    },
     deliverableType: {
       type: String,
       enum: ['proposal', 'statement_of_work', 'demo', 'interim_report', 'final_report'],
@@ -26,6 +31,20 @@ const sprintConfigSchema = new mongoose.Schema(
       required: true,
     },
     description: {
+      type: String,
+      default: null,
+    },
+    configurationStatus: {
+      type: String,
+      enum: ['draft', 'published'],
+      default: 'draft',
+      index: true,
+    },
+    publishedAt: {
+      type: Date,
+      default: null,
+    },
+    externalSprintKey: {
       type: String,
       default: null,
     },

--- a/backend/src/models/SprintIssue.js
+++ b/backend/src/models/SprintIssue.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const sprintIssueSchema = new mongoose.Schema(
+  {
+    sprintIssueId: {
+      type: String,
+      required: true,
+      unique: true,
+      default: () => `spi_${uuidv4().replace(/-/g, '').slice(0, 16)}`,
+    },
+    groupId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    sprintId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    issueKey: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    storyPoints: {
+      type: Number,
+      default: 0,
+    },
+    status: {
+      type: String,
+      default: null,
+    },
+    assigneeAccountId: {
+      type: String,
+      default: null,
+    },
+    assigneeDisplayName: {
+      type: String,
+      default: null,
+    },
+    rawIssue: {
+      type: mongoose.Schema.Types.Mixed,
+      default: null,
+    },
+    syncedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'sprint_issues',
+  }
+);
+
+sprintIssueSchema.index({ groupId: 1, sprintId: 1, issueKey: 1 }, { unique: true });
+sprintIssueSchema.index({ groupId: 1, sprintId: 1, syncedAt: -1 });
+
+module.exports = mongoose.model('SprintIssue', sprintIssueSchema);

--- a/backend/src/models/SyncJob.js
+++ b/backend/src/models/SyncJob.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+const syncJobSchema = new mongoose.Schema(
+  {
+    jobId: {
+      type: String,
+      required: true,
+      unique: true,
+      default: () => `sync_${uuidv4().replace(/-/g, '').slice(0, 16)}`,
+    },
+    groupId: { type: String, required: true, index: true },
+    sprintId: { type: String, required: true, index: true },
+    source: {
+      type: String,
+      enum: ['jira', 'github'],
+      required: true,
+      index: true,
+    },
+    status: {
+      type: String,
+      enum: ['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED'],
+      default: 'PENDING',
+    },
+    message: { type: String, default: null },
+    errorCode: { type: String, default: null },
+    errorMessage: { type: String, default: null },
+    startedAt: { type: Date, default: null },
+    completedAt: { type: Date, default: null },
+    triggeredBy: { type: String, default: null },
+  },
+  {
+    timestamps: true,
+    collection: 'sync_jobs',
+  }
+);
+
+syncJobSchema.index(
+  { groupId: 1, sprintId: 1, source: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { status: { $in: ['PENDING', 'IN_PROGRESS'] } },
+    name: 'uniq_active_sync_lock_by_source',
+  }
+);
+
+module.exports = mongoose.model('SyncJob', syncJobSchema);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const router = express.Router();
 const { authMiddleware, roleMiddleware, serviceOrBearerAuth } = require('../middleware/auth');
+const { checkJiraSyncRateLimit } = require('../middleware/jiraSyncRateLimit');
 const { checkScheduleWindow, checkAdvisorOperationWindow } = require('../middleware/scheduleWindow');
 const OPERATION_TYPES = require('../utils/operationTypes');
 
@@ -127,6 +128,7 @@ router.post(
   '/:groupId/sprints/:sprintId/jira-sync',
   serviceOrBearerAuth,
   roleMiddleware(['coordinator']),
+  checkJiraSyncRateLimit,
   triggerJiraSync
 );
 
@@ -173,6 +175,7 @@ router.post(
   '/:groupId/sprints/:sprintId/jira-sync',
   authMiddleware,
   roleMiddleware(['coordinator', 'admin']),
+  checkJiraSyncRateLimit,
   triggerJiraSync
 );
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -78,7 +78,7 @@ router.get('/:groupId', authMiddleware, getGroup);
 /**
  * GET /api/v1/groups/:groupId/committee-status — Committee status lookup (From your branch)
  */
-router.get('/:groupId/committee-status', authMiddleware, getGroupCommitteeStatus);
+// router.get('/:groupId/committee-status', authMiddleware, getGroupCommitteeStatus);
 
 // GET /api/v1/groups/:groupId/sprints/:sprintId/contributions — read-only Process 7.x summary
 router.get(

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -33,10 +33,8 @@ const {
 const { configureGithub, getGithub, configureJira, getJira } = require('../controllers/groupIntegrations');
 const { transitionStatus, getStatus } = require('../controllers/groupStatusTransition');
 const { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob, getSyncJobLogs } = require('../controllers/githubSync');
+const { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs } = require('../controllers/jiraSync');
 const {
-  triggerJiraSync,
-  getJiraSyncStatus,
-  getJiraSyncLogs,
   recalculateContributions,
 } = require('../controllers/sprintTracking');
 
@@ -171,14 +169,6 @@ router.get(
 // ============================================================================
 // PROCESS 7.1 — JIRA Sprint Sync (async ingestion bridge)
 // ============================================================================
-router.post(
-  '/:groupId/sprints/:sprintId/jira-sync',
-  authMiddleware,
-  roleMiddleware(['coordinator', 'admin']),
-  checkJiraSyncRateLimit,
-  triggerJiraSync
-);
-
 router.get(
   '/:groupId/sprints/:sprintId/jira-sync',
   authMiddleware,

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -29,7 +29,13 @@ const {
 
 const { configureGithub, getGithub, configureJira, getJira } = require('../controllers/groupIntegrations');
 const { transitionStatus, getStatus } = require('../controllers/groupStatusTransition');
-const { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob } = require('../controllers/githubSync');
+const { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob, getSyncJobLogs } = require('../controllers/githubSync');
+const {
+  triggerJiraSync,
+  getJiraSyncStatus,
+  getJiraSyncLogs,
+  recalculateContributions,
+} = require('../controllers/sprintTracking');
 
 // Integrated Controllers from both branches
 const { submitDeliverableHandler } = require('../controllers/deliverables'); // From main
@@ -114,20 +120,70 @@ router.get('/:groupId/jira', authMiddleware, getJira);
 router.post(
   '/:groupId/sprints/:sprintId/github-sync',
   authMiddleware,
-  roleMiddleware(['coordinator', 'professor']),
+  roleMiddleware(['coordinator', 'admin']),
   triggerGitHubSync
 );
 
 router.get(
   '/:groupId/sprints/:sprintId/github-sync',
   authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
   getLatestSyncJob
 );
 
 router.get(
   '/:groupId/sprints/:sprintId/github-sync/:jobId',
   authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
   getSyncJobStatus
+);
+
+router.get(
+  '/:groupId/sprints/:sprintId/github-sync/:jobId/logs',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  getSyncJobLogs
+);
+
+// ============================================================================
+// PROCESS 7.1 — JIRA Sprint Sync (async ingestion bridge)
+// ============================================================================
+router.post(
+  '/:groupId/sprints/:sprintId/jira-sync',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  triggerJiraSync
+);
+
+router.get(
+  '/:groupId/sprints/:sprintId/jira-sync',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  getJiraSyncStatus
+);
+
+router.get(
+  '/:groupId/sprints/:sprintId/jira-sync/:jobId',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  getJiraSyncStatus
+);
+
+router.get(
+  '/:groupId/sprints/:sprintId/jira-sync/:jobId/logs',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  getJiraSyncLogs
+);
+
+// ============================================================================
+// PROCESS 7.3/7.4/7.5 — Contribution recalculation (sync response)
+// ============================================================================
+router.post(
+  '/:groupId/sprints/:sprintId/contributions/recalculate',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'admin']),
+  recalculateContributions
 );
 
 router.patch(

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -2,7 +2,7 @@
 
 const express = require('express');
 const router = express.Router();
-const { authMiddleware, roleMiddleware } = require('../middleware/auth');
+const { authMiddleware, roleMiddleware, serviceOrBearerAuth } = require('../middleware/auth');
 const { checkScheduleWindow, checkAdvisorOperationWindow } = require('../middleware/scheduleWindow');
 const OPERATION_TYPES = require('../utils/operationTypes');
 
@@ -13,6 +13,7 @@ const {
   getGroup,
   getAllGroups,
   getSprintContributionSummary,
+  getGroupCommitteeStatus,
   createMemberRequest,
   decideMemberRequest,
   coordinatorOverride,
@@ -31,6 +32,7 @@ const {
 const { configureGithub, getGithub, configureJira, getJira } = require('../controllers/groupIntegrations');
 const { transitionStatus, getStatus } = require('../controllers/groupStatusTransition');
 const { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob } = require('../controllers/githubSync');
+const { triggerJiraSync } = require('../controllers/jiraSync');
 
 // Integrated Controllers from both branches
 const { submitDeliverableHandler } = require('../controllers/deliverables'); // From main
@@ -116,6 +118,12 @@ router.post('/:groupId/github', authMiddleware, configureGithub);
 router.get('/:groupId/github', authMiddleware, getGithub);
 router.post('/:groupId/jira', authMiddleware, configureJira);
 router.get('/:groupId/jira', authMiddleware, getJira);
+router.post(
+  '/:groupId/sprints/:sprintId/jira-sync',
+  serviceOrBearerAuth,
+  roleMiddleware(['coordinator']),
+  triggerJiraSync
+);
 
 // ============================================================================
 // PROCESS 7.2 — GitHub PR Sync (async validation bridge)

--- a/backend/src/services/githubSyncService.js
+++ b/backend/src/services/githubSyncService.js
@@ -31,6 +31,7 @@ const Group = require('../models/Group');
 const SprintRecord = require('../models/SprintRecord');
 const ContributionRecord = require('../models/ContributionRecord');
 const GitHubSyncJob = require('../models/GitHubSyncJob');
+const SprintIssue = require('../models/SprintIssue');
 const { createAuditLog } = require('./auditService');
 const { decrypt } = require('../utils/cryptoUtils');
 
@@ -153,19 +154,32 @@ async function getGitHubConfig(groupId) {
  * @throws {GitHubSyncError} 404 JIRA_DATA_MISSING if D6 is empty for this sprint
  */
 async function getSprintIssues(sprintId, groupId) {
+  const sprintIssues = await SprintIssue.find({ sprintId, groupId }).lean();
   const sprintRecord = await SprintRecord.findOne({ sprintId, groupId }).lean();
   const contributions = await ContributionRecord.find({ sprintId, groupId }).lean();
 
   const issues = [];
 
+  // Source 0: canonical SprintIssue rows from Process 7.1
+  for (const sprintIssue of sprintIssues) {
+    issues.push({
+      key: sprintIssue.issueKey,
+      prLink: null,
+      source: 'sprint_issue',
+    });
+  }
+
   // Source 1: deliverable refs from SprintRecord
   if (sprintRecord?.deliverableRefs?.length) {
     for (const ref of sprintRecord.deliverableRefs) {
-      issues.push({
-        key: ref.deliverableId,
-        prLink: null, // will be resolved by branch pattern
-        source: 'deliverable_ref',
-      });
+      const alreadyAdded = issues.some((issue) => issue.key === ref.deliverableId);
+      if (!alreadyAdded) {
+        issues.push({
+          key: ref.deliverableId,
+          prLink: null, // will be resolved by branch pattern
+          source: 'deliverable_ref',
+        });
+      }
     }
   }
 

--- a/backend/src/services/githubSyncService.js
+++ b/backend/src/services/githubSyncService.js
@@ -62,7 +62,17 @@ const MERGE_STATE_MAP = {
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * withRetry — calls fn up to maxAttempts times with exponential back-off.
+ * maskToken — hides most of a sensitive token for logging.
+ * e.g. "ghp_abc123..." -> "ghp_***23"
+ */
+function maskToken(token) {
+  if (!token) return 'null';
+  if (token.length < 10) return '***';
+  return `${token.substring(0, 4)}***${token.substring(token.length - 2)}`;
+}
+
+/**
+ * withRetry — calls fn up to maxAttempts times with exponential back-off + jitter.
  * 4xx client errors are NOT retried (they indicate a business-rule failure).
  * Throws the last error after exhausting attempts.
  *
@@ -81,7 +91,9 @@ async function withRetry(fn, maxAttempts = MAX_RETRY_ATTEMPTS) {
       }
       lastError = err;
       if (attempt < maxAttempts) {
-        await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1));
+        const exp = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
+        const jitter = Math.floor(Math.random() * 100);
+        await sleep(exp + jitter);
       }
     }
   }
@@ -110,7 +122,7 @@ function determineMergeStatus(pr) {
 /**
  * getGitHubConfig(groupId) — reads D2
  *
- * @returns {{ pat: string, owner: string, repo: string, repoUrl: string }}
+ * @returns {{ encryptedPat: string, owner: string, repo: string, repoUrl: string }}
  * @throws {GitHubSyncError} with code INVALID_GITHUB_CREDENTIALS if not configured
  */
 async function getGitHubConfig(groupId) {
@@ -126,7 +138,7 @@ async function getGitHubConfig(groupId) {
     );
   }
   return {
-    pat: decrypt(group.githubPat),
+    encryptedPat: group.githubPat, // Defer decryption until request level
     owner: group.githubOrg,
     repo: group.githubRepoName,
     repoUrl: group.githubRepoUrl,
@@ -144,7 +156,7 @@ async function getGitHubConfig(groupId) {
  *   1. SprintRecord.deliverableRefs (deliverable IDs act as issue keys here)
  *   2. ContributionRecord entries (one per student — represents a work item)
  *
- * Returns an array of { key, prLink } objects.
+ * Returns an array of { key: string, prLink: string|null, source: string, studentId?: string }.
  * prLink is derived from D6 metadata or falls back to branch-name convention.
  *
  * @returns {Array<{ key: string, prLink: string|null }>}
@@ -169,7 +181,8 @@ async function getSprintIssues(sprintId, groupId) {
 
   // Source 2: ContributionRecord entries (unique student work items)
   for (const contrib of contributions) {
-    const key = `${sprintId}-${contrib.studentId}`;
+    // FIX D: Use actual jiraIssueKey if available, fallback to student-specific key
+    const key = contrib.jiraIssueKey || `${sprintId}-${contrib.studentId}`;
     const alreadyAdded = issues.some((i) => i.key === key);
     if (!alreadyAdded) {
       issues.push({
@@ -204,11 +217,20 @@ async function getSprintIssues(sprintId, groupId) {
  * Returns the first matching PR object, or null if none found.
  *
  * @param {{ key: string, prLink: string|null }} issue
- * @param {{ pat: string, owner: string, repo: string }} config
+ * @param {{ encryptedPat: string, owner: string, repo: string }} config
  * @returns {Promise<Object|null>}
  */
 async function getPullRequestForIssue(issue, config) {
-  const { pat, owner, repo } = config;
+  const { encryptedPat, owner, repo } = config;
+  
+  // FIX E: Decrypt PAT only at request level
+  let pat;
+  try {
+    pat = decrypt(encryptedPat);
+  } catch (err) {
+    throw new GitHubSyncError(400, 'INVALID_GITHUB_CREDENTIALS', 'Failed to decrypt GitHub PAT');
+  }
+
   const headers = {
     Authorization: `Bearer ${pat}`,
     'User-Agent': 'senior-app-github-sync',
@@ -224,6 +246,8 @@ async function getPullRequestForIssue(issue, config) {
       return res.data;
     } catch (err) {
       if (err.response?.status === 404) return null;
+      // FIX E: Mask PAT in error logs
+      console.error(`[getPullRequestForIssue] API error for PR ${prNumber} with token ${maskToken(pat)}:`, err.message);
       throw err;
     }
   }
@@ -258,6 +282,8 @@ async function getPullRequestForIssue(issue, config) {
     } catch (err) {
       // 422 = invalid branch ref format — skip, not a real error
       if (err.response?.status === 422) continue;
+      // FIX E: Mask PAT in error logs
+      console.error(`[getPullRequestForIssue] API error for branch ${branch} with token ${maskToken(pat)}:`, err.message);
       throw err;
     }
   }
@@ -316,6 +342,7 @@ async function githubSyncWorker(groupId, sprintId, jobId) {
 
     // ── f33 + f34: Per-issue GitHub API call + D6 persistence ───────────────
     const validationRecords = [];
+    let upstreamErrorCount = 0;
 
     for (const issue of issues) {
       let pr = null;
@@ -329,6 +356,11 @@ async function githubSyncWorker(groupId, sprintId, jobId) {
         // Upstream errors after retries → log but continue processing other issues
         console.error(`[githubSyncWorker] PR lookup failed for issue ${issue.key}:`, err.message);
         errorNote = err.message;
+
+        // Classify critical upstream errors
+        if (err.response?.status >= 500 || err.code === 'ECONNABORTED') {
+          upstreamErrorCount++;
+        }
       }
 
       validationRecords.push({
@@ -343,7 +375,17 @@ async function githubSyncWorker(groupId, sprintId, jobId) {
 
     // Persist all records
     job.validationRecords = validationRecords;
-    job.status = 'COMPLETED';
+
+    // ── Job Status Classification ──────────────────────────────────────────
+    // If more than 50% of issues failed due to 5xx/timeout, fail the whole job
+    if (issues.length > 0 && upstreamErrorCount / issues.length > 0.5) {
+      job.status = 'FAILED';
+      job.errorCode = 'UPSTREAM_PROVIDER_ERROR';
+      job.errorMessage = `GitHub API returned consistent errors for ${upstreamErrorCount} issues. Check GitHub status.`;
+    } else {
+      job.status = 'COMPLETED';
+    }
+
     job.completedAt = new Date();
 
     // ── f35: Release lock ────────────────────────────────────────────────────

--- a/backend/src/services/githubSyncService.js
+++ b/backend/src/services/githubSyncService.js
@@ -181,16 +181,21 @@ async function getSprintIssues(sprintId, groupId) {
 
   // Source 2: ContributionRecord entries (unique student work items)
   for (const contrib of contributions) {
-    // FIX D: Use actual jiraIssueKey if available, fallback to student-specific key
-    const key = contrib.jiraIssueKey || `${sprintId}-${contrib.studentId}`;
-    const alreadyAdded = issues.some((i) => i.key === key);
-    if (!alreadyAdded) {
-      issues.push({
-        key,
-        prLink: null,
-        source: 'contribution_record',
-        studentId: contrib.studentId,
-      });
+    const studentKeys =
+      Array.isArray(contrib.jiraIssueKeys) && contrib.jiraIssueKeys.length > 0
+        ? contrib.jiraIssueKeys
+        : [`${sprintId}-${contrib.studentId}`];
+
+    for (const key of studentKeys) {
+      const alreadyAdded = issues.some((i) => i.key === key);
+      if (!alreadyAdded) {
+        issues.push({
+          key,
+          prLink: null,
+          source: 'contribution_record',
+          studentId: contrib.studentId,
+        });
+      }
     }
   }
 

--- a/backend/src/services/jiraSyncScheduler.js
+++ b/backend/src/services/jiraSyncScheduler.js
@@ -5,6 +5,7 @@ const JiraSyncJob = require('../models/JiraSyncJob');
 const { jiraSyncWorker } = require('./jiraSyncService');
 
 let schedulerHandle = null;
+let schedulerTickInProgress = false;
 
 async function enqueueEligibleSyncs() {
   const configs = await SprintConfig.find({
@@ -43,8 +44,14 @@ function startJiraSyncScheduler() {
 
   const intervalMs = Number(process.env.JIRA_SPRINT_SYNC_INTERVAL_MS || 24 * 60 * 60 * 1000);
   schedulerHandle = setInterval(() => {
+    if (schedulerTickInProgress) {
+      return;
+    }
+    schedulerTickInProgress = true;
     enqueueEligibleSyncs().catch((err) => {
       console.error('[jiraSyncScheduler] Tick failed:', err.message);
+    }).finally(() => {
+      schedulerTickInProgress = false;
     });
   }, intervalMs);
 

--- a/backend/src/services/jiraSyncScheduler.js
+++ b/backend/src/services/jiraSyncScheduler.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const SprintConfig = require('../models/SprintConfig');
+const JiraSyncJob = require('../models/JiraSyncJob');
+const { jiraSyncWorker } = require('./jiraSyncService');
+
+let schedulerHandle = null;
+
+async function enqueueEligibleSyncs() {
+  const configs = await SprintConfig.find({
+    configurationStatus: 'published',
+    deadline: { $gte: new Date() },
+    groupId: { $ne: null },
+    externalSprintKey: { $ne: null },
+  }).lean();
+
+  for (const config of configs) {
+    try {
+      const job = await JiraSyncJob.create({
+        groupId: config.groupId,
+        sprintId: config.sprintId,
+        status: 'PENDING',
+        triggeredBy: 'system',
+      });
+
+      setImmediate(() => {
+        jiraSyncWorker(config.groupId, config.sprintId, job.jobId).catch((err) => {
+          console.error('[jiraSyncScheduler] Worker error:', err.message);
+        });
+      });
+    } catch (err) {
+      if (err.code !== 11000) {
+        console.error('[jiraSyncScheduler] Failed to enqueue job:', err.message);
+      }
+    }
+  }
+}
+
+function startJiraSyncScheduler() {
+  if (schedulerHandle || process.env.ENABLE_JIRA_SPRINT_SYNC_SCHEDULER !== 'true') {
+    return null;
+  }
+
+  const intervalMs = Number(process.env.JIRA_SPRINT_SYNC_INTERVAL_MS || 24 * 60 * 60 * 1000);
+  schedulerHandle = setInterval(() => {
+    enqueueEligibleSyncs().catch((err) => {
+      console.error('[jiraSyncScheduler] Tick failed:', err.message);
+    });
+  }, intervalMs);
+
+  return schedulerHandle;
+}
+
+function stopJiraSyncScheduler() {
+  if (schedulerHandle) {
+    clearInterval(schedulerHandle);
+    schedulerHandle = null;
+  }
+}
+
+module.exports = {
+  enqueueEligibleSyncs,
+  startJiraSyncScheduler,
+  stopJiraSyncScheduler,
+};

--- a/backend/src/services/jiraSyncService.js
+++ b/backend/src/services/jiraSyncService.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const mongoose = require('mongoose');
 const axios = require('axios');
 const Group = require('../models/Group');
 const SprintConfig = require('../models/SprintConfig');
@@ -30,7 +31,15 @@ async function withRetry(fn, maxAttempts = MAX_RETRY_ATTEMPTS) {
     try {
       return await fn();
     } catch (err) {
-      if (err.response?.status >= 400 && err.response?.status < 500) {
+      const status = err.response?.status;
+      const shouldRetry =
+        err.code === 'ECONNABORTED' ||
+        !status ||
+        status === 502 ||
+        status === 503 ||
+        status === 504;
+
+      if (!shouldRetry) {
         throw err;
       }
 
@@ -123,56 +132,84 @@ async function fetchSprintIssuesFromJira(config, sprintConfig) {
   const headers = createJiraAuthHeaders(config.email, decryptedToken);
   const storyPointFieldId = await discoverStoryPointField(config.baseUrl, headers);
   const jql = `project = "${config.projectKey}" AND sprint = "${sprintConfig.externalSprintKey}"`;
+  const issues = [];
+  let startAt = 0;
+  let total = 0;
 
-  const response = await withRetry(() =>
-    axios.get(`${config.baseUrl}/rest/api/3/search`, {
-      headers,
-      timeout: 8000,
-      params: {
-        jql,
-        maxResults: 100,
-        fields: `summary,status,assignee,${storyPointFieldId}`,
-      },
-    })
-  );
+  do {
+    const response = await withRetry(() =>
+      axios.get(`${config.baseUrl}/rest/api/3/search`, {
+        headers,
+        timeout: 8000,
+        params: {
+          jql,
+          startAt,
+          maxResults: 100,
+          fields: `summary,status,assignee,${storyPointFieldId}`,
+        },
+      })
+    );
+
+    const pageIssues = response.data?.issues || [];
+    total = Number(response.data?.total || pageIssues.length);
+    issues.push(...pageIssues);
+    startAt += pageIssues.length;
+
+    if (pageIssues.length === 0) {
+      break;
+    }
+  } while (issues.length < total);
 
   return {
-    issues: response.data?.issues || [],
+    issues,
     storyPointFieldId,
     jql,
   };
 }
 
 async function persistSprintIssues(groupId, sprintId, issues, storyPointFieldId) {
-  let upserted = 0;
+  const session = await mongoose.startSession();
 
-  for (const issue of issues) {
-    const fields = issue.fields || {};
-    const assignee = fields.assignee || {};
+  try {
+    await session.withTransaction(async () => {
+      if (issues.length === 0) {
+        return;
+      }
 
-    await SprintIssue.updateOne(
-      { groupId, sprintId, issueKey: issue.key },
-      {
-        $set: {
-          storyPoints: Number(fields[storyPointFieldId] || 0),
-          status: fields.status?.name || null,
-          assigneeAccountId: assignee.accountId || null,
-          assigneeDisplayName: assignee.displayName || null,
-          rawIssue: issue,
-          syncedAt: new Date(),
-        },
-        $setOnInsert: {
-          groupId,
-          sprintId,
-          issueKey: issue.key,
-        },
-      },
-      { upsert: true }
-    );
-    upserted++;
+      const operations = issues.map((issue) => {
+        const fields = issue.fields || {};
+        const assignee = fields.assignee || {};
+
+        return {
+          updateOne: {
+            filter: { groupId, sprintId, issueKey: issue.key },
+            update: {
+              $set: {
+                storyPoints: Number(fields[storyPointFieldId] || 0),
+                status: fields.status?.name || null,
+                assigneeAccountId: assignee.accountId || null,
+                assigneeDisplayName: assignee.displayName || null,
+                rawIssue: issue,
+                syncedAt: new Date(),
+              },
+              $setOnInsert: {
+                groupId,
+                sprintId,
+                issueKey: issue.key,
+              },
+            },
+            upsert: true,
+          },
+        };
+      });
+
+      await SprintIssue.bulkWrite(operations, { session });
+    });
+
+    return issues.length;
+  } finally {
+    await session.endSession();
   }
-
-  return upserted;
 }
 
 async function logSyncError(groupId, actorId, message) {

--- a/backend/src/services/jiraSyncService.js
+++ b/backend/src/services/jiraSyncService.js
@@ -1,0 +1,287 @@
+'use strict';
+
+const axios = require('axios');
+const Group = require('../models/Group');
+const SprintConfig = require('../models/SprintConfig');
+const SprintIssue = require('../models/SprintIssue');
+const JiraSyncJob = require('../models/JiraSyncJob');
+const SyncErrorLog = require('../models/SyncErrorLog');
+const { decrypt } = require('../utils/cryptoUtils');
+const { createAuditLog } = require('./auditService');
+
+const MAX_RETRY_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 200;
+
+class JiraSyncError extends Error {
+  constructor(status, code, message) {
+    super(message);
+    this.name = 'JiraSyncError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function withRetry(fn, maxAttempts = MAX_RETRY_ATTEMPTS) {
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err.response?.status >= 400 && err.response?.status < 500) {
+        throw err;
+      }
+
+      lastError = err;
+      if (attempt < maxAttempts) {
+        await sleep(RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+async function getJiraConfig(groupId) {
+  const group = await Group.findOne({ groupId }).lean();
+  if (!group) {
+    throw new JiraSyncError(404, 'GROUP_NOT_FOUND', `Group ${groupId} not found`);
+  }
+
+  if (!group.jiraUrl || !group.jiraUsername || !group.jiraToken || !group.projectKey) {
+    throw new JiraSyncError(400, 'INVALID_JIRA_CONFIGURATION', 'JIRA integration is not configured for this group');
+  }
+
+  return {
+    baseUrl: group.jiraUrl,
+    email: group.jiraUsername,
+    encryptedToken: group.jiraToken,
+    projectKey: group.projectKey,
+  };
+}
+
+async function getPublishedSprintConfig(groupId, sprintId) {
+  const config = await SprintConfig.findOne({
+    groupId,
+    sprintId,
+    configurationStatus: 'published',
+    deadline: { $gte: new Date() },
+  }).lean();
+
+  if (!config) {
+    throw new JiraSyncError(
+      422,
+      'SPRINT_CONFIG_NOT_PUBLISHED',
+      `No published sprint configuration found for group ${groupId} / sprint ${sprintId}`
+    );
+  }
+
+  if (!config.externalSprintKey) {
+    throw new JiraSyncError(
+      422,
+      'SPRINT_CONFIG_INCOMPLETE',
+      `Published sprint configuration for ${sprintId} is missing externalSprintKey`
+    );
+  }
+
+  return config;
+}
+
+function createJiraAuthHeaders(email, token) {
+  const auth = Buffer.from(`${email}:${token}`).toString('base64');
+  return {
+    Authorization: `Basic ${auth}`,
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+}
+
+async function discoverStoryPointField(baseUrl, headers) {
+  const response = await withRetry(() =>
+    axios.get(`${baseUrl}/rest/api/3/field`, {
+      headers,
+      timeout: 8000,
+    })
+  );
+
+  const matchingField = (response.data || []).find((field) => {
+    const normalizedName = String(field?.name || '').trim().toLowerCase();
+    return normalizedName === 'story points' || normalizedName === 'story point estimate';
+  });
+
+  if (!matchingField?.id) {
+    throw new JiraSyncError(502, 'JIRA_STORY_POINTS_FIELD_NOT_FOUND', 'JIRA story points field could not be resolved');
+  }
+
+  return matchingField.id;
+}
+
+async function fetchSprintIssuesFromJira(config, sprintConfig) {
+  const decryptedToken = decrypt(config.encryptedToken);
+  const headers = createJiraAuthHeaders(config.email, decryptedToken);
+  const storyPointFieldId = await discoverStoryPointField(config.baseUrl, headers);
+  const jql = `project = "${config.projectKey}" AND sprint = "${sprintConfig.externalSprintKey}"`;
+
+  const response = await withRetry(() =>
+    axios.get(`${config.baseUrl}/rest/api/3/search`, {
+      headers,
+      timeout: 8000,
+      params: {
+        jql,
+        maxResults: 100,
+        fields: `summary,status,assignee,${storyPointFieldId}`,
+      },
+    })
+  );
+
+  return {
+    issues: response.data?.issues || [],
+    storyPointFieldId,
+    jql,
+  };
+}
+
+async function persistSprintIssues(groupId, sprintId, issues, storyPointFieldId) {
+  let upserted = 0;
+
+  for (const issue of issues) {
+    const fields = issue.fields || {};
+    const assignee = fields.assignee || {};
+
+    await SprintIssue.updateOne(
+      { groupId, sprintId, issueKey: issue.key },
+      {
+        $set: {
+          storyPoints: Number(fields[storyPointFieldId] || 0),
+          status: fields.status?.name || null,
+          assigneeAccountId: assignee.accountId || null,
+          assigneeDisplayName: assignee.displayName || null,
+          rawIssue: issue,
+          syncedAt: new Date(),
+        },
+        $setOnInsert: {
+          groupId,
+          sprintId,
+          issueKey: issue.key,
+        },
+      },
+      { upsert: true }
+    );
+    upserted++;
+  }
+
+  return upserted;
+}
+
+async function logSyncError(groupId, actorId, message) {
+  await SyncErrorLog.create({
+    service: 'jira',
+    groupId,
+    actorId,
+    attempts: MAX_RETRY_ATTEMPTS,
+    lastError: message,
+  });
+}
+
+function classifyJiraFailure(err) {
+  if (err instanceof JiraSyncError) {
+    return err;
+  }
+
+  if (err.code === 'ECONNABORTED') {
+    return new JiraSyncError(504, 'GATEWAY_TIMEOUT', 'JIRA API timed out after maximum retry attempts');
+  }
+
+  if (err.response?.status >= 500) {
+    return new JiraSyncError(502, 'UPSTREAM_PROVIDER_ERROR', 'JIRA API returned an upstream error');
+  }
+
+  if (err.response?.status >= 400 && err.response?.status < 500) {
+    return new JiraSyncError(502, 'UPSTREAM_PROVIDER_ERROR', 'JIRA API returned an invalid response');
+  }
+
+  return new JiraSyncError(504, 'GATEWAY_TIMEOUT', 'JIRA API failed after retry exhaustion');
+}
+
+async function jiraSyncWorker(groupId, sprintId, jobId) {
+  const job = await JiraSyncJob.findOne({ jobId });
+  if (!job) {
+    return;
+  }
+
+  job.status = 'IN_PROGRESS';
+  job.startedAt = new Date();
+  await job.save();
+
+  try {
+    const config = await getJiraConfig(groupId);
+    const sprintConfig = await getPublishedSprintConfig(groupId, sprintId);
+    const { issues, storyPointFieldId, jql } = await fetchSprintIssuesFromJira(config, sprintConfig);
+    const upserted = await persistSprintIssues(groupId, sprintId, issues, storyPointFieldId);
+
+    job.status = 'COMPLETED';
+    job.issuesProcessed = issues.length;
+    job.issuesUpserted = upserted;
+    job.completedAt = new Date();
+    await job.save();
+
+    try {
+      await createAuditLog({
+        action: 'JIRA_SYNC_COMPLETED',
+        actorId: job.triggeredBy || 'system',
+        groupId,
+        targetId: jobId,
+        payload: {
+          sprintId,
+          jobId,
+          issuesProcessed: issues.length,
+          issuesUpserted: upserted,
+          externalSprintKey: sprintConfig.externalSprintKey,
+          jql,
+        },
+      });
+    } catch (auditErr) {
+      console.error('[jiraSyncWorker] Audit log failed (non-fatal):', auditErr.message);
+    }
+  } catch (err) {
+    const normalizedError = classifyJiraFailure(err);
+
+    job.status = 'FAILED';
+    job.completedAt = new Date();
+    job.errorCode = normalizedError.code;
+    job.errorMessage = normalizedError.message;
+    await job.save();
+
+    try {
+      await logSyncError(groupId, job.triggeredBy || 'system', normalizedError.message);
+    } catch (syncErr) {
+      console.error('[jiraSyncWorker] SyncErrorLog write failed (non-fatal):', syncErr.message);
+    }
+
+    try {
+      await createAuditLog({
+        action: 'JIRA_SYNC_FAILED',
+        actorId: job.triggeredBy || 'system',
+        groupId,
+        targetId: jobId,
+        payload: {
+          sprintId,
+          jobId,
+          errorCode: normalizedError.code,
+          errorMessage: normalizedError.message,
+        },
+      });
+    } catch (auditErr) {
+      console.error('[jiraSyncWorker] Audit log failed (non-fatal):', auditErr.message);
+    }
+  }
+}
+
+module.exports = {
+  JiraSyncError,
+  jiraSyncWorker,
+  getJiraConfig,
+  getPublishedSprintConfig,
+};

--- a/backend/src/utils/cryptoUtils.js
+++ b/backend/src/utils/cryptoUtils.js
@@ -15,10 +15,24 @@ const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
 
-// Fallback key for development only. In production, this must be in process.env.ENCRYPTION_KEY
-const KEY = process.env.ENCRYPTION_KEY 
-  ? Buffer.from(process.env.ENCRYPTION_KEY, 'hex') 
-  : Buffer.from('8f1e6f7c9a2b5d4e3f1a2c3d4e5f607182930415263748596071829304152637', 'hex');
+function resolveEncryptionKey() {
+  const configuredKey = process.env.ENCRYPTION_KEY;
+
+  if (configuredKey) {
+    if (!/^[0-9a-fA-F]{64}$/.test(configuredKey)) {
+      throw new Error('ENCRYPTION_KEY must be a 64-character hex string');
+    }
+    return Buffer.from(configuredKey, 'hex');
+  }
+
+  // Test runs still need deterministic crypto, but we avoid shipping a hardcoded fallback key.
+  if (process.env.NODE_ENV === 'test') {
+    const seed = process.env.JWT_SECRET || process.env.TEST_ENCRYPTION_SEED || 'test-seed';
+    return crypto.createHash('sha256').update(seed).digest();
+  }
+
+  throw new Error('ENCRYPTION_KEY is required for encryption/decryption outside test mode');
+}
 
 /**
  * Encrypts a string.
@@ -26,9 +40,10 @@ const KEY = process.env.ENCRYPTION_KEY
  */
 function encrypt(text) {
   if (!text) return null;
-  
+
+  const key = resolveEncryptionKey();
   const iv = crypto.randomBytes(IV_LENGTH);
-  const cipher = crypto.createCipheriv(ALGORITHM, KEY, iv);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
   
   let encrypted = cipher.update(text, 'utf8', 'hex');
   encrypted += cipher.final('hex');
@@ -44,23 +59,24 @@ function encrypt(text) {
  */
 function decrypt(ciphertext) {
   if (!ciphertext) return null;
-  
+
   try {
     const [ivHex, authTagHex, encryptedHex] = ciphertext.split(':');
     if (!ivHex || !authTagHex || !encryptedHex) {
       // If it doesn't match our format, it might be legacy plain text (for migration safety)
       return ciphertext;
     }
-    
+
+    const key = resolveEncryptionKey();
     const iv = Buffer.from(ivHex, 'hex');
     const authTag = Buffer.from(authTagHex, 'hex');
-    const decipher = crypto.createDecipheriv(ALGORITHM, KEY, iv);
-    
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+
     decipher.setAuthTag(authTag);
-    
+
     let decrypted = decipher.update(encryptedHex, 'hex', 'utf8');
     decrypted += decipher.final('utf8');
-    
+
     return decrypted;
   } catch (err) {
     console.error('[cryptoUtils] Decryption failed:', err.message);

--- a/backend/tests/github-sync.test.js
+++ b/backend/tests/github-sync.test.js
@@ -35,6 +35,7 @@ const Group = require('../src/models/Group');
 const SprintRecord = require('../src/models/SprintRecord');
 const ContributionRecord = require('../src/models/ContributionRecord');
 const GitHubSyncJob = require('../src/models/GitHubSyncJob');
+const SprintIssue = require('../src/models/SprintIssue');
 const AuditLog = require('../src/models/AuditLog');
 const { encrypt } = require('../src/utils/cryptoUtils');
 
@@ -248,6 +249,24 @@ describe('Process 7.2 — GitHub PR Sync', () => {
       expect(issues.length).toBeGreaterThanOrEqual(2);
       expect(issues.map((i) => i.key)).toContain('del_001');
       expect(issues.map((i) => i.key)).toContain('del_002');
+    });
+
+    it('prefers canonical SprintIssue rows from Process 7.1 when present', async () => {
+      const groupId = unique('grp');
+      const sprintId = unique('spr');
+
+      await SprintIssue.create({
+        groupId,
+        sprintId,
+        issueKey: 'SPM-777',
+        storyPoints: 8,
+        status: 'Done',
+      });
+
+      const { getSprintIssues: gsi } = require('../src/services/githubSyncService');
+      const issues = await gsi(sprintId, groupId);
+
+      expect(issues.some((issue) => issue.key === 'SPM-777' && issue.source === 'sprint_issue')).toBe(true);
     });
 
     it('supplements with ContributionRecord entries', async () => {

--- a/backend/tests/jira-sync.test.js
+++ b/backend/tests/jira-sync.test.js
@@ -1,0 +1,354 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'jira-sync-test-secret';
+
+jest.mock('axios');
+const axios = require('axios');
+
+const mongoose = require('mongoose');
+const request = require('supertest');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const { generateAccessToken } = require('../src/utils/jwt');
+const { encrypt } = require('../src/utils/cryptoUtils');
+const Group = require('../src/models/Group');
+const SprintConfig = require('../src/models/SprintConfig');
+const SprintIssue = require('../src/models/SprintIssue');
+const JiraSyncJob = require('../src/models/JiraSyncJob');
+const SyncErrorLog = require('../src/models/SyncErrorLog');
+const { enqueueEligibleSyncs, stopJiraSyncScheduler } = require('../src/services/jiraSyncScheduler');
+
+let mongod;
+let app;
+
+const API = '/api/v1';
+const unique = (prefix) => `${prefix}_${Date.now()}_${Math.floor(Math.random() * 1e9)}`;
+
+function tokenFor(role, userId = unique(role)) {
+  return { userId, token: generateAccessToken(userId, role) };
+}
+
+async function clearAllCollections() {
+  const { collections } = mongoose.connection;
+  await Promise.all(Object.values(collections).map((collection) => collection.deleteMany({})));
+}
+
+async function seedJiraGroup(overrides = {}) {
+  const groupId = overrides.groupId || unique('grp');
+  const leaderId = overrides.leaderId || unique('lead');
+
+  const group = await Group.create({
+    groupId,
+    groupName: unique('GroupJira'),
+    leaderId,
+    status: 'active',
+    members: [{ userId: leaderId, role: 'leader', status: 'accepted' }],
+    jiraUrl: 'https://example.atlassian.net',
+    jiraUsername: 'jira@example.com',
+    jiraToken: encrypt('jira-token'),
+    projectKey: 'SPM',
+    ...overrides.groupFields,
+  });
+
+  return { group, groupId, leaderId };
+}
+
+async function seedSprintConfig(groupId, sprintId, overrides = {}) {
+  return SprintConfig.create({
+    groupId,
+    sprintId,
+    deliverableType: 'proposal',
+    deadline: overrides.deadline || new Date(Date.now() + 60_000),
+    configurationStatus: overrides.configurationStatus || 'published',
+    publishedAt: overrides.publishedAt || new Date(),
+    externalSprintKey: overrides.externalSprintKey || 'Sprint 12',
+    description: overrides.description || 'test sprint',
+  });
+}
+
+async function waitForJobToSettle(jobId, maxMs = 6000) {
+  const start = Date.now();
+  while (Date.now() - start < maxMs) {
+    const job = await JiraSyncJob.findOne({ jobId }).lean();
+    if (job && !['PENDING', 'IN_PROGRESS'].includes(job.status)) {
+      return job;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return JiraSyncJob.findOne({ jobId }).lean();
+}
+
+describe('Process 7.1 - JIRA Sprint Sync', () => {
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+    app = require('../src/index');
+  }, 60000);
+
+  afterAll(async () => {
+    stopJiraSyncScheduler();
+    await mongoose.disconnect();
+    if (mongod) {
+      await mongod.stop();
+    }
+  });
+
+  afterEach(async () => {
+    await clearAllCollections();
+    jest.clearAllMocks();
+    axios.get.mockReset && axios.get.mockReset();
+  });
+
+  describe('POST /groups/:groupId/sprints/:sprintId/jira-sync', () => {
+    it('returns 401 when authorization is missing', async () => {
+      const res = await request(app).post(`${API}/groups/grp_x/sprints/spr_x/jira-sync`);
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 403 for non-coordinator callers', async () => {
+      const { token } = tokenFor('student');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId);
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 422 when no published sprint config exists', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toBe('SPRINT_CONFIG_NOT_PUBLISHED');
+    });
+
+    it('returns 422 when config exists but is still draft', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId, { configurationStatus: 'draft' });
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(422);
+      expect(res.body.error).toBe('SPRINT_CONFIG_NOT_PUBLISHED');
+    });
+
+    it('returns 202 with queued status for a valid request', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId);
+
+      axios.get
+        .mockResolvedValueOnce({
+          data: [{ id: 'customfield_10016', name: 'Story Points' }],
+        })
+        .mockResolvedValueOnce({
+          data: { issues: [] },
+        });
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(202);
+      expect(res.body.jobId).toBeTruthy();
+      expect(res.body.status).toBe('queued');
+      expect(res.body.source).toBe('jira');
+    });
+
+    it('returns 409 when a sync job is already active', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId);
+      await JiraSyncJob.create({ groupId, sprintId, status: 'IN_PROGRESS', triggeredBy: 'coord_seed' });
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).toBe(409);
+      expect(res.body.error).toBe('SYNC_ALREADY_RUNNING');
+    });
+
+    it('persists sprint issues into D6 after a successful sync', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId, { externalSprintKey: 'Sprint Alpha' });
+
+      axios.get
+        .mockResolvedValueOnce({
+          data: [{ id: 'customfield_10016', name: 'Story Points' }],
+        })
+        .mockResolvedValueOnce({
+          data: {
+            issues: [
+              {
+                key: 'SPM-101',
+                fields: {
+                  customfield_10016: 5,
+                  status: { name: 'Done' },
+                  assignee: { accountId: 'acc_1', displayName: 'Alice' },
+                },
+              },
+              {
+                key: 'SPM-102',
+                fields: {
+                  customfield_10016: 3,
+                  status: { name: 'In Progress' },
+                  assignee: { accountId: 'acc_2', displayName: 'Bob' },
+                },
+              },
+            ],
+          },
+        });
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      const settled = await waitForJobToSettle(res.body.jobId);
+      const issues = await SprintIssue.find({ groupId, sprintId }).sort({ issueKey: 1 }).lean();
+
+      expect(settled.status).toBe('COMPLETED');
+      expect(issues).toHaveLength(2);
+      expect(issues[0].issueKey).toBe('SPM-101');
+      expect(issues[0].storyPoints).toBe(5);
+      expect(issues[1].issueKey).toBe('SPM-102');
+      expect(issues[1].assigneeDisplayName).toBe('Bob');
+    });
+
+    it('retries transient upstream errors and eventually succeeds', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId);
+
+      let attempts = 0;
+      const transientError = Object.assign(new Error('Service Unavailable'), {
+        response: { status: 503 },
+      });
+
+      axios.get = jest.fn().mockImplementation(() => {
+        attempts++;
+        if (attempts <= 2) {
+          return Promise.reject(transientError);
+        }
+        if (attempts === 3) {
+          return Promise.resolve({
+            data: [{ id: 'customfield_10016', name: 'Story Points' }],
+          });
+        }
+        return Promise.resolve({ data: { issues: [] } });
+      });
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      const settled = await waitForJobToSettle(res.body.jobId, 8000);
+
+      expect(settled.status).toBe('COMPLETED');
+      expect(attempts).toBeGreaterThanOrEqual(4);
+    }, 12000);
+
+    it('marks the job failed with gateway timeout and writes SyncErrorLog after retry exhaustion', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId);
+
+      const timeoutError = Object.assign(new Error('timeout'), { code: 'ECONNABORTED' });
+      axios.get = jest.fn().mockRejectedValue(timeoutError);
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      const settled = await waitForJobToSettle(res.body.jobId, 8000);
+      const syncErr = await SyncErrorLog.findOne({ groupId, service: 'jira' }).lean();
+
+      expect(settled.status).toBe('FAILED');
+      expect(settled.errorCode).toBe('GATEWAY_TIMEOUT');
+      expect(syncErr).toBeTruthy();
+    }, 12000);
+
+    it('marks the job failed with upstream provider error on persistent 5xx failures', async () => {
+      const { token } = tokenFor('coordinator');
+      const { groupId } = await seedJiraGroup();
+      const sprintId = unique('spr');
+      await seedSprintConfig(groupId, sprintId);
+
+      const serverError = Object.assign(new Error('bad gateway'), {
+        response: { status: 503 },
+      });
+      axios.get = jest.fn().mockRejectedValue(serverError);
+
+      const res = await request(app)
+        .post(`${API}/groups/${groupId}/sprints/${sprintId}/jira-sync`)
+        .set('Authorization', `Bearer ${token}`);
+
+      const settled = await waitForJobToSettle(res.body.jobId, 8000);
+
+      expect(settled.status).toBe('FAILED');
+      expect(settled.errorCode).toBe('UPSTREAM_PROVIDER_ERROR');
+    }, 12000);
+  });
+
+  describe('scheduler', () => {
+    it('enqueues only published, non-expired configs', async () => {
+      const { groupId } = await seedJiraGroup({ groupId: 'grp_sched_a' });
+      const sprintId = 'spr_sched_a';
+      await seedSprintConfig(groupId, sprintId);
+      await seedSprintConfig('grp_sched_b', 'spr_sched_b', {
+        configurationStatus: 'draft',
+      });
+      await seedSprintConfig('grp_sched_c', 'spr_sched_c', {
+        deadline: new Date(Date.now() - 60_000),
+      });
+
+      axios.get
+        .mockResolvedValueOnce({ data: [{ id: 'customfield_10016', name: 'Story Points' }] })
+        .mockResolvedValueOnce({ data: { issues: [] } });
+
+      await enqueueEligibleSyncs();
+
+      const jobs = await JiraSyncJob.find({}).lean();
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].groupId).toBe(groupId);
+      expect(jobs[0].sprintId).toBe(sprintId);
+    });
+
+    it('is idempotent when an active lock already exists', async () => {
+      const { groupId } = await seedJiraGroup({ groupId: 'grp_sched_lock' });
+      const sprintId = 'spr_sched_lock';
+      await seedSprintConfig(groupId, sprintId);
+      await JiraSyncJob.create({
+        groupId,
+        sprintId,
+        status: 'IN_PROGRESS',
+        triggeredBy: 'system',
+      });
+
+      await enqueueEligibleSyncs();
+
+      const jobs = await JiraSyncJob.find({ groupId, sprintId }).lean();
+      expect(jobs).toHaveLength(1);
+    });
+  });
+});

--- a/backend/tests/multi-issue-mapping.test.js
+++ b/backend/tests/multi-issue-mapping.test.js
@@ -1,0 +1,198 @@
+/**
+ * multi-issue-mapping.test.js — Verification for [H1] Multi-Issue Mapping Data Loss
+ */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = 'test-secret';
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const ContributionRecord = require('../src/models/ContributionRecord');
+const { githubSyncWorker } = require('../src/services/githubSyncService');
+const GitHubSyncJob = require('../src/models/GitHubSyncJob');
+const Group = require('../src/models/Group');
+const SprintRecord = require('../src/models/SprintRecord');
+const User = require('../src/models/User');
+const { encrypt } = require('../src/utils/cryptoUtils');
+const { generateAccessToken } = require('../src/utils/jwt');
+const request = require('supertest');
+
+// Mock axios for GitHub API calls
+jest.mock('axios');
+const axios = require('axios');
+
+let app;
+
+describe('Multi-Issue Mapping Verification', () => {
+  let mongod;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+    app = require('../src/index');
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongod.stop();
+  });
+
+  it('should store multiple jiraIssueKeys in ContributionRecord', async () => {
+    const sprintId = 'spr-1';
+    const studentId = 'stu-1';
+    const groupId = 'grp-1';
+
+    // Directly create a record with multiple keys to test the model
+    const record = await ContributionRecord.create({
+      sprintId,
+      studentId,
+      groupId,
+      jiraIssueKeys: ['ISSUE-1', 'ISSUE-2'],
+      storyPointsAssigned: 10,
+    });
+
+    expect(record.jiraIssueKeys).toContain('ISSUE-1');
+    expect(record.jiraIssueKeys).toContain('ISSUE-2');
+    expect(Array.isArray(record.jiraIssueKeys)).toBe(true);
+  });
+
+  it('githubSyncWorker should process all jiraIssueKeys', async () => {
+    const sprintId = 'spr-2';
+    const studentId = 'stu-2';
+    const groupId = 'grp-2';
+    const jobId = 'job-1';
+
+    // Setup Group
+    await Group.create({
+      groupId,
+      groupName: 'Test Group',
+      leaderId: 'lead-1',
+      status: 'active',
+      githubOrg: 'org',
+      githubRepoName: 'repo',
+      githubPat: encrypt('pat'),
+    });
+
+    // Setup SprintRecord
+    await SprintRecord.create({
+      sprintId,
+      groupId,
+      deliverableRefs: [],
+    });
+
+    // Setup ContributionRecord with 2 keys
+    await ContributionRecord.create({
+      sprintId,
+      studentId,
+      groupId,
+      jiraIssueKeys: ['ISSUE-A', 'ISSUE-B'],
+    });
+
+    // Setup GitHubSyncJob
+    await GitHubSyncJob.create({
+      jobId,
+      groupId,
+      sprintId,
+      status: 'PENDING',
+    });
+
+    // Mock axios to return merged PR for ISSUE-A and NOT_FOUND for ISSUE-B
+    axios.get.mockImplementation((url, config) => {
+      if (config.params?.head?.includes('ISSUE-A')) {
+        return Promise.resolve({
+          data: [{ number: 1, html_url: 'url1', merged: true, merge_state: 'merged' }]
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    // Run worker
+    await githubSyncWorker(groupId, sprintId, jobId);
+
+    // Verify job results
+    const job = await GitHubSyncJob.findOne({ jobId });
+    expect(job.status).toBe('COMPLETED');
+    
+    const issueA = job.validationRecords.find(r => r.issueKey === 'ISSUE-A');
+    const issueB = job.validationRecords.find(r => r.issueKey === 'ISSUE-B');
+    
+    expect(issueA.mergeStatus).toBe('MERGED');
+    expect(issueB.mergeStatus).toBe('UNKNOWN');
+  });
+
+  it('recalculateContributions should calculate proportional SP for multiple keys', async () => {
+    const sprintId = 'spr-3';
+    const groupId = 'grp-3';
+    const studentId = 'stu-3';
+    const coordinatorId = 'coord-1';
+
+    // Setup Users
+    await User.create({
+      userId: studentId,
+      email: 'stu3@test.com',
+      role: 'student',
+      accountStatus: 'active',
+      hashedPassword: 'hash'
+    });
+    await User.create({
+      userId: coordinatorId,
+      email: 'coord1@test.com',
+      role: 'coordinator',
+      accountStatus: 'active',
+      hashedPassword: 'hash'
+    });
+
+    const token = generateAccessToken(coordinatorId, 'coordinator');
+
+    // Setup Group
+    await Group.create({
+      groupId,
+      groupName: 'Test Group 3',
+      leaderId: studentId,
+      status: 'active',
+      members: [{ userId: studentId, role: 'leader', status: 'accepted' }]
+    });
+
+    // Setup ContributionRecord with 2 keys and 10 SP
+    await ContributionRecord.create({
+      sprintId,
+      studentId,
+      groupId,
+      jiraIssueKeys: ['ISSUE-1', 'ISSUE-2'],
+      storyPointsAssigned: 10,
+    });
+
+    // Setup GitHubSyncJob with ISSUE-1 MERGED
+    await GitHubSyncJob.create({
+      jobId: 'job-sync-3',
+      groupId,
+      sprintId,
+      status: 'COMPLETED',
+      validationRecords: [
+        {
+          issueKey: 'ISSUE-1',
+          mergeStatus: 'MERGED',
+          lastValidated: new Date()
+        },
+        {
+          issueKey: 'ISSUE-2',
+          mergeStatus: 'NOT_MERGED',
+          lastValidated: new Date()
+        }
+      ]
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/groups/${groupId}/sprints/${sprintId}/contributions/recalculate`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    const contrib = res.body.contributions.find(c => c.studentId === studentId);
+    
+    // Proportional SP: (1 merged / 2 total) * 10 SP = 5 SP
+    expect(contrib.completedStoryPoints).toBe(5);
+    expect(contrib.mappingWarnings).toContain('Mapped issue ISSUE-2 is not merged in latest GitHub sync.');
+  });
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -29,10 +29,11 @@ import DeliverableSubmissionForm from './components/DeliverableSubmissionForm.js
 import SubmitDeliverablePage from './pages/SubmitDeliverablePage.jsx';
 import ReviewPage from './pages/ReviewPage.jsx';
 import ReviewManagement from './pages/ReviewManagement.jsx';
+import CoordinatorSprintDashboard from './pages/CoordinatorSprintDashboard.jsx';
 
 
 const Profile = () => <div className="page">Profile - Coming Soon</div>;
-const Unauthorized = () => <div className="page error">Unauthorized Access</div>;
+const Unauthorized = () => <div className="page error">403 Forbidden - Coordinator access required</div>;
 const NotFound = () => <div className="page error">Page Not Found</div>;
 
 function App() {
@@ -81,6 +82,10 @@ function App() {
             <Route
               path="/coordinator"
               element={<ProtectedRoute component={CoordinatorPanel} requiredRoles={['coordinator', 'admin']} />}
+            />
+            <Route
+              path="/coordinator/sprint-dashboard"
+              element={<ProtectedRoute component={CoordinatorSprintDashboard} requiredRoles={['coordinator']} />}
             />
 
             {/* Committee Routes from main */}

--- a/frontend/src/api/sprintTrackingService.js
+++ b/frontend/src/api/sprintTrackingService.js
@@ -1,0 +1,216 @@
+import apiClient from './apiClient';
+import { TERMINAL_JOB_STATUSES } from '../types/sprintTracking';
+
+const STATUS_POLL_INTERVAL_MS = 2500;
+const STATUS_POLL_MAX_MS = 120000;
+const STATUS_POLL_MAX_CONSECUTIVE_ERRORS = 5;
+
+const toLower = (value) => (typeof value === 'string' ? value.toLowerCase() : '');
+
+const normalizeStatus = (rawStatus) => {
+  const status = toLower(rawStatus);
+  if (status === 'pending' || status === 'queued') return 'queued';
+  if (status === 'in_progress' || status === 'running') return 'running';
+  if (status === 'completed') return 'completed';
+  if (status === 'failed') return 'failed';
+  return 'queued';
+};
+
+const deriveProgress = (status) => {
+  if (status === 'queued') return 20;
+  if (status === 'running') return 65;
+  if (status === 'completed') return 100;
+  return 100;
+};
+
+const normalizeSyncJob = (source, payload = {}) => {
+  const status = normalizeStatus(payload.status);
+  return {
+    jobId: payload.jobId || payload.job_id || '',
+    status,
+    source,
+    message: payload.message || null,
+    startedAt: payload.startedAt || null,
+    completedAt: payload.completedAt || null,
+    createdAt: payload.createdAt || null,
+    updatedAt: payload.updatedAt || null,
+    errorCode: payload.errorCode || payload.error_code || null,
+    lastError: payload.last_error || payload.errorMessage || payload.message || null,
+    validationRecords: Array.isArray(payload.validationRecords) ? payload.validationRecords : [],
+    progress: deriveProgress(status),
+  };
+};
+
+const buildJiraPayload = ({ coordinatorId, jiraBoardId, sprintKey }) => ({
+  coordinatorId,
+  jiraBoardId,
+  sprintKey,
+  retryOnFailure: true,
+  notifyOnCompletion: false,
+});
+
+const buildGithubPayload = ({ coordinatorId, repositorySlug }) => ({
+  coordinatorId,
+  repositorySlug,
+  revalidateAll: false,
+});
+
+const buildRecalculatePayload = ({ triggeredBy }) => ({
+  triggeredBy,
+  overrideExisting: true,
+  notifyStudents: false,
+  useRubricWeights: true,
+});
+
+export const triggerJiraSync = async ({ groupId, sprintId, coordinatorId, jiraBoardId, sprintKey }) => {
+  const response = await apiClient.post(
+    `/groups/${groupId}/sprints/${sprintId}/jira-sync`,
+    buildJiraPayload({ coordinatorId, jiraBoardId, sprintKey })
+  );
+  return normalizeSyncJob('jira', response.data);
+};
+
+export const triggerGithubSync = async ({ groupId, sprintId, coordinatorId, repositorySlug }) => {
+  const response = await apiClient.post(
+    `/groups/${groupId}/sprints/${sprintId}/github-sync`,
+    buildGithubPayload({ coordinatorId, repositorySlug })
+  );
+  return normalizeSyncJob('github', response.data);
+};
+
+export const getLatestSyncJob = async ({ source, groupId, sprintId }) => {
+  const response = await apiClient.get(`/groups/${groupId}/sprints/${sprintId}/${source}-sync`);
+  return normalizeSyncJob(source, response.data);
+};
+
+export const getSyncJobById = async ({ source, groupId, sprintId, jobId }) => {
+  const response = await apiClient.get(`/groups/${groupId}/sprints/${sprintId}/${source}-sync/${jobId}`);
+  return normalizeSyncJob(source, response.data);
+};
+
+export const getSyncJobLogs = async ({ source, groupId, sprintId, jobId }) => {
+  const response = await apiClient.get(`/groups/${groupId}/sprints/${sprintId}/${source}-sync/${jobId}/logs`);
+  const data = response.data || {};
+  return {
+    jobId: data.jobId || jobId,
+    source,
+    status: normalizeStatus(data.status),
+    logs: Array.isArray(data.logs) ? data.logs : [],
+  };
+};
+
+export const pollSyncJobUntilTerminal = async ({ source, groupId, sprintId, jobId, onTick }) => {
+  const startedAt = Date.now();
+  let consecutiveErrors = 0;
+
+  while (Date.now() - startedAt < STATUS_POLL_MAX_MS) {
+    try {
+      const job = jobId
+        ? await getSyncJobById({ source, groupId, sprintId, jobId })
+        : await getLatestSyncJob({ source, groupId, sprintId });
+
+      consecutiveErrors = 0;
+
+      if (typeof onTick === 'function') {
+        onTick(job);
+      }
+
+      if (TERMINAL_JOB_STATUSES.includes(job.status)) {
+        return job;
+      }
+    } catch (error) {
+      consecutiveErrors += 1;
+      const status = error?.response?.status;
+      const shouldFailImmediately = status >= 400 && status < 500 && status !== 429;
+
+      if (shouldFailImmediately || consecutiveErrors >= STATUS_POLL_MAX_CONSECUTIVE_ERRORS) {
+        return {
+          jobId: jobId || '',
+          status: 'failed',
+          source,
+          message: error?.response?.data?.message || error?.message || 'Polling failed due to repeated errors.',
+          startedAt: null,
+          completedAt: null,
+          createdAt: null,
+          updatedAt: null,
+          errorCode: error?.response?.data?.error || (shouldFailImmediately ? 'POLL_CLIENT_ERROR' : 'POLL_RETRY_EXHAUSTED'),
+          lastError: error?.response?.data?.message || error?.message || 'Polling failed due to repeated errors.',
+          progress: 100,
+        };
+      }
+    }
+
+    const adaptiveDelay = STATUS_POLL_INTERVAL_MS * (1 + Math.min(consecutiveErrors, 3));
+    await new Promise((resolve) => setTimeout(resolve, adaptiveDelay));
+  }
+
+  return {
+    jobId: jobId || '',
+    status: 'failed',
+    source,
+    message: 'Polling timed out before job reached a terminal state.',
+    startedAt: null,
+    completedAt: null,
+    createdAt: null,
+    updatedAt: null,
+    errorCode: 'POLL_TIMEOUT',
+    lastError: 'Polling timed out before job reached a terminal state.',
+    progress: 100,
+  };
+};
+
+const extractWarnings = (entry = {}) => {
+  const warningFields = [entry.mappingWarnings, entry.warnings, entry.warningMessages, entry.warning];
+  return warningFields
+    .flatMap((item) => (Array.isArray(item) ? item : item ? [String(item)] : []))
+    .filter(Boolean);
+};
+
+const deriveWarningCount = (entry = {}, warnings = []) => {
+  const explicitCount =
+    entry.mappingWarningsCount ??
+    entry.mappingWarningCount ??
+    entry.warningsCount ??
+    entry.warningCount;
+  const numericCount = Number(explicitCount);
+  if (Number.isFinite(numericCount) && numericCount >= 0) {
+    return Math.trunc(numericCount);
+  }
+  return warnings.length;
+};
+
+const normalizeContributionRow = (entry = {}) => {
+  const warnings = extractWarnings(entry);
+  return {
+    studentId: entry.studentId || '',
+    studentName: entry.studentName || entry.githubUsername || entry.studentId || 'Unknown',
+    completedStoryPoints: Number(entry.completedStoryPoints || 0),
+    targetStoryPoints: Number(entry.targetStoryPoints || 0),
+    contributionRatio: Number(entry.contributionRatio || 0),
+    mappingWarningsCount: deriveWarningCount(entry, warnings),
+    warnings,
+  };
+};
+
+export const recalculateContributions = async ({ groupId, sprintId, triggeredBy }) => {
+  const response = await apiClient.post(
+    `/groups/${groupId}/sprints/${sprintId}/contributions/recalculate`,
+    buildRecalculatePayload({ triggeredBy })
+  );
+
+  const data = response.data || {};
+  const warnings = Array.isArray(data.warnings) ? data.warnings : [];
+
+  return {
+    groupId: data.groupId || groupId,
+    sprintId: data.sprintId || sprintId,
+    recalculatedAt: data.recalculatedAt || new Date().toISOString(),
+    basedOnTargets: Boolean(data.basedOnTargets),
+    contributions: Array.isArray(data.contributions) ? data.contributions.map(normalizeContributionRow) : [],
+    summaryWarnings: warnings,
+    summaryMessage:
+      data.summary ||
+      data.message ||
+      `Recalculated ${Array.isArray(data.contributions) ? data.contributions.length : 0} student contribution records.`,
+  };
+};

--- a/frontend/src/components/coordinator-sprint/ContributionResultsTable.jsx
+++ b/frontend/src/components/coordinator-sprint/ContributionResultsTable.jsx
@@ -1,0 +1,129 @@
+import React, { useMemo, useState } from 'react';
+
+const formatRatio = (value) => `${(Number(value || 0) * 100).toFixed(1)}%`;
+
+const ContributionResultsTable = ({ summary }) => {
+  const rows = summary?.contributions || [];
+  const [searchTerm, setSearchTerm] = useState('');
+  const [warningsOnly, setWarningsOnly] = useState(false);
+  const [sortBy, setSortBy] = useState('ratio_desc');
+
+  const filteredAndSortedRows = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+
+    const filtered = rows.filter((row) => {
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        String(row.studentName || '')
+          .toLowerCase()
+          .includes(normalizedSearch) ||
+        String(row.studentId || '')
+          .toLowerCase()
+          .includes(normalizedSearch);
+      const matchesWarnings = !warningsOnly || Number(row.mappingWarningsCount || 0) > 0;
+      return matchesSearch && matchesWarnings;
+    });
+
+    const sorted = [...filtered];
+    if (sortBy === 'name_asc') {
+      sorted.sort((a, b) => String(a.studentName || '').localeCompare(String(b.studentName || '')));
+    } else if (sortBy === 'completed_desc') {
+      sorted.sort((a, b) => Number(b.completedStoryPoints || 0) - Number(a.completedStoryPoints || 0));
+    } else if (sortBy === 'target_desc') {
+      sorted.sort((a, b) => Number(b.targetStoryPoints || 0) - Number(a.targetStoryPoints || 0));
+    } else if (sortBy === 'warnings_desc') {
+      sorted.sort((a, b) => Number(b.mappingWarningsCount || 0) - Number(a.mappingWarningsCount || 0));
+    } else {
+      sorted.sort((a, b) => Number(b.contributionRatio || 0) - Number(a.contributionRatio || 0));
+    }
+
+    return sorted;
+  }, [rows, searchTerm, warningsOnly, sortBy]);
+
+  return (
+    <section className="bg-white rounded-lg shadow-sm border border-slate-200 p-5">
+      <h2 className="text-lg font-semibold text-slate-900 mb-2">Contribution Results</h2>
+
+      {summary && (
+        <div className="mb-4 rounded-md bg-slate-50 border border-slate-200 p-3">
+          <p className="text-sm text-slate-800">{summary.summaryMessage}</p>
+          <p className="text-xs text-slate-500 mt-1">Recalculated at: {new Date(summary.recalculatedAt).toLocaleString()}</p>
+          {summary.summaryWarnings?.length > 0 && (
+            <ul className="mt-2 text-xs text-amber-700 list-disc pl-5">
+              {summary.summaryWarnings.map((warning, index) => (
+                <li key={`${warning}-${index}`}>{warning}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-slate-500">Run recalculation to see per-student contribution metrics.</p>
+      ) : (
+        <div>
+          <div className="mb-3 flex flex-col md:flex-row gap-3 md:items-center md:justify-between">
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(event) => setSearchTerm(event.target.value)}
+              placeholder="Filter by student name or ID"
+              className="w-full md:max-w-xs rounded-md border border-slate-300 px-3 py-2 text-sm"
+            />
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={warningsOnly}
+                  onChange={(event) => setWarningsOnly(event.target.checked)}
+                />
+                Warnings only
+              </label>
+              <select
+                value={sortBy}
+                onChange={(event) => setSortBy(event.target.value)}
+                className="rounded-md border border-slate-300 px-2 py-2 text-sm"
+              >
+                <option value="ratio_desc">Sort: Ratio (high to low)</option>
+                <option value="name_asc">Sort: Name (A-Z)</option>
+                <option value="completed_desc">Sort: Completed SP</option>
+                <option value="target_desc">Sort: Target SP</option>
+                <option value="warnings_desc">Sort: Warnings</option>
+              </select>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border-collapse">
+            <thead>
+              <tr className="bg-slate-50 border-b border-slate-200">
+                <th className="text-left px-3 py-2 font-semibold text-slate-700">Student Name</th>
+                <th className="text-left px-3 py-2 font-semibold text-slate-700">Completed SP</th>
+                <th className="text-left px-3 py-2 font-semibold text-slate-700">Target SP</th>
+                <th className="text-left px-3 py-2 font-semibold text-slate-700">Ratio</th>
+                <th className="text-left px-3 py-2 font-semibold text-slate-700">Mapping Warnings</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredAndSortedRows.map((row) => (
+                <tr key={row.studentId} className="border-b border-slate-100">
+                  <td className="px-3 py-2 text-slate-800">{row.studentName}</td>
+                  <td className="px-3 py-2 text-slate-700">{row.completedStoryPoints}</td>
+                  <td className="px-3 py-2 text-slate-700">{row.targetStoryPoints}</td>
+                  <td className="px-3 py-2 text-slate-700">{formatRatio(row.contributionRatio)}</td>
+                  <td className="px-3 py-2 text-slate-700">{row.mappingWarningsCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          </div>
+          {filteredAndSortedRows.length === 0 && (
+            <p className="text-sm text-slate-500 mt-3">No students match the selected filter.</p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ContributionResultsTable;

--- a/frontend/src/components/coordinator-sprint/JobStatusPanel.jsx
+++ b/frontend/src/components/coordinator-sprint/JobStatusPanel.jsx
@@ -48,46 +48,57 @@ const JobStatusPanel = ({ jobs, onViewLogs, logDetailsBySource = {} }) => {
               <div className="mt-3 rounded-md bg-red-50 border border-red-200 p-3">
                 <p className="text-sm font-medium text-red-700 mb-1">Last error</p>
                 <p className="text-xs text-red-700">{job.lastError}</p>
+              </div>
+            )}
+
+            {(job.status === 'completed' || job.status === 'failed') && (
+              <div className="mt-3">
                 <button
                   type="button"
                   onClick={() => onViewLogs?.(job)}
-                  className="text-xs underline text-red-700 mt-2 inline-block"
+                  className="text-xs font-medium text-indigo-600 hover:text-indigo-800 underline transition-colors"
                 >
-                  View Logs
+                  {logDetailsBySource[job.source] ? 'Hide Logs' : 'View Logs'}
                 </button>
+              </div>
+            )}
 
-                {logDetailsBySource[job.source] && (
-                  <div className="mt-2 rounded bg-white border border-red-100 p-2">
-                    <p className="text-xs text-slate-700">
-                      Error Code: {logDetailsBySource[job.source].errorCode || 'N/A'}
+            {logDetailsBySource[job.source] && (
+              <div className="mt-3 rounded-md bg-slate-50 border border-slate-200 p-3">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-2 mb-2">
+                  <p className="text-xs text-slate-700 font-medium">
+                    Status Code: <span className="font-normal">{logDetailsBySource[job.source].errorCode || 'SUCCESS'}</span>
+                  </p>
+                  {logDetailsBySource[job.source].errorMessage && (
+                    <p className="text-xs text-red-600 font-medium">
+                      Error: <span className="font-normal">{logDetailsBySource[job.source].errorMessage}</span>
                     </p>
-                    <p className="text-xs text-slate-700">
-                      Started: {formatDate(logDetailsBySource[job.source].startedAt)}
+                  )}
+                </div>
+                
+                {Array.isArray(logDetailsBySource[job.source].validationRecords) &&
+                  logDetailsBySource[job.source].validationRecords.length > 0 && (
+                    <p className="text-xs text-slate-700 mb-2">
+                      Validation records: <span className="font-semibold">{logDetailsBySource[job.source].validationRecords.length}</span>
                     </p>
-                    <p className="text-xs text-slate-700">
-                      Ended: {formatDate(logDetailsBySource[job.source].completedAt)}
-                    </p>
-                    {Array.isArray(logDetailsBySource[job.source].validationRecords) &&
-                      logDetailsBySource[job.source].validationRecords.length > 0 && (
-                        <p className="text-xs text-slate-700">
-                          Validation records: {logDetailsBySource[job.source].validationRecords.length}
-                        </p>
-                      )}
-                    {Array.isArray(logDetailsBySource[job.source].logs) &&
-                      logDetailsBySource[job.source].logs.length > 0 && (
-                        <div className="mt-2 border-t border-slate-100 pt-2">
-                          <p className="text-xs font-semibold text-slate-700 mb-1">Log entries</p>
-                          <ul className="space-y-1">
-                            {logDetailsBySource[job.source].logs.slice(-5).map((entry, index) => (
-                              <li key={`${job.source}-log-${index}`} className="text-xs text-slate-700">
-                                [{entry.level || 'info'}] {formatDate(entry.at)} - {entry.message}
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-                      )}
-                  </div>
-                )}
+                  )}
+                
+                {Array.isArray(logDetailsBySource[job.source].logs) &&
+                  logDetailsBySource[job.source].logs.length > 0 && (
+                    <div className="mt-2 border-t border-slate-200 pt-2">
+                      <p className="text-xs font-semibold text-slate-700 mb-1">Recent log entries:</p>
+                      <ul className="space-y-1">
+                        {logDetailsBySource[job.source].logs.slice(-5).map((entry, index) => (
+                          <li key={`${job.source}-log-${index}`} className="text-xs text-slate-600 leading-relaxed">
+                            <span className={`font-mono uppercase ${entry.level === 'error' ? 'text-red-500' : 'text-slate-400'}`}>
+                              [{entry.level || 'info'}]
+                            </span>{' '}
+                            <span className="text-slate-400">{formatDate(entry.at)}:</span> {entry.message}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
               </div>
             )}
           </article>

--- a/frontend/src/components/coordinator-sprint/JobStatusPanel.jsx
+++ b/frontend/src/components/coordinator-sprint/JobStatusPanel.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+
+const statusStyleMap = {
+  queued: 'bg-amber-100 text-amber-700',
+  running: 'bg-blue-100 text-blue-700',
+  completed: 'bg-emerald-100 text-emerald-700',
+  failed: 'bg-red-100 text-red-700',
+};
+
+const formatDate = (value) => (value ? new Date(value).toLocaleString() : '—');
+
+const JobStatusPanel = ({ jobs, onViewLogs, logDetailsBySource = {} }) => {
+  return (
+    <section className="bg-white rounded-lg shadow-sm border border-slate-200 p-5">
+      <h2 className="text-lg font-semibold text-slate-900 mb-4">Job Status</h2>
+      {jobs.length === 0 && (
+        <p className="text-sm text-slate-500">No sync job has been triggered yet for this sprint.</p>
+      )}
+
+      <div className="space-y-4">
+        {jobs.map((job) => (
+          <article key={`${job.source}-${job.jobId || 'latest'}`} className="border border-slate-200 rounded-md p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900 uppercase">{job.source} sync</p>
+                <p className="text-xs text-slate-500">Job ID: {job.jobId || '—'}</p>
+              </div>
+              <span className={`text-xs px-2 py-1 rounded-full font-semibold ${statusStyleMap[job.status] || 'bg-slate-100 text-slate-700'}`}>
+                {job.status}
+              </span>
+            </div>
+
+            <div className="mt-3">
+              <div className="h-2 w-full rounded-full bg-slate-100">
+                <div
+                  className={`h-2 rounded-full ${job.status === 'failed' ? 'bg-red-500' : 'bg-indigo-500'}`}
+                  style={{ width: `${job.progress || 0}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-2 text-xs text-slate-600">
+              <p>Started: {formatDate(job.startedAt || job.createdAt)}</p>
+              <p>Ended: {formatDate(job.completedAt || job.updatedAt)}</p>
+            </div>
+
+            {job.lastError && (
+              <div className="mt-3 rounded-md bg-red-50 border border-red-200 p-3">
+                <p className="text-sm font-medium text-red-700 mb-1">Last error</p>
+                <p className="text-xs text-red-700">{job.lastError}</p>
+                <button
+                  type="button"
+                  onClick={() => onViewLogs?.(job)}
+                  className="text-xs underline text-red-700 mt-2 inline-block"
+                >
+                  View Logs
+                </button>
+
+                {logDetailsBySource[job.source] && (
+                  <div className="mt-2 rounded bg-white border border-red-100 p-2">
+                    <p className="text-xs text-slate-700">
+                      Error Code: {logDetailsBySource[job.source].errorCode || 'N/A'}
+                    </p>
+                    <p className="text-xs text-slate-700">
+                      Started: {formatDate(logDetailsBySource[job.source].startedAt)}
+                    </p>
+                    <p className="text-xs text-slate-700">
+                      Ended: {formatDate(logDetailsBySource[job.source].completedAt)}
+                    </p>
+                    {Array.isArray(logDetailsBySource[job.source].validationRecords) &&
+                      logDetailsBySource[job.source].validationRecords.length > 0 && (
+                        <p className="text-xs text-slate-700">
+                          Validation records: {logDetailsBySource[job.source].validationRecords.length}
+                        </p>
+                      )}
+                    {Array.isArray(logDetailsBySource[job.source].logs) &&
+                      logDetailsBySource[job.source].logs.length > 0 && (
+                        <div className="mt-2 border-t border-slate-100 pt-2">
+                          <p className="text-xs font-semibold text-slate-700 mb-1">Log entries</p>
+                          <ul className="space-y-1">
+                            {logDetailsBySource[job.source].logs.slice(-5).map((entry, index) => (
+                              <li key={`${job.source}-log-${index}`} className="text-xs text-slate-700">
+                                [{entry.level || 'info'}] {formatDate(entry.at)} - {entry.message}
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                  </div>
+                )}
+              </div>
+            )}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default JobStatusPanel;

--- a/frontend/src/components/coordinator-sprint/SprintSelector.jsx
+++ b/frontend/src/components/coordinator-sprint/SprintSelector.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+const SprintSelector = ({
+  groups,
+  selectedGroupId,
+  selectedSprintId,
+  onGroupChange,
+  onSprintChange,
+  loadingGroups,
+}) => {
+  const selectedGroup = groups.find((group) => group.groupId === selectedGroupId);
+  const sprintOptions = Array.isArray(selectedGroup?.sprints) ? selectedGroup.sprints : [];
+
+  return (
+    <section className="bg-white rounded-lg shadow-sm border border-slate-200 p-5">
+      <h2 className="text-lg font-semibold text-slate-900 mb-4">Sprint Selector</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="group-select">
+            Group
+          </label>
+          <select
+            id="group-select"
+            value={selectedGroupId}
+            onChange={(event) => onGroupChange(event.target.value)}
+            disabled={loadingGroups}
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">{loadingGroups ? 'Loading groups...' : 'Select group'}</option>
+            {groups.map((group) => (
+              <option key={group.groupId} value={group.groupId}>
+                {group.groupName} ({group.groupId})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="sprint-select">
+            Sprint
+          </label>
+          <select
+            id="sprint-select"
+            value={selectedSprintId}
+            onChange={(event) => onSprintChange(event.target.value)}
+            disabled={!selectedGroupId}
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          >
+            <option value="">{selectedGroupId ? 'Select sprint' : 'Choose group first'}</option>
+            {sprintOptions.map((sprint) => {
+              const sprintId = sprint.sprintId || sprint.id || sprint.key;
+              const sprintName = sprint.name || sprint.sprintName || sprintId;
+              if (!sprintId) return null;
+              return (
+                <option key={sprintId} value={sprintId}>
+                  {sprintName}
+                </option>
+              );
+            })}
+          </select>
+          <p className="text-xs text-slate-500 mt-1">
+            If no sprint list is returned by backend yet, you can type a sprint id below.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <label className="block text-sm font-medium text-slate-700 mb-1" htmlFor="sprint-input">
+          Sprint ID (manual override)
+        </label>
+        <input
+          id="sprint-input"
+          type="text"
+          value={selectedSprintId}
+          onChange={(event) => onSprintChange(event.target.value)}
+          placeholder="e.g. sprint-2026-04"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          disabled={!selectedGroupId}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default SprintSelector;

--- a/frontend/src/components/coordinator-sprint/SyncActionButtons.jsx
+++ b/frontend/src/components/coordinator-sprint/SyncActionButtons.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+const buttonBaseClass =
+  'rounded-md px-4 py-2 text-sm font-semibold text-white disabled:opacity-60 disabled:cursor-not-allowed';
+
+const SyncActionButtons = ({
+  disabled,
+  jiraDisabled = false,
+  githubDisabled = false,
+  jiraLoading,
+  githubLoading,
+  recalcLoading,
+  onRunJiraSync,
+  onRunGithubSync,
+  onRecalculate,
+}) => {
+  return (
+    <section className="bg-white rounded-lg shadow-sm border border-slate-200 p-5">
+      <h2 className="text-lg font-semibold text-slate-900 mb-4">Actions</h2>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={onRunJiraSync}
+          disabled={disabled || jiraDisabled || jiraLoading}
+          className={`${buttonBaseClass} bg-blue-600 hover:bg-blue-700`}
+        >
+          {jiraLoading ? 'Running JIRA Sync...' : 'Run JIRA Sync'}
+        </button>
+
+        <button
+          type="button"
+          onClick={onRunGithubSync}
+          disabled={disabled || githubDisabled || githubLoading}
+          className={`${buttonBaseClass} bg-slate-800 hover:bg-slate-900`}
+        >
+          {githubLoading ? 'Running GitHub Sync...' : 'Run GitHub Sync'}
+        </button>
+
+        <button
+          type="button"
+          onClick={onRecalculate}
+          disabled={disabled || recalcLoading}
+          className={`${buttonBaseClass} bg-emerald-600 hover:bg-emerald-700`}
+        >
+          {recalcLoading ? 'Recalculating...' : 'Recalculate Contributions'}
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default SyncActionButtons;

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -130,6 +130,13 @@ const Sidebar = () => {
           )
         },
         {
+          label: 'Sprint Dashboard', path: '/coordinator/sprint-dashboard', icon: (
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 17v-6m3 6V7m3 10v-4m5 6H4a1 1 0 01-1-1V4a1 1 0 011-1h16a1 1 0 011 1v14a1 1 0 01-1 1z" />
+            </svg>
+          ), requiredRoles: ['coordinator']
+        },
+        {
           label: 'New Committee', path: '/coordinator/committees/new', icon: (
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />

--- a/frontend/src/pages/CoordinatorSprintDashboard.jsx
+++ b/frontend/src/pages/CoordinatorSprintDashboard.jsx
@@ -1,0 +1,267 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import useAuthStore from '../store/authStore';
+import { getAllGroups } from '../api/groupService';
+import {
+  getLatestSyncJob,
+  getSyncJobLogs,
+  getSyncJobById,
+  pollSyncJobUntilTerminal,
+  recalculateContributions,
+  triggerGithubSync,
+  triggerJiraSync,
+} from '../api/sprintTrackingService';
+import SprintSelector from '../components/coordinator-sprint/SprintSelector';
+import SyncActionButtons from '../components/coordinator-sprint/SyncActionButtons';
+import JobStatusPanel from '../components/coordinator-sprint/JobStatusPanel';
+import ContributionResultsTable from '../components/coordinator-sprint/ContributionResultsTable';
+
+const CoordinatorSprintDashboard = () => {
+  const user = useAuthStore((state) => state.user);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  const [groups, setGroups] = useState([]);
+  const [groupsLoading, setGroupsLoading] = useState(true);
+  const [selectedGroupId, setSelectedGroupId] = useState('');
+  const [selectedSprintId, setSelectedSprintId] = useState('');
+  const [jobs, setJobs] = useState([]);
+  const [jobLogs, setJobLogs] = useState({});
+  const [summary, setSummary] = useState(null);
+  const [globalError, setGlobalError] = useState('');
+
+  const [jiraLoading, setJiraLoading] = useState(false);
+  const [githubLoading, setGithubLoading] = useState(false);
+  const [recalcLoading, setRecalcLoading] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    const loadGroups = async () => {
+      setGroupsLoading(true);
+      try {
+        const response = await getAllGroups();
+        if (!mounted) return;
+        const loadedGroups = response.groups || [];
+        setGroups(loadedGroups);
+      } catch (error) {
+        if (!mounted) return;
+        setGlobalError(error?.response?.data?.message || 'Failed to load groups.');
+      } finally {
+        if (mounted) setGroupsLoading(false);
+      }
+    };
+
+    loadGroups();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const activeGroup = useMemo(
+    () => groups.find((group) => group.groupId === selectedGroupId) || null,
+    [groups, selectedGroupId]
+  );
+  const hasJiraIntegration = Boolean(activeGroup?.jiraProjectId || activeGroup?.projectKey);
+  const hasGithubIntegration = Boolean(activeGroup?.githubOrg && activeGroup?.githubRepoName);
+
+  const addOrUpdateJob = (incomingJob) => {
+    setJobs((prev) => {
+      const existingIndex = prev.findIndex((job) => job.source === incomingJob.source);
+      if (existingIndex === -1) return [incomingJob, ...prev];
+      const copy = [...prev];
+      copy[existingIndex] = { ...copy[existingIndex], ...incomingJob };
+      return copy;
+    });
+  };
+
+  const ensureSelection = () => {
+    if (!selectedGroupId || !selectedSprintId) {
+      setGlobalError('Please select both group and sprint before running an action.');
+      return false;
+    }
+    setGlobalError('');
+    return true;
+  };
+
+  const handleRunJiraSync = async () => {
+    if (!ensureSelection()) return;
+    if (!hasJiraIntegration) {
+      setGlobalError('JIRA integration is not configured for this group. Configure JIRA first.');
+      return;
+    }
+    setJiraLoading(true);
+    try {
+      const initialJob = await triggerJiraSync({
+        groupId: selectedGroupId,
+        sprintId: selectedSprintId,
+        coordinatorId: user?.userId || '',
+        jiraBoardId: activeGroup?.jiraProjectId || activeGroup?.projectKey,
+        sprintKey: selectedSprintId,
+      });
+      addOrUpdateJob(initialJob);
+
+      const finalJob = await pollSyncJobUntilTerminal({
+        source: 'jira',
+        groupId: selectedGroupId,
+        sprintId: selectedSprintId,
+        jobId: initialJob.jobId,
+        onTick: addOrUpdateJob,
+      });
+      addOrUpdateJob(finalJob);
+    } catch (error) {
+      setGlobalError(error?.response?.data?.message || error?.message || 'JIRA sync failed to start.');
+    } finally {
+      setJiraLoading(false);
+    }
+  };
+
+  const handleRunGithubSync = async () => {
+    if (!ensureSelection()) return;
+    if (!hasGithubIntegration) {
+      setGlobalError('GitHub integration is not configured for this group. Configure GitHub first.');
+      return;
+    }
+    setGithubLoading(true);
+    try {
+      const repositorySlug = `${activeGroup.githubOrg}/${activeGroup.githubRepoName}`;
+
+      const initialJob = await triggerGithubSync({
+        groupId: selectedGroupId,
+        sprintId: selectedSprintId,
+        coordinatorId: user?.userId || '',
+        repositorySlug,
+      });
+      addOrUpdateJob(initialJob);
+
+      const finalJob = await pollSyncJobUntilTerminal({
+        source: 'github',
+        groupId: selectedGroupId,
+        sprintId: selectedSprintId,
+        jobId: initialJob.jobId,
+        onTick: addOrUpdateJob,
+      });
+      addOrUpdateJob(finalJob);
+    } catch (error) {
+      setGlobalError(error?.response?.data?.message || error?.message || 'GitHub sync failed to start.');
+    } finally {
+      setGithubLoading(false);
+    }
+  };
+
+  const handleRecalculate = async () => {
+    if (!ensureSelection()) return;
+    setRecalcLoading(true);
+    try {
+      const result = await recalculateContributions({
+        groupId: selectedGroupId,
+        sprintId: selectedSprintId,
+        triggeredBy: user?.userId || '',
+      });
+      setSummary(result);
+    } catch (error) {
+      setGlobalError(error?.response?.data?.message || error?.message || 'Contribution recalculation failed.');
+    } finally {
+      setRecalcLoading(false);
+    }
+  };
+
+  const handleViewLogs = async (job) => {
+    try {
+      const details = job?.jobId
+        ? await getSyncJobById({
+            source: job.source,
+            groupId: selectedGroupId,
+            sprintId: selectedSprintId,
+            jobId: job.jobId,
+          })
+        : await getLatestSyncJob({
+            source: job.source,
+            groupId: selectedGroupId,
+            sprintId: selectedSprintId,
+          });
+
+      const logs = job?.jobId
+        ? await getSyncJobLogs({
+            source: job.source,
+            groupId: selectedGroupId,
+            sprintId: selectedSprintId,
+            jobId: job.jobId,
+          })
+        : { logs: [] };
+
+      setJobLogs((prev) => ({
+        ...prev,
+        [job.source]: {
+          ...details,
+          logs: logs.logs || [],
+        },
+      }));
+    } catch (error) {
+      setGlobalError(error?.response?.data?.message || error?.message || 'Failed to fetch job logs.');
+    }
+  };
+
+  if (!isAuthenticated) return <Navigate to="/auth/login" replace />;
+  if (user?.role !== 'coordinator') return <Navigate to="/unauthorized" replace />;
+
+  return (
+    <div className="page p-6 bg-slate-50 min-h-screen">
+      <div className="max-w-6xl mx-auto space-y-5">
+        <header>
+          <h1 className="text-2xl font-bold text-slate-900">Coordinator Sprint Tracking Dashboard</h1>
+          <p className="text-sm text-slate-600 mt-1">
+            Ingest (JIRA/GitHub) → Process (Recalculate) → Display (Contribution table)
+          </p>
+        </header>
+
+        {globalError && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {globalError}
+          </div>
+        )}
+
+        <SprintSelector
+          groups={groups}
+          selectedGroupId={selectedGroupId}
+          selectedSprintId={selectedSprintId}
+          onGroupChange={(groupId) => {
+            setSelectedGroupId(groupId);
+            setSummary(null);
+            setJobs([]);
+            setJobLogs({});
+          }}
+          onSprintChange={(sprintId) => {
+            setSelectedSprintId(sprintId);
+            setSummary(null);
+            setJobs([]);
+            setJobLogs({});
+          }}
+          loadingGroups={groupsLoading}
+        />
+
+        <SyncActionButtons
+          disabled={!selectedGroupId || !selectedSprintId}
+          jiraDisabled={!hasJiraIntegration}
+          githubDisabled={!hasGithubIntegration}
+          jiraLoading={jiraLoading}
+          githubLoading={githubLoading}
+          recalcLoading={recalcLoading}
+          onRunJiraSync={handleRunJiraSync}
+          onRunGithubSync={handleRunGithubSync}
+          onRecalculate={handleRecalculate}
+        />
+
+        {(selectedGroupId && (!hasJiraIntegration || !hasGithubIntegration)) && (
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            {!hasJiraIntegration && <p>JIRA sync is unavailable: this group has no JIRA integration yet.</p>}
+            {!hasGithubIntegration && <p>GitHub sync is unavailable: this group has no GitHub integration yet.</p>}
+          </div>
+        )}
+
+        <JobStatusPanel jobs={jobs} onViewLogs={handleViewLogs} logDetailsBySource={jobLogs} />
+        <ContributionResultsTable summary={summary} />
+      </div>
+    </div>
+  );
+};
+
+export default CoordinatorSprintDashboard;

--- a/frontend/src/pages/CoordinatorSprintDashboard.jsx
+++ b/frontend/src/pages/CoordinatorSprintDashboard.jsx
@@ -165,6 +165,16 @@ const CoordinatorSprintDashboard = () => {
   };
 
   const handleViewLogs = async (job) => {
+    // Toggle: if logs for this source are already shown, hide them
+    if (jobLogs[job.source]) {
+      setJobLogs((prev) => {
+        const copy = { ...prev };
+        delete copy[job.source];
+        return copy;
+      });
+      return;
+    }
+
     try {
       const details = job?.jobId
         ? await getSyncJobById({

--- a/frontend/src/types/sprintTracking.js
+++ b/frontend/src/types/sprintTracking.js
@@ -1,0 +1,46 @@
+/**
+ * @typedef {'queued'|'running'|'completed'|'failed'} SyncJobStatus
+ */
+
+/**
+ * @typedef {'jira'|'github'} SyncJobSource
+ */
+
+/**
+ * @typedef {Object} SprintSyncJob
+ * @property {string} jobId
+ * @property {SyncJobStatus} status
+ * @property {SyncJobSource} source
+ * @property {string | null} message
+ * @property {string | null} startedAt
+ * @property {string | null} completedAt
+ * @property {string | null} createdAt
+ * @property {string | null} updatedAt
+ * @property {string | null} errorCode
+ * @property {string | null} lastError
+ * @property {number} progress
+ */
+
+/**
+ * @typedef {Object} SprintContributionRow
+ * @property {string} studentId
+ * @property {string} studentName
+ * @property {number} completedStoryPoints
+ * @property {number} targetStoryPoints
+ * @property {number} contributionRatio
+ * @property {number} mappingWarningsCount
+ * @property {string[]} warnings
+ */
+
+/**
+ * @typedef {Object} SprintContributionSummaryResponse
+ * @property {string} groupId
+ * @property {string} sprintId
+ * @property {string} recalculatedAt
+ * @property {boolean} basedOnTargets
+ * @property {SprintContributionRow[]} contributions
+ * @property {string[]} summaryWarnings
+ * @property {string} summaryMessage
+ */
+
+export const TERMINAL_JOB_STATUSES = ['completed', 'failed'];


### PR DESCRIPTION
Adds Process 7.1 backend support for manual and scheduled JIRA sprint syncs. Introduces JiraSyncJob and SprintIssue models, published SprintConfig gating, retry-aware JIRA worker logic, and the new /groups/:groupId/sprints/:sprintId/jira-sync endpoint with duplicate-run protection. Also updates GitHub sync to read canonical sprint issues first, adds coverage for the new flow, and hardens app startup for environments missing optional Swagger packages.
Closes #233 