### PR TITLE
feat(fe): implement read-only committee final results view #257

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,6 +30,7 @@ import SubmitDeliverablePage from './pages/SubmitDeliverablePage.jsx';
 import ReviewPage from './pages/ReviewPage.jsx';
 import ReviewManagement from './pages/ReviewManagement.jsx';
 import SprintContributionDashboard from './pages/SprintContributionDashboard.jsx';
+import CommitteeFinalResults from './pages/CommitteeFinalResults.jsx';
 
 
 const Profile = () => <div className="page">Profile - Coming Soon</div>;
@@ -141,6 +142,10 @@ function App() {
             <Route
               path="/jury/committees"
               element={<ProtectedRoute component={JuryCommittees} requiredRoles={['professor', 'committee_member', 'admin']} />}
+            />
+            <Route
+              path="/committees/:committeeId/final-results"
+              element={<ProtectedRoute component={CommitteeFinalResults} requiredRoles={['committee_member', 'admin']} />}
             />
             <Route
               path="/profile"

--- a/frontend/src/api/finalGradeService.js
+++ b/frontend/src/api/finalGradeService.js
@@ -1,0 +1,50 @@
+import apiClient from './apiClient';
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+
+const getFinalGradesFromResponse = (data) => {
+  if (Array.isArray(data)) return data;
+  if (Array.isArray(data?.finalGrades)) return data.finalGrades;
+  if (Array.isArray(data?.results)) return data.results;
+  if (Array.isArray(data?.grades)) return data.grades;
+  if (Array.isArray(data?.groups)) {
+    return data.groups.flatMap((group) =>
+      asArray(group.finalGrades || group.results || group.grades).map((grade) => ({
+        ...grade,
+        groupId: grade.groupId || group.groupId,
+        groupName: grade.groupName || group.groupName,
+        publishedAt: grade.publishedAt || group.publishedAt || data.publishedAt,
+      }))
+    );
+  }
+  return [];
+};
+
+/**
+ * Fetch committee-scoped published final grade results.
+ *
+ * Issue #257 / Process 8.5:
+ * GET /committees/{committeeId}/final-results?status=published
+ */
+export const getCommitteeFinalResults = async (committeeId) => {
+  const response = await apiClient.get(`/committees/${committeeId}/final-results`, {
+    params: { status: 'published' },
+  });
+  const data = response.data || {};
+  const finalGrades = getFinalGradesFromResponse(data).filter(
+    (grade) => !grade.status || grade.status === 'published'
+  );
+
+  return {
+    ...data,
+    committeeId: data.committeeId || committeeId,
+    publishedAt: data.publishedAt || finalGrades[0]?.publishedAt || finalGrades[0]?.createdAt || null,
+    finalGrades,
+  };
+};
+
+const finalGradeService = {
+  getCommitteeFinalResults,
+};
+
+export default finalGradeService;

--- a/frontend/src/components/JuryCommittees.js
+++ b/frontend/src/components/JuryCommittees.js
@@ -80,6 +80,15 @@ const JuryCommittees = () => {
                 <span className="info-label">Jury</span>
                 <span className="info-value">{committee.juryIds.join(', ')}</span>
               </div>
+              <div className="info-row">
+                <span className="info-label">Results</span>
+                <a
+                  className="info-value"
+                  href={`/committees/${committee.committeeId}/final-results`}
+                >
+                  Final Results
+                </a>
+              </div>
             </div>
           </div>
         ))}

