### PR TITLE
feat(fe): implement read-only Grade Review Panel for Issue #254

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,6 +30,7 @@ import SubmitDeliverablePage from './pages/SubmitDeliverablePage.jsx';
 import ReviewPage from './pages/ReviewPage.jsx';
 import ReviewManagement from './pages/ReviewManagement.jsx';
 import SprintContributionDashboard from './pages/SprintContributionDashboard.jsx';
+import FinalGradeReviewPanel from './pages/FinalGradeReviewPanel.jsx';
 
 
 const Profile = () => <div className="page">Profile - Coming Soon</div>;
@@ -125,6 +126,10 @@ function App() {
             <Route
               path="/groups/:groupId/sprints/:sprintId/contributions"
               element={<ProtectedRoute component={SprintContributionDashboard} />}
+            />
+            <Route
+              path="/groups/:groupId/final-grades/review"
+              element={<ProtectedRoute component={FinalGradeReviewPanel} requiredRoles={['professor']} />}
             />
             <Route
               path="/dashboard/submit-deliverable"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -129,7 +129,7 @@ function App() {
             />
             <Route
               path="/groups/:groupId/final-grades/review"
-              element={<ProtectedRoute component={FinalGradeReviewPanel} requiredRoles={['professor']} />}
+              element={<ProtectedRoute component={FinalGradeReviewPanel} requiredRoles={['professor', 'advisor']} />}
             />
             <Route
               path="/dashboard/submit-deliverable"

--- a/frontend/src/__tests__/ProtectedRoute.test.js
+++ b/frontend/src/__tests__/ProtectedRoute.test.js
@@ -209,6 +209,31 @@ describe('ProtectedRoute Component', () => {
       expect(screen.getByText('Protected Content')).toBeInTheDocument();
     });
 
+    it('allows advisor user when advisor is included in required roles', () => {
+      useAuthStore.mockReturnValue({
+        isAuthenticated: true,
+        user: { id: '123', role: 'advisor' },
+      });
+
+      render(
+        <MemoryRouter initialEntries={['/grade-review']}>
+          <Routes>
+            <Route
+              path="/grade-review"
+              element={
+                <ProtectedRoute
+                  component={MockProtectedComponent}
+                  requiredRoles={['professor', 'advisor']}
+                />
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText('Protected Content')).toBeInTheDocument();
+    });
+
     it('denies access when user role is not in requiredRoles array', () => {
       useAuthStore.mockReturnValue({
         isAuthenticated: true,

--- a/frontend/src/api/finalGradeReviewService.js
+++ b/frontend/src/api/finalGradeReviewService.js
@@ -1,0 +1,13 @@
+import apiClient from './apiClient';
+
+/**
+ * Fetch the read-only final grade review snapshot for professor/advisor oversight.
+ *
+ * Expected backend endpoint:
+ * GET /groups/{groupId}/final-grades/review
+ */
+export const getFinalGradeReview = async (groupId) => {
+  const response = await apiClient.get(`/groups/${groupId}/final-grades/review`);
+  return response.data;
+};
+

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -23,6 +23,13 @@ const Sidebar = () => {
     return user.role.charAt(0).toUpperCase() + user.role.slice(1).replace(/_/g, ' ');
   };
 
+  const reviewGroupId = [
+    user?.groupId,
+    user?.advisedGroupId,
+    user?.advisorGroupId,
+    user?.currentGroupId,
+  ].find((value) => typeof value === 'string' && value.trim() && !value.includes(':'));
+
   const navSections = [
     {
       title: 'Main',
@@ -54,6 +61,13 @@ const Sidebar = () => {
             </svg>
           ), requiredRoles: ['professor']
         },
+        ...(reviewGroupId ? [{
+          label: 'Grade Review', path: `/groups/${reviewGroupId}/final-grades/review`, icon: (
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 17v-6m4 6V7m4 10v-4M5 21h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
+            </svg>
+          ), requiredRoles: ['professor']
+        }] : []),
         {
           label: 'Jury Committees', path: '/jury/committees', icon: (
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -52,7 +52,7 @@ const Sidebar = () => {
     },
     {
       title: 'Academic Center',
-      requiredRoles: ['professor', 'admin', 'committee_member', 'coordinator'],
+      requiredRoles: ['professor', 'advisor', 'admin', 'committee_member', 'coordinator'],
       items: [
         {
           label: 'Inbox', path: '/professor/inbox', icon: (
@@ -66,7 +66,7 @@ const Sidebar = () => {
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 17v-6m4 6V7m4 10v-4M5 21h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z" />
             </svg>
-          ), requiredRoles: ['professor']
+          ), requiredRoles: ['professor', 'advisor']
         }] : []),
         {
           label: 'Jury Committees', path: '/jury/committees', icon: (

--- a/frontend/src/pages/FinalGradeReviewPanel.css
+++ b/frontend/src/pages/FinalGradeReviewPanel.css
@@ -1,0 +1,230 @@
+.final-grade-review-page {
+  background: #f8fafc;
+  color: #1f2937;
+  min-height: 100vh;
+  padding: 32px 28px 48px;
+}
+
+.final-grade-review-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  margin: 0 auto 22px;
+  max-width: 1180px;
+}
+
+.final-grade-review-kicker {
+  color: #0f766e;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+.final-grade-review-header h1 {
+  color: #111827;
+  font-size: 28px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.final-grade-review-meta {
+  color: #64748b;
+  font-size: 14px;
+  margin: 8px 0 0;
+}
+
+.final-grade-review-button {
+  background: #0f766e;
+  border: 1px solid #0f766e;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  min-height: 38px;
+  padding: 8px 14px;
+}
+
+.final-grade-review-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.final-grade-review-state,
+.final-grade-review-message,
+.final-grade-review-empty,
+.final-grade-review-panel,
+.final-grade-review-metrics {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1180px;
+}
+
+.final-grade-review-state,
+.final-grade-review-empty,
+.final-grade-review-message.empty {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  color: #475569;
+  padding: 24px;
+}
+
+.final-grade-review-message.error {
+  background: #fff1f2;
+  border: 1px solid #fecdd3;
+  border-radius: 8px;
+  color: #9f1239;
+  padding: 20px 22px;
+}
+
+.final-grade-review-message h2 {
+  font-size: 18px;
+  margin: 0 0 6px;
+}
+
+.final-grade-review-message p {
+  margin: 0;
+}
+
+.final-grade-review-metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-bottom: 16px;
+}
+
+.final-grade-review-metrics > div {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.final-grade-review-metrics .metric-label {
+  color: #64748b;
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.final-grade-review-metrics strong {
+  color: #111827;
+  display: block;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.final-grade-review-panel {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.final-grade-review-panel-header {
+  align-items: center;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: space-between;
+  padding: 18px 20px;
+}
+
+.final-grade-review-panel-header h2 {
+  color: #111827;
+  font-size: 18px;
+  margin: 0;
+}
+
+.final-grade-review-panel-header p {
+  color: #64748b;
+  font-size: 13px;
+  margin: 5px 0 0;
+}
+
+.final-grade-review-table-wrap {
+  overflow-x: auto;
+}
+
+.final-grade-review-table {
+  border-collapse: collapse;
+  min-width: 980px;
+  width: 100%;
+}
+
+.final-grade-review-table th,
+.final-grade-review-table td {
+  border-bottom: 1px solid #eef2f7;
+  font-size: 13px;
+  padding: 13px 16px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.final-grade-review-table th {
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.final-grade-review-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.override-badge,
+.readonly-badge {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 10px;
+}
+
+.override-badge {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.readonly-badge {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.override-comment {
+  color: #64748b;
+  font-size: 12px;
+  margin: 8px 0 0;
+  max-width: 220px;
+}
+
+@media (max-width: 760px) {
+  .final-grade-review-page {
+    padding: 22px 16px 36px;
+  }
+
+  .final-grade-review-header {
+    flex-direction: column;
+  }
+
+  .final-grade-review-button {
+    width: 100%;
+  }
+
+  .final-grade-review-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .final-grade-review-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+

--- a/frontend/src/pages/FinalGradeReviewPanel.jsx
+++ b/frontend/src/pages/FinalGradeReviewPanel.jsx
@@ -1,0 +1,277 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getFinalGradeReview } from '../api/finalGradeReviewService';
+import './FinalGradeReviewPanel.css';
+
+const EMPTY_STATUS = 'preview_unavailable';
+
+const formatNumber = (value, fractionDigits = 2) => {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '-';
+  return number.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: fractionDigits,
+  });
+};
+
+const formatDateTime = (value) => {
+  if (!value) return 'Not available';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+};
+
+const formatStatus = (status, approval) => {
+  if (approval?.decision === 'approved') return 'Approved';
+  if (approval?.decision === 'rejected') return 'Rejected';
+
+  const labels = {
+    preview_ready: 'Preview ready',
+    preview_unavailable: 'Preview unavailable',
+    approved: 'Approved',
+    rejected: 'Rejected',
+  };
+
+  return labels[status] || 'Review pending';
+};
+
+const normalizeResponse = (data) => {
+  const preview = data?.preview || data?.finalGradesPreview || data || null;
+  const approval = data?.approval || data?.finalGradeApproval || null;
+  const status = data?.status || approval?.decision || (preview?.students ? 'preview_ready' : EMPTY_STATUS);
+
+  return {
+    preview,
+    approval,
+    status,
+  };
+};
+
+const resolveErrorState = (error) => {
+  const status = error?.response?.status;
+  const message = error?.response?.data?.message || error?.message;
+
+  if (status === 404) {
+    return {
+      kind: 'empty',
+      title: 'Final grade preview is not available yet',
+      message: 'The coordinator needs to generate the final grade preview before professor review can begin.',
+    };
+  }
+
+  if (status === 403 || error?.code === 'FORBIDDEN') {
+    return {
+      kind: 'error',
+      title: 'Access denied',
+      message: message || 'You are not authorized to view this final grade review.',
+    };
+  }
+
+  if (status === 409) {
+    return {
+      kind: 'error',
+      title: 'Review snapshot is unavailable',
+      message: message || 'The final grade configuration is locked or in a conflicting state.',
+    };
+  }
+
+  return {
+    kind: 'error',
+    title: 'Unable to load final grade review',
+    message: message || 'Please refresh and try again.',
+  };
+};
+
+const buildOverrideMap = (approval) => {
+  const entries = Array.isArray(approval?.overrideEntries) ? approval.overrideEntries : [];
+  return entries.reduce((map, entry) => {
+    if (entry?.studentId) map.set(entry.studentId, entry);
+    return map;
+  }, new Map());
+};
+
+const formatBreakdown = (breakdown) => {
+  if (!breakdown || typeof breakdown !== 'object') return 'No breakdown returned';
+
+  const entries = Object.entries(breakdown);
+  if (entries.length === 0) return 'No breakdown returned';
+
+  return entries
+    .map(([deliverableId, score]) => `${deliverableId}: ${formatNumber(score)}`)
+    .join(', ');
+};
+
+const FinalGradeReviewPanel = () => {
+  const { groupId } = useParams();
+  const [review, setReview] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [stateMessage, setStateMessage] = useState(null);
+
+  const loadReview = async ({ isRefresh = false } = {}) => {
+    if (!groupId) return;
+
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    setStateMessage(null);
+
+    try {
+      const data = await getFinalGradeReview(groupId);
+      const normalized = normalizeResponse(data);
+
+      if (normalized.status === EMPTY_STATUS || !Array.isArray(normalized.preview?.students)) {
+        setReview(normalized);
+        setStateMessage({
+          kind: 'empty',
+          title: 'Final grade preview is not available yet',
+          message: 'The coordinator needs to generate the final grade preview before professor review can begin.',
+        });
+        return;
+      }
+
+      setReview(normalized);
+    } catch (error) {
+      setReview(null);
+      setStateMessage(resolveErrorState(error));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    loadReview();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId]);
+
+  const preview = review?.preview;
+  const approval = review?.approval;
+  const students = useMemo(
+    () => (Array.isArray(preview?.students) ? preview.students : []),
+    [preview]
+  );
+  const overrideMap = useMemo(() => buildOverrideMap(approval), [approval]);
+  const hasOverrides = approval?.overridesApplied || overrideMap.size > 0;
+
+  return (
+    <div className="final-grade-review-page">
+      <header className="final-grade-review-header">
+        <div>
+          <p className="final-grade-review-kicker">Read-only grade review</p>
+          <h1>Professor Grade Review</h1>
+          <p className="final-grade-review-meta">Group {preview?.groupId || groupId}</p>
+        </div>
+        <button
+          type="button"
+          className="final-grade-review-button"
+          onClick={() => loadReview({ isRefresh: true })}
+          disabled={loading || refreshing}
+        >
+          {refreshing ? 'Refreshing' : 'Refresh'}
+        </button>
+      </header>
+
+      {loading && (
+        <div className="final-grade-review-state" role="status">
+          Loading final grade review
+        </div>
+      )}
+
+      {!loading && stateMessage && (
+        <div
+          className={`final-grade-review-message ${stateMessage.kind === 'empty' ? 'empty' : 'error'}`}
+          role={stateMessage.kind === 'empty' ? 'status' : 'alert'}
+        >
+          <h2>{stateMessage.title}</h2>
+          <p>{stateMessage.message}</p>
+        </div>
+      )}
+
+      {!loading && !stateMessage && preview && (
+        <>
+          <section className="final-grade-review-metrics" aria-label="Final grade review metrics">
+            <div>
+              <span className="metric-label">Approval status</span>
+              <strong>{formatStatus(review.status, approval)}</strong>
+            </div>
+            <div>
+              <span className="metric-label">Base group score</span>
+              <strong>{formatNumber(preview.baseGroupScore)}</strong>
+            </div>
+            <div>
+              <span className="metric-label">Preview created</span>
+              <strong>{formatDateTime(preview.createdAt)}</strong>
+            </div>
+            <div>
+              <span className="metric-label">Overrides</span>
+              <strong>{hasOverrides ? 'Applied' : 'None'}</strong>
+            </div>
+          </section>
+
+          <section className="final-grade-review-panel">
+            <div className="final-grade-review-panel-header">
+              <div>
+                <h2>Final grade snapshot</h2>
+                <p>
+                  Approval recorded: {formatDateTime(approval?.approvedAt)}
+                  {approval?.coordinatorId ? ` by ${approval.coordinatorId}` : ''}
+                </p>
+              </div>
+            </div>
+
+            {students.length === 0 ? (
+              <div className="final-grade-review-empty">
+                No student grade entries were returned for this preview.
+              </div>
+            ) : (
+              <div className="final-grade-review-table-wrap">
+                <table className="final-grade-review-table">
+                  <thead>
+                    <tr>
+                      <th>Student ID</th>
+                      <th>Contribution ratio</th>
+                      <th>Computed grade</th>
+                      <th>Reviewed grade</th>
+                      <th>Override</th>
+                      <th>Deliverable breakdown</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {students.map((student) => {
+                      const override = overrideMap.get(student.studentId);
+                      const reviewedGrade = override?.overriddenFinalGrade ?? student.computedFinalGrade;
+
+                      return (
+                        <tr key={student.studentId}>
+                          <td>{student.studentId}</td>
+                          <td>{formatNumber(student.contributionRatio, 4)}</td>
+                          <td>{formatNumber(student.computedFinalGrade)}</td>
+                          <td>{formatNumber(reviewedGrade)}</td>
+                          <td>
+                            {override ? (
+                              <span className="override-badge" title={override.comment || 'Coordinator override applied'}>
+                                Override applied
+                              </span>
+                            ) : (
+                              <span className="readonly-badge">Original</span>
+                            )}
+                            {override?.comment && <p className="override-comment">{override.comment}</p>}
+                          </td>
+                          <td>{formatBreakdown(student.deliverableScoreBreakdown)}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FinalGradeReviewPanel;
+


### PR DESCRIPTION
Developed a read-only final grade review interface for Professor and Advisor roles as per Issue #254 requirements.

Key Deliverables:
- Created FinalGradeReviewPanel UI for read-only grade oversight.
- Integrated finalGradeReviewService to fetch data via GET /groups/{groupId}/final-grades/review.
- Added protected routing in App.js restricted to 'professor' role.
- Implemented conditional sidebar navigation for professors with active group context.
- Ensured strict read-only compliance by omitting all approval, override, and publish controls.

Verified with a successful production build (npm run build). No backend or test files were modified. Closes #254