### PR TITLE
Implement deliverable score aggregation for final grade preview

### DIFF
--- a/backend/src/controllers/finalGradeController.js
+++ b/backend/src/controllers/finalGradeController.js
@@ -1,83 +1,39 @@
+'use strict';
+
+const finalGradePreviewService = require('../services/finalGradePreviewService');
+const { approveGroupGrades, GradeApprovalError } = require('../services/approvalService');
+
+/**
+ * Controller for Process 8.1 - Final Grade Preview
+ */
+const previewFinalGrades = async (req, res, next) => {
+  try {
+    const { groupId } = req.params;
+
+    // Orchestrates D4, D5, D8 data to compute baseGroupScore and calls formula engine
+    const previewData = await finalGradePreviewService.previewGroupGrade(groupId);
+
+    // Return the response ensuring it conforms to the f8_ds_d4_p81 OpenAPI schema
+    return res.status(200).json({
+      ...previewData,
+      createdAt: new Date(),
+    });
+  } catch (error) {
+    if (error.status === 400 || error.status === 409) {
+      return res.status(error.status).json({ error: error.message });
+    }
+    next(error);
+  }
+};
+
 /**
  * ================================================================================
  * ISSUE #253: Final Grade Approval Controller
  * ================================================================================
- *
- * Purpose:
- * HTTP request handler for coordinator approval endpoint.
- * Responsible for:
- * 1. Role-based access control (coordinator-only)
- * 2. Request validation (publishCycle, decision, overrides)
- * 3. Calling approval service
- * 4. Error handling and status codes
- * 5. Response formatting for frontend (Issue #252)
- *
- * Process Context:
- * - Input: POST request from Issue #252 (UI submission)
- * - Middleware: authMiddleware (verify JWT), roleMiddleware (coordinator only)
- * - Service call: approvalService.approveGroupGrades()
- * - Output: FinalGradeApproval JSON response
- * - Status codes: 200 (success), 403 (forbidden), 404 (not found), 409 (conflict), 422 (validation)
- *
- * ================================================================================
  */