--- a/frontend/src/pages/CommitteeFinalResults.css
+++ b/frontend/src/pages/CommitteeFinalResults.css
@@ -1,0 +1,219 @@
+.committee-results-page {
+  background: #f8fafc;
+  color: #1f2937;
+  min-height: 100vh;
+  padding: 32px 28px 48px;
+}
+
+.committee-results-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  margin: 0 auto 22px;
+  max-width: 1180px;
+}
+
+.committee-results-kicker {
+  color: #2563eb;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+.committee-results-header h1 {
+  color: #111827;
+  font-size: 28px;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.committee-results-meta {
+  color: #64748b;
+  font-size: 14px;
+  margin: 8px 0 0;
+}
+
+.committee-results-button {
+  background: #2563eb;
+  border: 1px solid #2563eb;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  min-height: 38px;
+  padding: 8px 14px;
+}
+
+.committee-results-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.committee-results-state,
+.committee-results-error,
+.committee-results-empty,
+.committee-results-panel,
+.committee-results-metrics {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1180px;
+}
+
+.committee-results-state,
+.committee-results-empty {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  color: #64748b;
+  padding: 24px;
+}
+
+.committee-results-error {
+  background: #fff1f2;
+  border: 1px solid #fecdd3;
+  border-radius: 8px;
+  color: #9f1239;
+  padding: 20px 22px;
+}
+
+.committee-results-error h2 {
+  font-size: 18px;
+  margin: 0 0 6px;
+}
+
+.committee-results-error p {
+  margin: 0;
+}
+
+.committee-results-metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 2fr);
+  margin-bottom: 16px;
+}
+
+.committee-results-metrics > div {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.metric-label {
+  color: #64748b;
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+}
+
+.committee-results-metrics strong {
+  color: #111827;
+  display: block;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.committee-results-panel {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.committee-results-panel-header {
+  align-items: center;
+  border-bottom: 1px solid #e5e7eb;
+  display: flex;
+  justify-content: space-between;
+  padding: 18px 20px;
+}
+
+.committee-results-panel-header h2 {
+  color: #111827;
+  font-size: 18px;
+  margin: 0;
+}
+
+.committee-results-panel-header p {
+  color: #64748b;
+  font-size: 13px;
+  margin: 5px 0 0;
+}
+
+.committee-results-table-wrap {
+  overflow-x: auto;
+}
+
+.committee-results-table {
+  border-collapse: collapse;
+  min-width: 960px;
+  width: 100%;
+}
+
+.committee-results-table th,
+.committee-results-table td {
+  border-bottom: 1px solid #eef2f7;
+  font-size: 13px;
+  padding: 13px 16px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.committee-results-table th {
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.committee-results-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.student-label {
+  color: #111827;
+  display: block;
+  font-weight: 700;
+}
+
+.student-id {
+  color: #64748b;
+  display: block;
+  font-size: 12px;
+  margin-top: 3px;
+}
+
+.published-badge {
+  background: #dcfce7;
+  border-radius: 999px;
+  color: #166534;
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 10px;
+}
+
+@media (max-width: 760px) {
+  .committee-results-page {
+    padding: 22px 16px 36px;
+  }
+
+  .committee-results-header {
+    flex-direction: column;
+  }
+
+  .committee-results-button {
+    width: 100%;
+  }
+
+  .committee-results-metrics {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/CommitteeFinalResults.jsx
+++ b/frontend/src/pages/CommitteeFinalResults.jsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getCommitteeFinalResults } from '../api/finalGradeService';
+import './CommitteeFinalResults.css';
+
+const formatDateTime = (value) => {
+  if (!value) return 'Not published yet';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+};
+
+const formatNumber = (value, fractionDigits = 2) => {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return 'N/A';
+  return number.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: fractionDigits,
+  });
+};
+
+const resolveError = (error) => {
+  const status = error?.response?.status;
+  const code = error?.code;
+
+  if (status === 403 || code === 'FORBIDDEN') {
+    return {
+      title: 'Access denied',
+      message: 'Only assigned committee members can view published final results for this committee.',
+    };
+  }
+
+  if (status === 404) {
+    return {
+      title: 'No published results found',
+      message: 'This committee does not have published final grade results yet.',
+    };
+  }
+
+  return {
+    title: 'Unable to load final results',
+    message: error?.response?.data?.message || error?.message || 'Please refresh and try again.',
+  };
+};
+
+const getStudentLabel = (entry) =>
+  entry.studentName || entry.studentFullName || entry.studentEmail || entry.studentId || 'Unknown student';
+
+const CommitteeFinalResults = () => {
+  const { committeeId } = useParams();
+  const [results, setResults] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadResults = async ({ isRefresh = false } = {}) => {
+    if (!committeeId) return;
+
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    setError(null);
+    try {
+      const data = await getCommitteeFinalResults(committeeId);
+      setResults(data);
+    } catch (err) {
+      setResults(null);
+      setError(resolveError(err));
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    loadResults();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [committeeId]);
+
+  const finalGrades = useMemo(
+    () =>
+      (Array.isArray(results?.finalGrades) ? results.finalGrades : []).filter(
+        (entry) => !entry.status || entry.status === 'published'
+      ),
+    [results]
+  );
+
+  const latestPublishedAt = useMemo(() => {
+    if (results?.publishedAt) return results.publishedAt;
+
+    const sortedDates = finalGrades
+      .map((entry) => entry.publishedAt || entry.createdAt)
+      .filter(Boolean)
+      .sort();
+
+    return sortedDates[sortedDates.length - 1];
+  }, [finalGrades, results]);
+
+  return (
+    <div className="committee-results-page">
+      <header className="committee-results-header">
+        <div>
+          <p className="committee-results-kicker">Read-only final results</p>
+          <h1>Committee Final Results</h1>
+          <p className="committee-results-meta">Committee {results?.committeeId || committeeId}</p>
+        </div>
+        <button
+          type="button"
+          className="committee-results-button"
+          onClick={() => loadResults({ isRefresh: true })}
+          disabled={loading || refreshing}
+        >
+          {refreshing ? 'Refreshing' : 'Refresh'}
+        </button>
+      </header>
+
+      {loading && (
+        <div className="committee-results-state" role="status">
+          Loading published final results
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="committee-results-error" role="alert">
+          <h2>{error.title}</h2>
+          <p>{error.message}</p>
+        </div>
+      )}
+
+      {!loading && !error && (
+        <>
+          <section className="committee-results-metrics" aria-label="Published result metrics">
+            <div>
+              <span className="metric-label">Published records</span>
+              <strong>{finalGrades.length}</strong>
+            </div>
+            <div>
+              <span className="metric-label">Last published</span>
+              <strong>{formatDateTime(latestPublishedAt)}</strong>
+            </div>
+          </section>
+
+          <section className="committee-results-panel">
+            <div className="committee-results-panel-header">
+              <div>
+                <h2>Published final grades</h2>
+                <p>Draft previews and approval states are excluded from this view.</p>
+              </div>
+            </div>
+
+            {finalGrades.length === 0 ? (
+              <div className="committee-results-empty">
+                No published final grade records were returned for this committee.
+              </div>
+            ) : (
+              <div className="committee-results-table-wrap">
+                <table className="committee-results-table">
+                  <thead>
+                    <tr>
+                      <th>Student</th>
+                      <th>Group</th>
+                      <th>Final grade</th>
+                      <th>Base score</th>
+                      <th>Ratio</th>
+                      <th>Published at</th>
+                      <th>Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {finalGrades.map((entry) => (
+                      <tr key={`${entry.groupId || 'group'}-${entry.studentId}`}>
+                        <td>
+                          <span className="student-label">{getStudentLabel(entry)}</span>
+                          {entry.studentId && <span className="student-id">{entry.studentId}</span>}
+                        </td>
+                        <td>{entry.groupName || entry.groupId || 'N/A'}</td>
+                        <td>{formatNumber(entry.finalGrade)}</td>
+                        <td>{formatNumber(entry.baseGroupScore)}</td>
+                        <td>{formatNumber(entry.individualRatio ?? entry.contributionRatio, 4)}</td>
+                        <td>{formatDateTime(entry.publishedAt || entry.createdAt)}</td>
+                        <td>
+                          <span className="published-badge">{entry.status || 'published'}</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default CommitteeFinalResults;


### PR DESCRIPTION
Implemented the student final grade visualization dashboard for the Committee role as per Issue #257.

Key Changes:
- Added a new protected route: /committees/:committeeId/final-results[cite: 87].
- Created CommitteeFinalResults.jsx and .css for a read-only tabular view[cite: 86, 87].
- Integrated finalGradeService with defensive filtering to ensure only 'published' grades are visible[cite: 85, 88].
- Added "Final Results" navigation links to Committee cards in the Jury overview[cite: 87].
- Verified the implementation with a successful production build.

Notes:
- Strictly frontend-only; no modifications to backend or test suites.
- Navigation uses standard href to maintain compatibility with existing legacy tests.
- UI explicitly excludes all administrative actions (approve, publish, override)[cite: 87, 88]. Closes #257