-
-const { approveGroupGrades, GradeApprovalError } = require('../services/approvalService');
 
 /**
  * ISSUE #253: POST /groups/:groupId/final-grades/approval
- * 
- * Handler for coordinator grade approval endpoint.
- * Receives approval decision and optional overrides from UI (Issue #252),
- * persists approval state to D7, and returns confirmation for Issue #255 consumption.
- *
- * Request body (from Issue #252):
- * {
- *   publishCycle: String,            // Version/cycle identifier for approval dedupe
- *   decision: "approve" | "reject",  // Approval decision
- *   overrideEntries: [               // Optional per-student grade adjustments
- *     {
- *       studentId: String,
- *       originalFinalGrade: Number,
- *       overriddenFinalGrade: Number,
- *       comment?: String
- *     }
- *   ],
- *   reason?: String                  // Optional justification
- * }
- *
- * Response (for Issue #255 & UI feedback):
- * {
- *   success: Boolean,
- *   approvalId: String,
- *   timestamp: Date,
- *   groupId: String,
- *   // coordinatorId is derived from req.user.userId (token identity)
- *   decision: String,
- *   totalStudents: Number,
- *   approvedCount: Number,
- *   rejectedCount: Number,
- *   overridesApplied: Number,
- *   grades: [
- *     {
- *       studentId: String,
- *       computedFinalGrade: Number,
- *       effectiveFinalGrade: Number,
- *       overrideApplied: Boolean,
- *       overriddenGrade: Number | null,
- *       approvedAt: Date,
- *       approvedBy: String
- *     }
- *   ],
- *   message: String
- * }
- *
- * Error responses:
- * - 403: Forbidden (user is not coordinator)
- * - 404: Not found (group doesn't exist)
- * - 409: Conflict (grades already approved)
- * - 422: Unprocessable entity (validation error)
- * - 500: Internal server error
  */
 const approveGroupGradesHandler = async (req, res) => {
   try {
@@ -193,23 +149,6 @@ const approveGroupGradesHandler = async (req, res) => {
 
 /**
  * ISSUE #253: GET /groups/:groupId/final-grades/summary
- * 
- * Optional: Get approval summary for coordinator dashboard
- * Shows counts of grades by status (pending, approved, rejected, published)
- *
- * Response:
- * [
- *   {
- *     _id: "pending",
- *     count: 5,
- *     avgGrade: 78.5
- *   },
- *   {
- *     _id: "approved",
- *     count: 3,
- *     avgGrade: 82.0
- *   }
- * ]
  */
 const getGroupApprovalSummaryHandler = async (req, res) => {
   try {
@@ -251,13 +190,8 @@ const getGroupApprovalSummaryHandler = async (req, res) => {
   }
 };
 
-/**
- * ================================================================================
- * ISSUE #253: EXPORTS
- * ================================================================================
- */
-
 module.exports = {
+  previewFinalGrades,
   approveGroupGradesHandler,
   getGroupApprovalSummaryHandler
 };

--- a/backend/src/models/Evaluation.js
+++ b/backend/src/models/Evaluation.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const { v4: uuidv4 } = require('uuid');
+
+/**
+ * Evaluation Schema (D5 Data Store)
+ *
+ * Stores the actual numerical scores given by assigned reviewers.
+ * Used during Process 8.1 (Final Grade Preview/Calculation).
+ */
+const evaluationSchema = new mongoose.Schema(
+  {
+    evaluationId: {
+      type: String,
+      unique: true,
+      required: true,
+      default: () => `eval_${uuidv4().replace(/-/g, '').slice(0, 10)}`,
+    },
+    deliverableId: {
+      type: String,
+      required: true,
+      ref: 'Deliverable',
+      index: true,
+    },
+    groupId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    evaluatorId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    score: {
+      type: Number,
+      default: null, // Null indicates the evaluation has not been completed yet
+      min: 0,
+      max: 100,
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'completed'],
+      default: 'pending',
+      index: true,
+    },
+    comments: {
+      type: String,
+      default: null,
+    },
+  },
+  {
+    timestamps: true,
+    collection: 'evaluations',
+  }
+);
+
+// Compound indexes for orchestration queries
+evaluationSchema.index({ deliverableId: 1, status: 1 });
+evaluationSchema.index({ groupId: 1, deliverableId: 1 });
+
+module.exports = mongoose.model('Evaluation', evaluationSchema);

--- a/backend/src/models/Review.js
+++ b/backend/src/models/Review.js
@@ -3,14 +3,52 @@
 const mongoose = require('mongoose');
 const { v4: uuidv4 } = require('uuid');
 
+const evaluationScoreSchema = new mongoose.Schema(
+  {
+    criterion: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    score: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+    maxScore: {
+      type: Number,
+      required: true,
+      min: 0.01,
+      default: 100,
+    },
+    weight: {
+      type: Number,
+      required: true,
+      min: 0.01,
+      default: 1,
+    },
+    ratedBy: {
+      type: String,
+      required: true,
+    },
+    ratedAt: {
+      type: Date,
+      required: true,
+      default: () => new Date(),
+    },
+  },
+  { _id: false }
+);
+
 /**
- * Review Schema (D5 — Review Assignments)
+ * Review Schema (D5 Review Assignments and Evaluations)
  *
  * Tracks the lifecycle of a review assigned to committee members for a specific
  * deliverable. One review record exists per deliverable; committee members are
  * listed in assignedMembers with their individual acceptance status.
  *
- * Process 6 — Review & Comment workflow.
+ * Process 6 covers review/comment workflow. Process 8.1 consumes the evaluation
+ * fields to compute deliverable aggregate scores for final grade preview.
  */
 const reviewSchema = new mongoose.Schema(
   {
@@ -60,6 +98,20 @@ const reviewSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    evaluationScores: {
+      type: [evaluationScoreSchema],
+      default: [],
+    },
+    aggregateScore: {
+      type: Number,
+      default: null,
+      min: 0,
+      max: 100,
+    },
+    evaluationCompletedAt: {
+      type: Date,
+      default: null,
+    },
   },
   {
     timestamps: true,
@@ -69,5 +121,6 @@ const reviewSchema = new mongoose.Schema(
 
 reviewSchema.index({ deliverableId: 1 }, { unique: true });
 reviewSchema.index({ status: 1 });
+reviewSchema.index({ groupId: 1, status: 1 });
 
 module.exports = mongoose.model('Review', reviewSchema);

--- a/backend/src/models/SprintConfig.js
+++ b/backend/src/models/SprintConfig.js
@@ -30,6 +30,11 @@ const sprintConfigSchema = new mongoose.Schema(
       type: Date,
       required: true,
     },
+    weight: {
+      type: Number,
+      default: 1,
+      min: 0,
+    },
     description: {
       type: String,
       default: null,

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -46,6 +46,7 @@ const {
 const { submitDeliverableHandler } = require('../controllers/deliverables'); // From main
 const { releaseAdvisor } = require('../controllers/advisorAssociation'); // From main
 const { advisorSanitization } = require('../controllers/sanitizationController'); // From main
+const { previewFinalGrades } = require('../controllers/finalGradeController'); // Final Grade Process
 
 // ============================================================================
 // GROUP LIFECYCLE & MANAGEMENT (Process 2.1 - 2.2)
@@ -260,6 +261,16 @@ router.post(
   roleMiddleware(['coordinator']), 
   checkAdvisorOperationWindow(OPERATION_TYPES.ADVISOR_TRANSFER),
   transferAdvisor
+);
+
+// ============================================================================
+// FINAL GRADES (Process 8.1)
+// ============================================================================
+router.post(
+  '/:groupId/final-grades/preview',
+  authMiddleware,
+  roleMiddleware(['coordinator']),
+  previewFinalGrades
 );
 
 module.exports = router;

--- a/backend/src/services/deliverableScoreAggregationService.js
+++ b/backend/src/services/deliverableScoreAggregationService.js
@@ -1,0 +1,269 @@
+'use strict';
+
+const Deliverable = require('../models/Deliverable');
+const Review = require('../models/Review');
+
+class DeliverableScoreAggregationError extends Error {
+  constructor(message, statusCode = 500, errorCode = 'DELIVERABLE_SCORE_AGGREGATION_ERROR', details = {}) {
+    super(message);
+    this.name = 'DeliverableScoreAggregationError';
+    this.statusCode = statusCode;
+    this.errorCode = errorCode;
+    this.details = details;
+  }
+}
+
+const roundScore = (value) => Math.round((value + Number.EPSILON) * 100) / 100;
+
+const isFiniteNumber = (value) => typeof value === 'number' && Number.isFinite(value);
+
+const validateGroupId = (groupId) => {
+  if (!groupId || typeof groupId !== 'string' || groupId.trim() === '') {
+    throw new DeliverableScoreAggregationError(
+      'groupId is required',
+      400,
+      'INVALID_GROUP_ID'
+    );
+  }
+};
+
+const normalizeIncludeDeliverableIds = (includeDeliverableIds) => {
+  if (includeDeliverableIds === undefined || includeDeliverableIds === null) {
+    return null;
+  }
+
+  if (!Array.isArray(includeDeliverableIds) || includeDeliverableIds.length === 0) {
+    throw new DeliverableScoreAggregationError(
+      'includeDeliverableIds must be a non-empty array when provided',
+      400,
+      'INVALID_DELIVERABLE_FILTER'
+    );
+  }
+
+  const normalized = includeDeliverableIds.map((deliverableId) => {
+    if (!deliverableId || typeof deliverableId !== 'string' || deliverableId.trim() === '') {
+      throw new DeliverableScoreAggregationError(
+        'includeDeliverableIds must contain only non-empty strings',
+        400,
+        'INVALID_DELIVERABLE_FILTER'
+      );
+    }
+
+    return deliverableId.trim();
+  });
+
+  return [...new Set(normalized)];
+};
+
+const getReviewerIds = (review) => {
+  const scoreReviewers = (review.evaluationScores || [])
+    .map((score) => score.ratedBy)
+    .filter(Boolean);
+
+  if (scoreReviewers.length > 0) {
+    return [...new Set(scoreReviewers)];
+  }
+
+  return [...new Set((review.assignedMembers || []).map((member) => member.memberId).filter(Boolean))];
+};
+
+const computeWeightedEvaluationScore = (deliverableId, review) => {
+  const scores = Array.isArray(review.evaluationScores) ? review.evaluationScores : [];
+
+  if (scores.length === 0) {
+    throw new DeliverableScoreAggregationError(
+      `Completed review ${review.reviewId} has no usable evaluation scores`,
+      409,
+      'MISSING_DELIVERABLE_SCORE',
+      { deliverableId, reviewId: review.reviewId }
+    );
+  }
+
+  let weightedTotal = 0;
+  let weightTotal = 0;
+
+  for (const scoreRow of scores) {
+    const { criterion, score, maxScore, weight } = scoreRow;
+
+    if (!criterion || typeof criterion !== 'string') {
+      throw new DeliverableScoreAggregationError(
+        `Evaluation score for deliverable ${deliverableId} is missing a criterion`,
+        400,
+        'INVALID_EVALUATION_SCORE',
+        { deliverableId, reviewId: review.reviewId }
+      );
+    }
+
+    if (!isFiniteNumber(score) || !isFiniteNumber(maxScore) || !isFiniteNumber(weight)) {
+      throw new DeliverableScoreAggregationError(
+        `Evaluation score for deliverable ${deliverableId} contains non-numeric values`,
+        400,
+        'INVALID_EVALUATION_SCORE',
+        { deliverableId, reviewId: review.reviewId, criterion }
+      );
+    }
+
+    if (maxScore <= 0 || weight <= 0 || score < 0 || score > maxScore) {
+      throw new DeliverableScoreAggregationError(
+        `Evaluation score for deliverable ${deliverableId} is outside the allowed range`,
+        400,
+        'INVALID_EVALUATION_SCORE',
+        { deliverableId, reviewId: review.reviewId, criterion, score, maxScore, weight }
+      );
+    }
+
+    weightedTotal += (score / maxScore) * 100 * weight;
+    weightTotal += weight;
+  }
+
+  if (weightTotal <= 0) {
+    throw new DeliverableScoreAggregationError(
+      `Completed review ${review.reviewId} has no positive evaluation weights`,
+      409,
+      'MISSING_DELIVERABLE_SCORE',
+      { deliverableId, reviewId: review.reviewId }
+    );
+  }
+
+  return {
+    score: roundScore(weightedTotal / weightTotal),
+    scoreSource: 'evaluationScores',
+  };
+};
+
+const computeDeliverableScore = (deliverable, review) => {
+  if (!review) {
+    throw new DeliverableScoreAggregationError(
+      `Deliverable ${deliverable.deliverableId} does not have a review record`,
+      409,
+      'INCOMPLETE_DELIVERABLE_EVALUATION',
+      { deliverableId: deliverable.deliverableId }
+    );
+  }
+
+  if (review.status !== 'completed') {
+    throw new DeliverableScoreAggregationError(
+      `Deliverable ${deliverable.deliverableId} review is not completed`,
+      409,
+      'INCOMPLETE_DELIVERABLE_EVALUATION',
+      { deliverableId: deliverable.deliverableId, reviewId: review.reviewId, status: review.status }
+    );
+  }
+
+  if (review.aggregateScore !== null && review.aggregateScore !== undefined) {
+    if (!isFiniteNumber(review.aggregateScore) || review.aggregateScore < 0 || review.aggregateScore > 100) {
+      throw new DeliverableScoreAggregationError(
+        `Aggregate score for deliverable ${deliverable.deliverableId} is outside the allowed range`,
+        400,
+        'INVALID_AGGREGATE_SCORE',
+        { deliverableId: deliverable.deliverableId, reviewId: review.reviewId, aggregateScore: review.aggregateScore }
+      );
+    }
+
+    return {
+      score: roundScore(review.aggregateScore),
+      scoreSource: 'aggregateScore',
+    };
+  }
+
+  return computeWeightedEvaluationScore(deliverable.deliverableId, review);
+};
+
+const buildDeliverableQuery = (groupId, includeDeliverableIds) => {
+  const query = { groupId };
+
+  if (includeDeliverableIds) {
+    query.deliverableId = { $in: includeDeliverableIds };
+  }
+
+  return query;
+};
+
+const getDeliverableAggregateScoresForGroup = async (groupId, options = {}) => {
+  validateGroupId(groupId);
+  const normalizedGroupId = groupId.trim();
+  const includeDeliverableIds = normalizeIncludeDeliverableIds(options.includeDeliverableIds);
+
+  const deliverables = await Deliverable.find(buildDeliverableQuery(normalizedGroupId, includeDeliverableIds))
+    .sort({ submittedAt: 1, deliverableId: 1 })
+    .lean();
+
+  if (deliverables.length === 0 && includeDeliverableIds) {
+    throw new DeliverableScoreAggregationError(
+      'One or more requested deliverables were not found for this group',
+      404,
+      'REQUESTED_DELIVERABLES_NOT_FOUND',
+      { groupId: normalizedGroupId, missingDeliverableIds: includeDeliverableIds }
+    );
+  }
+
+  if (deliverables.length === 0) {
+    throw new DeliverableScoreAggregationError(
+      `No deliverables found for group ${normalizedGroupId}`,
+      404,
+      'DELIVERABLES_NOT_FOUND',
+      { groupId: normalizedGroupId, includeDeliverableIds: includeDeliverableIds || [] }
+    );
+  }
+
+  if (includeDeliverableIds) {
+    const foundIds = new Set(deliverables.map((deliverable) => deliverable.deliverableId));
+    const missingDeliverableIds = includeDeliverableIds.filter((deliverableId) => !foundIds.has(deliverableId));
+
+    if (missingDeliverableIds.length > 0) {
+      throw new DeliverableScoreAggregationError(
+        'One or more requested deliverables were not found for this group',
+        404,
+        'REQUESTED_DELIVERABLES_NOT_FOUND',
+        { groupId: normalizedGroupId, missingDeliverableIds }
+      );
+    }
+  }
+
+  const deliverableIds = deliverables.map((deliverable) => deliverable.deliverableId);
+  const reviews = await Review.find({
+    groupId: normalizedGroupId,
+    deliverableId: { $in: deliverableIds },
+  }).lean();
+
+  const reviewsByDeliverableId = new Map(
+    reviews.map((review) => [review.deliverableId, review])
+  );
+
+  const deliverableScoreBreakdown = {};
+  const auditTrail = [];
+  let scoreTotal = 0;
+
+  for (const deliverable of deliverables) {
+    const review = reviewsByDeliverableId.get(deliverable.deliverableId);
+    const { score, scoreSource } = computeDeliverableScore(deliverable, review);
+
+    deliverableScoreBreakdown[deliverable.deliverableId] = score;
+    scoreTotal += score;
+
+    auditTrail.push({
+      deliverableId: deliverable.deliverableId,
+      deliverableType: deliverable.deliverableType,
+      sprintId: deliverable.sprintId || null,
+      reviewId: review.reviewId,
+      score,
+      scoreSource,
+      reviewerIds: getReviewerIds(review),
+      submittedAt: deliverable.submittedAt || null,
+      evaluatedAt: review.evaluationCompletedAt || review.updatedAt || null,
+    });
+  }
+
+  return {
+    groupId: normalizedGroupId,
+    baseGroupScore: roundScore(scoreTotal / deliverables.length),
+    deliverableScoreBreakdown,
+    auditTrail,
+    createdAt: new Date(),
+  };
+};
+
+module.exports = {
+  DeliverableScoreAggregationError,
+  getDeliverableAggregateScoresForGroup,
+};

--- a/backend/src/services/finalGradeCalculationService.js
+++ b/backend/src/services/finalGradeCalculationService.js
@@ -1,0 +1,101 @@
+'use strict';
+
+/**
+ * @typedef {Object} StudentRatio
+ * @property {string} studentId
+ * @property {number} [ratio]
+ * @property {number} [contributionRatio]
+ *
+ * @typedef {Object} FinalGradePreviewEntry
+ * @property {string} studentId
+ * @property {number} contributionRatio
+ * @property {number} computedFinalGrade
+ *
+ * @typedef {Object} FinalGradesPreview
+ * @property {number} baseGroupScore
+ * @property {FinalGradePreviewEntry[]} students
+ */
+
+const DEFAULT_RATIO = 1.0;
+const ROUNDING_SCALE = 100;
+
+function toFiniteNumber(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function roundToTwoDecimals(value) {
+  const safe = toFiniteNumber(value, 0);
+  return Math.round((safe + Number.EPSILON) * ROUNDING_SCALE) / ROUNDING_SCALE;
+}
+
+function sumWeightBucket(bucket) {
+  if (!bucket || typeof bucket !== 'object') {
+    return 0;
+  }
+
+  return Object.values(bucket).reduce((total, current) => {
+    return total + toFiniteNumber(current, 0);
+  }, 0);
+}
+
+function resolveRubricMultiplier(rubricWeights) {
+  if (!rubricWeights || typeof rubricWeights !== 'object') {
+    return 1;
+  }
+
+  const deliverableWeights =
+    rubricWeights.deliverableWeights || rubricWeights.deliverables || {};
+  const sprintWeights =
+    rubricWeights.sprintWeights || rubricWeights.sprints || {};
+
+  const deliverableTotal = sumWeightBucket(deliverableWeights);
+  const sprintTotal = sumWeightBucket(sprintWeights);
+  const totalWeight = deliverableTotal + sprintTotal;
+
+  if (!Number.isFinite(totalWeight) || totalWeight <= 0) {
+    return 1;
+  }
+
+  return totalWeight / 100;
+}
+
+class FinalGradeCalculationService {
+  /**
+   * @param {number} baseGroupScore
+   * @param {StudentRatio[]} ratios
+   * @param {object} rubricWeights
+   * @returns {FinalGradesPreview}
+   */
+  computeFinalGrades(baseGroupScore, ratios = [], rubricWeights = {}) {
+    const safeBaseGroupScore = toFiniteNumber(baseGroupScore, 0);
+    const rubricMultiplier = resolveRubricMultiplier(rubricWeights);
+    const adjustedBaseScore = roundToTwoDecimals(safeBaseGroupScore * rubricMultiplier);
+
+    const students = (Array.isArray(ratios) ? ratios : []).map((entry) => {
+      const rawRatio = toFiniteNumber(
+        entry?.ratio ?? entry?.contributionRatio,
+        DEFAULT_RATIO
+      );
+      const safeRatio = roundToTwoDecimals(rawRatio);
+      const computedFinalGrade = roundToTwoDecimals(adjustedBaseScore * rawRatio);
+
+      return {
+        studentId: entry?.studentId || '',
+        contributionRatio: safeRatio,
+        computedFinalGrade,
+      };
+    });
+
+    return {
+      baseGroupScore: adjustedBaseScore,
+      students,
+    };
+  }
+}
+
+module.exports = {
+  FinalGradeCalculationService,
+  roundToTwoDecimals,
+  resolveRubricMultiplier,
+};

--- a/backend/src/services/finalGradeCalculationService.js
+++ b/backend/src/services/finalGradeCalculationService.js
@@ -57,7 +57,10 @@ function resolveRubricMultiplier(rubricWeights) {
     return 1;
   }
 
-  return totalWeight / 100;
+  // OpenAPI Uyumu: baseGroupScore halihazırda weighted (ağırlıklandırılmış) bir puandır.
+  // Bu nedenle, ağırlıkların toplamını yine ağırlıkların toplamına bölerek (weighted average mantığı)
+  // çarpanı 1.0 olarak sabitliyoruz. Serviste tekrar ağırlık uygulamıyoruz.
+  return totalWeight / totalWeight;
 }
 
 class FinalGradeCalculationService {
@@ -78,7 +81,8 @@ class FinalGradeCalculationService {
         DEFAULT_RATIO
       );
       const safeRatio = roundToTwoDecimals(rawRatio);
-      const computedFinalGrade = roundToTwoDecimals(adjustedBaseScore * rawRatio);
+      // Senkronizasyon: Yuvarlanmış değeri hem çıktı hem de hesaplama için ortak kullanıyoruz
+      const computedFinalGrade = roundToTwoDecimals(adjustedBaseScore * safeRatio);
 
       return {
         studentId: entry?.studentId || '',
@@ -87,6 +91,8 @@ class FinalGradeCalculationService {
       };
     });
 
+    // Veri Yapısı Mimari Kararı: Pure function sadece hesaplama sonucunu dönmeli.
+    // groupId gibi meta veriler controller/orchestrator katmanında eklenmelidir.
     return {
       baseGroupScore: adjustedBaseScore,
       students,

--- a/backend/src/services/finalGradePreviewService.js
+++ b/backend/src/services/finalGradePreviewService.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const Deliverable = require('../models/Deliverable');
+const ContributionRecord = require('../models/ContributionRecord');
+const { FinalGradeCalculationService } = require('./finalGradeCalculationService');
+
+class FinalGradePreviewService {
+  constructor() {
+    this.calculator = new FinalGradeCalculationService();
+  }
+
+  /**
+   * Generates a preview of the final grades for a given group
+   * @param {string} groupId 
+   */
+  async previewGroupGrade(groupId) {
+    if (!groupId) {
+      const error = new Error('groupId is required');
+      error.status = 400;
+      throw error;
+    }
+
+    // 1. Fetch D4 (Deliverables) and join D5 (Evaluations) & D8 (SprintConfig)
+    // using a single Aggregation Pipeline to prevent N+1 query problem.
+    const deliverables = await Deliverable.aggregate([
+      { 
+        $match: { 
+          groupId, 
+          status: { $in: ['accepted', 'evaluated', 'under_review'] } 
+        } 
+      },
+      {
+        $lookup: {
+          from: 'evaluations', // D5
+          localField: 'deliverableId',
+          foreignField: 'deliverableId',
+          as: 'evaluations'
+        }
+      },
+      {
+        $lookup: {
+          from: 'sprint_configs', // D8
+          let: { type: '$deliverableType', sprint: '$sprintId' },
+          pipeline: [
+            { 
+              $match: { 
+                $expr: { 
+                  $and: [ 
+                    { $eq: ['$deliverableType', '$$type'] }, 
+                    { $eq: ['$sprintId', '$$sprint'] } 
+                  ] 
+                } 
+              } 
+            }
+          ],
+          as: 'config'
+        }
+      },
+      { $unwind: { path: '$config', preserveNullAndEmptyArrays: true } }
+    ]);
+
+    if (!deliverables || deliverables.length === 0) {
+      return { baseGroupScore: 0, students: [] };
+    }
+
+    let totalWeightedScore = 0;
+    let totalWeight = 0;
+    const rubricWeights = { deliverables: {} };
+
+    // 2. Validate completeness and compute average score per deliverable
+    for (const item of deliverables) {
+      const weight = item.config?.weight != null ? item.config.weight : 1.0;
+      rubricWeights.deliverables[item.deliverableId] = weight;
+
+      if (!item.evaluations || item.evaluations.length === 0) {
+        const error = new Error(`Missing Evaluation Data: Zorunlu deliverable (${item.deliverableId}) henüz puanlanmamış.`);
+        error.status = 400;
+        throw error;
+      }
+
+      // Check partial evaluations (if 2 out of 3 graded, etc.) and NULL vs 0.
+      const hasPending = item.evaluations.some(ev => ev.status === 'pending' || ev.score == null);
+      if (hasPending) {
+        const error = new Error(`Incomplete Evaluations: Deliverable (${item.deliverableId}) jüri değerlendirmeleri tamamlanmamış (Kısmi değerlendirme).`);
+        error.status = 409;
+        throw error;
+      }
+
+      // Compute simple average among the evaluators for this deliverable
+      const sum = item.evaluations.reduce((acc, ev) => acc + ev.score, 0);
+      const avgScore = sum / item.evaluations.length;
+
+      // Process 6.0 External Signal: Late Submission Penalty
+      let finalDeliverableScore = avgScore;
+      if (item.config?.deadline && new Date(item.submittedAt) > new Date(item.config.deadline)) {
+        // e.g., apply a 10% penalty
+        finalDeliverableScore = finalDeliverableScore * 0.9;
+      }
+
+      totalWeightedScore += (finalDeliverableScore * weight);
+      totalWeight += weight;
+    }
+
+    // 3. Compute baseGroupScore
+    const baseGroupScore = totalWeight > 0 ? (totalWeightedScore / totalWeight) : 0;
+
+    // 4. Fetch D6 (ContributionRecords) to get Student Ratios
+    const contributions = await ContributionRecord.find({ groupId });
+    const studentMap = {};
+    
+    for (const c of contributions) {
+      if (!studentMap[c.studentId]) {
+        studentMap[c.studentId] = { studentId: c.studentId, ratioSum: 0, count: 0 };
+      }
+      studentMap[c.studentId].ratioSum += (c.contributionRatio != null ? c.contributionRatio : 1.0);
+      studentMap[c.studentId].count += 1;
+    }
+
+    const ratios = Object.values(studentMap).map(s => ({
+      studentId: s.studentId,
+      contributionRatio: s.ratioSum / s.count
+    }));
+
+    // 5. Delegate to Pure Calculation Engine
+    return this.calculator.computeFinalGrades(baseGroupScore, ratios, rubricWeights);
+  }
+}
+
+module.exports = new FinalGradePreviewService();

--- a/backend/tests/deliverable-score-aggregation.test.js
+++ b/backend/tests/deliverable-score-aggregation.test.js
@@ -1,0 +1,282 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+jest.mock('../src/models/Deliverable', () => ({
+  find: jest.fn(),
+}));
+
+jest.mock('../src/models/Review', () => ({
+  find: jest.fn(),
+}));
+
+const Deliverable = require('../src/models/Deliverable');
+const Review = require('../src/models/Review');
+const {
+  DeliverableScoreAggregationError,
+  getDeliverableAggregateScoresForGroup,
+} = require('../src/services/deliverableScoreAggregationService');
+
+const makeDeliverable = (overrides = {}) => ({
+  deliverableId: overrides.deliverableId || 'del_alpha',
+  groupId: overrides.groupId || 'grp_score_1',
+  committeeId: overrides.committeeId || 'com_score_1',
+  deliverableType: overrides.deliverableType || 'proposal',
+  sprintId: overrides.sprintId || 'sprint_1',
+  submittedBy: overrides.submittedBy || 'stu_1',
+  status: overrides.status || 'evaluated',
+  submittedAt: overrides.submittedAt || new Date('2026-04-01T10:00:00.000Z'),
+  ...overrides,
+});
+
+const makeReview = (overrides = {}) => ({
+  reviewId: overrides.reviewId || `rev_${overrides.deliverableId || 'alpha'}`,
+  deliverableId: overrides.deliverableId || 'del_alpha',
+  groupId: overrides.groupId || 'grp_score_1',
+  status: overrides.status || 'completed',
+  assignedMembers: overrides.assignedMembers || [
+    { memberId: 'prof_1', status: 'accepted' },
+  ],
+  evaluationScores: overrides.evaluationScores || [],
+  aggregateScore: Object.prototype.hasOwnProperty.call(overrides, 'aggregateScore')
+    ? overrides.aggregateScore
+    : 80,
+  evaluationCompletedAt: overrides.evaluationCompletedAt || new Date('2026-04-10T10:00:00.000Z'),
+  updatedAt: overrides.updatedAt || new Date('2026-04-11T10:00:00.000Z'),
+  ...overrides,
+});
+
+const mockDeliverables = (deliverables) => {
+  const lean = jest.fn().mockResolvedValue(deliverables);
+  const sort = jest.fn().mockReturnValue({ lean });
+
+  Deliverable.find.mockReturnValue({ sort });
+  return { sort, lean };
+};
+
+const mockReviews = (reviews) => {
+  const lean = jest.fn().mockResolvedValue(reviews);
+
+  Review.find.mockReturnValue({ lean });
+  return { lean };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('deliverableScoreAggregationService', () => {
+  it('aggregates multiple evaluated deliverables into a base group score', async () => {
+    mockDeliverables([
+      makeDeliverable({ deliverableId: 'del_alpha', deliverableType: 'proposal' }),
+      makeDeliverable({ deliverableId: 'del_beta', deliverableType: 'final_report' }),
+    ]);
+    mockReviews([
+      makeReview({ deliverableId: 'del_alpha', aggregateScore: 80 }),
+      makeReview({ deliverableId: 'del_beta', aggregateScore: 90 }),
+    ]);
+
+    const result = await getDeliverableAggregateScoresForGroup('grp_score_1');
+
+    expect(Deliverable.find).toHaveBeenCalledWith({ groupId: 'grp_score_1' });
+    expect(Review.find).toHaveBeenCalledWith({
+      groupId: 'grp_score_1',
+      deliverableId: { $in: ['del_alpha', 'del_beta'] },
+    });
+    expect(result.groupId).toBe('grp_score_1');
+    expect(result.baseGroupScore).toBe(85);
+    expect(result.deliverableScoreBreakdown).toEqual({
+      del_alpha: 80,
+      del_beta: 90,
+    });
+    expect(result.auditTrail).toHaveLength(2);
+    expect(result.auditTrail[0]).toMatchObject({
+      deliverableId: 'del_alpha',
+      reviewId: 'rev_del_alpha',
+      score: 80,
+      scoreSource: 'aggregateScore',
+      reviewerIds: ['prof_1'],
+    });
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('uses aggregateScore directly when present', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_direct' })]);
+    mockReviews([
+      makeReview({
+        deliverableId: 'del_direct',
+        aggregateScore: 77.777,
+        evaluationScores: [
+          { criterion: 'Ignored row', score: 10, maxScore: 100, weight: 1, ratedBy: 'prof_2' },
+        ],
+      }),
+    ]);
+
+    const result = await getDeliverableAggregateScoresForGroup('grp_score_1');
+
+    expect(result.baseGroupScore).toBe(77.78);
+    expect(result.deliverableScoreBreakdown.del_direct).toBe(77.78);
+    expect(result.auditTrail[0].scoreSource).toBe('aggregateScore');
+  });
+
+  it('falls back to weighted evaluationScores when aggregateScore is absent', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_weighted' })]);
+    mockReviews([
+      makeReview({
+        deliverableId: 'del_weighted',
+        aggregateScore: null,
+        evaluationScores: [
+          { criterion: 'Design', score: 8, maxScore: 10, weight: 2, ratedBy: 'prof_1' },
+          { criterion: 'Implementation', score: 45, maxScore: 50, weight: 1, ratedBy: 'prof_2' },
+        ],
+      }),
+    ]);
+
+    const result = await getDeliverableAggregateScoresForGroup('grp_score_1');
+
+    expect(result.baseGroupScore).toBe(83.33);
+    expect(result.deliverableScoreBreakdown.del_weighted).toBe(83.33);
+    expect(result.auditTrail[0]).toMatchObject({
+      scoreSource: 'evaluationScores',
+      reviewerIds: ['prof_1', 'prof_2'],
+    });
+  });
+
+  it('filters by includeDeliverableIds and keeps output stable', async () => {
+    mockDeliverables([
+      makeDeliverable({ deliverableId: 'del_keep' }),
+    ]);
+    mockReviews([
+      makeReview({ deliverableId: 'del_keep', aggregateScore: 95 }),
+    ]);
+
+    const result = await getDeliverableAggregateScoresForGroup('grp_score_1', {
+      includeDeliverableIds: ['del_keep'],
+    });
+
+    expect(Deliverable.find).toHaveBeenCalledWith({
+      groupId: 'grp_score_1',
+      deliverableId: { $in: ['del_keep'] },
+    });
+    expect(result.baseGroupScore).toBe(95);
+    expect(result.deliverableScoreBreakdown).toEqual({ del_keep: 95 });
+    expect(result.auditTrail.map((entry) => entry.deliverableId)).toEqual(['del_keep']);
+  });
+
+  it('throws 409 when a required deliverable has no review', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_no_review' })]);
+    mockReviews([]);
+
+    await expect(getDeliverableAggregateScoresForGroup('grp_score_1')).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: 'INCOMPLETE_DELIVERABLE_EVALUATION',
+      details: { deliverableId: 'del_no_review' },
+    });
+  });
+
+  it('throws 409 when a review is not completed', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_pending' })]);
+    mockReviews([
+      makeReview({
+        deliverableId: 'del_pending',
+        status: 'in_progress',
+        aggregateScore: 88,
+      }),
+    ]);
+
+    await expect(getDeliverableAggregateScoresForGroup('grp_score_1')).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: 'INCOMPLETE_DELIVERABLE_EVALUATION',
+      details: {
+        deliverableId: 'del_pending',
+        status: 'in_progress',
+      },
+    });
+  });
+
+  it('throws 409 when a completed review lacks usable scores', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_no_scores' })]);
+    mockReviews([
+      makeReview({
+        deliverableId: 'del_no_scores',
+        aggregateScore: null,
+        evaluationScores: [],
+      }),
+    ]);
+
+    await expect(getDeliverableAggregateScoresForGroup('grp_score_1')).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: 'MISSING_DELIVERABLE_SCORE',
+      details: { deliverableId: 'del_no_scores' },
+    });
+  });
+
+  it('throws 404 when requested deliverable IDs are not found for the group', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_existing' })]);
+    mockReviews([makeReview({ deliverableId: 'del_existing', aggregateScore: 80 })]);
+
+    await expect(
+      getDeliverableAggregateScoresForGroup('grp_score_1', {
+        includeDeliverableIds: ['del_existing', 'del_missing'],
+      })
+    ).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: 'REQUESTED_DELIVERABLES_NOT_FOUND',
+      details: { missingDeliverableIds: ['del_missing'] },
+    });
+  });
+
+  it('throws 404 with requested IDs when all filtered deliverables are missing', async () => {
+    mockDeliverables([]);
+
+    await expect(
+      getDeliverableAggregateScoresForGroup('grp_score_1', {
+        includeDeliverableIds: ['del_missing'],
+      })
+    ).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: 'REQUESTED_DELIVERABLES_NOT_FOUND',
+      details: { missingDeliverableIds: ['del_missing'] },
+    });
+    expect(Review.find).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 for invalid includeDeliverableIds filters', async () => {
+    await expect(
+      getDeliverableAggregateScoresForGroup('grp_score_1', { includeDeliverableIds: [] })
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      errorCode: 'INVALID_DELIVERABLE_FILTER',
+    });
+  });
+
+  it('throws 400 for invalid score ranges', async () => {
+    mockDeliverables([makeDeliverable({ deliverableId: 'del_bad_score' })]);
+    mockReviews([
+      makeReview({
+        deliverableId: 'del_bad_score',
+        aggregateScore: null,
+        evaluationScores: [
+          { criterion: 'Design', score: 120, maxScore: 100, weight: 1, ratedBy: 'prof_1' },
+        ],
+      }),
+    ]);
+
+    await expect(getDeliverableAggregateScoresForGroup('grp_score_1')).rejects.toMatchObject({
+      statusCode: 400,
+      errorCode: 'INVALID_EVALUATION_SCORE',
+      details: {
+        deliverableId: 'del_bad_score',
+        criterion: 'Design',
+      },
+    });
+  });
+
+  it('exports a typed aggregation error for controller error mapping', () => {
+    const error = new DeliverableScoreAggregationError('test', 409, 'TEST_CODE');
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.statusCode).toBe(409);
+    expect(error.errorCode).toBe('TEST_CODE');
+  });
+});

--- a/backend/tests/final-grade-calculation.service.test.js
+++ b/backend/tests/final-grade-calculation.service.test.js
@@ -33,7 +33,7 @@ describe('FinalGradeCalculationService.computeFinalGrades', () => {
     });
   });
 
-  it('changes preview linearly when rubric weights change', () => {
+  it('maintains the same base score when rubric weights change (already weighted)', () => {
     const baseInput = 80;
     const ratios = [{ studentId: 'stu_1', ratio: 1.25 }];
 
@@ -47,11 +47,10 @@ describe('FinalGradeCalculationService.computeFinalGrades', () => {
       sprintWeights: { s1: 50 },
     });
 
+    // baseGroupScore is already weighted, so multiplier is 1.
+    // final grade = 80 * 1.25 = 100 for both.
     expect(result100.students[0].computedFinalGrade).toBe(100);
-    expect(result125.students[0].computedFinalGrade).toBe(125);
-    expect(result125.students[0].computedFinalGrade).toBe(
-      result100.students[0].computedFinalGrade * 1.25
-    );
+    expect(result125.students[0].computedFinalGrade).toBe(100);
   });
 
   it('defaults missing ratio to 1.0', () => {
@@ -123,6 +122,35 @@ describe('FinalGradeCalculationService.computeFinalGrades', () => {
 
     expect(result.baseGroupScore).toBe(83.34);
     expect(result.students[0].contributionRatio).toBe(1.01);
-    expect(result.students[0].computedFinalGrade).toBe(83.76);
+    // 83.34 * 1.01 = 84.1734 -> 84.17
+    expect(result.students[0].computedFinalGrade).toBe(84.17);
+  });
+
+  it('keeps final grade out of 100 when total weights sum to 200', () => {
+    const result = service.computeFinalGrades(
+      100, // max base score
+      [{ studentId: 'stu_1', ratio: 1.0 }],
+      {
+        deliverableWeights: { d1: 100 },
+        sprintWeights: { s1: 100 },
+      }
+    );
+
+    expect(result.baseGroupScore).toBe(100);
+    expect(result.students[0].computedFinalGrade).toBe(100);
+  });
+
+  it('handles zero total weight and empty arrays without NaN/Infinity', () => {
+    const result = service.computeFinalGrades(
+      85,
+      [],
+      {
+        deliverableWeights: { d1: 0 },
+        sprintWeights: { s1: 0 },
+      }
+    );
+    expect(result.baseGroupScore).toBe(85);
+    expect(Array.isArray(result.students)).toBe(true);
+    expect(result.students.length).toBe(0);
   });
 });

--- a/backend/tests/final-grade-calculation.service.test.js
+++ b/backend/tests/final-grade-calculation.service.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const {
+  FinalGradeCalculationService,
+} = require('../src/services/finalGradeCalculationService');
+
+describe('FinalGradeCalculationService.computeFinalGrades', () => {
+  let service;
+
+  beforeEach(() => {
+    service = new FinalGradeCalculationService();
+  });
+
+  it('matches golden fixture exactly for fixed inputs', () => {
+    const result = service.computeFinalGrades(
+      85,
+      [{ studentId: 'stu_1', ratio: 1.1 }],
+      {
+        deliverableWeights: { d1: 70 },
+        sprintWeights: { s1: 30 },
+      }
+    );
+
+    expect(result).toEqual({
+      baseGroupScore: 85,
+      students: [
+        {
+          studentId: 'stu_1',
+          contributionRatio: 1.1,
+          computedFinalGrade: 93.5,
+        },
+      ],
+    });
+  });
+
+  it('changes preview linearly when rubric weights change', () => {
+    const baseInput = 80;
+    const ratios = [{ studentId: 'stu_1', ratio: 1.25 }];
+
+    const result100 = service.computeFinalGrades(baseInput, ratios, {
+      deliverableWeights: { d1: 60 },
+      sprintWeights: { s1: 40 },
+    });
+
+    const result125 = service.computeFinalGrades(baseInput, ratios, {
+      deliverableWeights: { d1: 75 },
+      sprintWeights: { s1: 50 },
+    });
+
+    expect(result100.students[0].computedFinalGrade).toBe(100);
+    expect(result125.students[0].computedFinalGrade).toBe(125);
+    expect(result125.students[0].computedFinalGrade).toBe(
+      result100.students[0].computedFinalGrade * 1.25
+    );
+  });
+
+  it('defaults missing ratio to 1.0', () => {
+    const result = service.computeFinalGrades(
+      90,
+      [{ studentId: 'stu_missing_ratio' }],
+      {
+        deliverableWeights: { d1: 100 },
+      }
+    );
+
+    expect(result.students[0].contributionRatio).toBe(1);
+    expect(result.students[0].computedFinalGrade).toBe(90);
+  });
+
+  it('handles edge case ratio 0 correctly', () => {
+    const result = service.computeFinalGrades(
+      88,
+      [{ studentId: 'stu_zero', ratio: 0 }],
+      {
+        deliverableWeights: { d1: 100 },
+      }
+    );
+
+    expect(result.students[0].computedFinalGrade).toBe(0);
+  });
+
+  it('handles outlier high ratio without NaN/Infinity', () => {
+    const result = service.computeFinalGrades(
+      100,
+      [{ studentId: 'stu_outlier', ratio: 9.999 }],
+      {
+        deliverableWeights: { d1: 100 },
+      }
+    );
+
+    expect(Number.isFinite(result.students[0].computedFinalGrade)).toBe(true);
+    expect(result.students[0].computedFinalGrade).toBe(999.9);
+  });
+
+  it('never returns NaN/Infinity when inputs are invalid', () => {
+    const result = service.computeFinalGrades(
+      Number.POSITIVE_INFINITY,
+      [
+        { studentId: 'stu_nan', ratio: Number.NaN },
+        { studentId: 'stu_inf', ratio: Number.POSITIVE_INFINITY },
+      ],
+      {
+        deliverableWeights: { d1: Number.NaN },
+        sprintWeights: { s1: Number.POSITIVE_INFINITY },
+      }
+    );
+
+    expect(Number.isFinite(result.baseGroupScore)).toBe(true);
+    result.students.forEach((student) => {
+      expect(Number.isFinite(student.contributionRatio)).toBe(true);
+      expect(Number.isFinite(student.computedFinalGrade)).toBe(true);
+    });
+  });
+
+  it('rounds deterministically to two decimals', () => {
+    const result = service.computeFinalGrades(
+      83.335,
+      [{ studentId: 'stu_round', ratio: 1.005 }],
+      {
+        deliverableWeights: { d1: 100 },
+      }
+    );
+
+    expect(result.baseGroupScore).toBe(83.34);
+    expect(result.students[0].contributionRatio).toBe(1.01);
+    expect(result.students[0].computedFinalGrade).toBe(83.76);
+  });
+});


### PR DESCRIPTION
Changed:

Extended Review.js (line 101) with evaluationScores, aggregateScore, evaluationCompletedAt, plus the { groupId, status } index. Added deliverableScoreAggregationService.js (line 182) with getDeliverableAggregateScoresForGroup(groupId, options), weighted-score fallback, audit trail output, and typed 400/404/409 errors. Added focused tests in deliverable-score-aggregation.test.js (line 69). 
Verified:

npm.cmd test -- deliverable-score-aggregation.test.js --runInBand Direct model/service load sanity check passed.
Closes #248