### PR TITLE
Implement final grade contribution ratio resolver

### DIFF
--- a/backend/src/controllers/finalGradeController.js
+++ b/backend/src/controllers/finalGradeController.js
@@ -23,6 +23,92 @@
  */
 
 const { approveGroupGrades, GradeApprovalError } = require('../services/approvalService');
+const { buildFinalGradesPreview } = require('../services/finalGradePreviewService');
+const {
+  FinalGradeRatioResolverError,
+} = require('../services/finalGradeContributionRatioService');
+const Group = require('../models/Group');
+
+const previewFinalGradesHandler = async (req, res) => {
+  try {
+    const { groupId } = req.params;
+    const requestedBy = req.user?.userId;
+    const requesterRole = req.user?.role;
+    const {
+      includeDeliverableIds,
+      includeSprintIds,
+      useLatestRatios,
+    } = req.body || {};
+
+    if (!groupId || typeof groupId !== 'string' || groupId.trim() === '') {
+      return res.status(400).json({
+        error: 'Invalid group ID',
+        code: 'INVALID_GROUP_ID',
+      });
+    }
+
+    if (!requestedBy || typeof requestedBy !== 'string' || requestedBy.trim() === '') {
+      return res.status(422).json({
+        error: 'Authenticated requester identity is missing',
+        code: 'MISSING_AUTH_USER_ID',
+      });
+    }
+
+    const group = await Group.findOne({ groupId: groupId.trim() })
+      .select('groupId professorId advisorId')
+      .lean();
+
+    if (!group) {
+      return res.status(404).json({
+        error: `Group ${groupId} was not found.`,
+        code: 'GROUP_NOT_FOUND',
+      });
+    }
+
+    // Note: System treats assigned professors and designated advisors equally for preview authorization.
+    if (requesterRole !== 'coordinator') {
+      const isAssigned =
+        String(group.professorId || '') === String(requestedBy) ||
+        String(group.advisorId || '') === String(requestedBy);
+
+      if (!isAssigned) {
+        return res.status(403).json({
+          error: 'Access denied: You are not assigned as an advisor or professor for this group.',
+          code: 'FORBIDDEN_GROUP_ACCESS',
+        });
+      }
+    }
+
+    const preview = await buildFinalGradesPreview(groupId, {
+      requestedBy,
+      includeDeliverableIds,
+      includeSprintIds,
+      useLatestRatios,
+    });
+
+    return res.status(200).json({
+      groupId: preview.groupId,
+      baseGroupScore: preview.baseGroupScore,
+      students: preview.students,
+      createdAt: preview.createdAt,
+    });
+  } catch (error) {
+    if (error instanceof FinalGradeRatioResolverError) {
+      return res.status(error.status).json({
+        error: error.message,
+        code: error.code,
+        details: error.details,
+        timestamp: error.timestamp || new Date(),
+      });
+    }
+
+    return res.status(500).json({
+      error: 'Internal server error',
+      code: 'INTERNAL_ERROR',
+      timestamp: new Date(),
+    });
+  }
+};
 
 /**
  * ISSUE #253: POST /groups/:groupId/final-grades/approval
@@ -258,6 +344,7 @@ const getGroupApprovalSummaryHandler = async (req, res) => {
  */
 
 module.exports = {
+  previewFinalGradesHandler,
   approveGroupGradesHandler,
   getGroupApprovalSummaryHandler
 };

--- a/backend/src/routes/finalGrades.js
+++ b/backend/src/routes/finalGrades.js
@@ -36,9 +36,17 @@ const { authMiddleware, roleMiddleware } = require('../middleware/auth');
 
 // ISSUE #253: Import controller handlers
 const {
+  previewFinalGradesHandler,
   approveGroupGradesHandler,
   getGroupApprovalSummaryHandler
 } = require('../controllers/finalGradeController');
+
+router.post(
+  '/:groupId/final-grades/preview',
+  authMiddleware,
+  roleMiddleware(['coordinator', 'professor', 'advisor']),
+  previewFinalGradesHandler
+);
 
 /**
  * ISSUE #253: POST /groups/:groupId/final-grades/approval

--- a/backend/src/services/finalGradeContributionRatioService.js
+++ b/backend/src/services/finalGradeContributionRatioService.js
@@ -56,7 +56,15 @@ function getRecordTimestamp(record) {
 }
 
 function compareRecordsByRecency(a, b) {
-  return getRecordTimestamp(b).getTime() - getRecordTimestamp(a).getTime();
+  const timestampDelta = getRecordTimestamp(b).getTime() - getRecordTimestamp(a).getTime();
+  if (timestampDelta !== 0) {
+    return timestampDelta;
+  }
+
+  // Deterministic final tie-breaker: newer ObjectId/string _id wins.
+  const aId = a && a._id ? String(a._id) : '';
+  const bId = b && b._id ? String(b._id) : '';
+  return bId.localeCompare(aId);
 }
 
 function roundTo(value, precision = 4) {
@@ -295,7 +303,7 @@ async function resolveContributionRatiosForPreview(groupId, input = {}) {
 
   if (missingStudentIds.length > 0) {
     throw new FinalGradeRatioResolverError(
-      404,
+      422,
       'MISSING_CONTRIBUTION_RATIOS',
       'Required contribution ratios are missing for one or more enrolled students.',
       {

--- a/backend/src/services/finalGradeContributionRatioService.js
+++ b/backend/src/services/finalGradeContributionRatioService.js
@@ -1,0 +1,329 @@
+const mongoose = require('mongoose');
+
+const ContributionRecord = require('../models/ContributionRecord');
+const Group = require('../models/Group');
+const GroupMembership = require('../models/GroupMembership');
+const User = require('../models/User');
+
+class FinalGradeRatioResolverError extends Error {
+  constructor(status, code, message, details = null) {
+    super(message);
+    this.name = 'FinalGradeRatioResolverError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+    this.timestamp = new Date();
+  }
+}
+
+function normalizeStringArray(value, fieldName) {
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new FinalGradeRatioResolverError(
+      400,
+      'INVALID_PREVIEW_FILTER',
+      `${fieldName} must be an array of strings.`,
+      { field: fieldName }
+    );
+  }
+
+  const normalized = value
+    .map((item) => (typeof item === 'string' ? item.trim() : ''))
+    .filter(Boolean);
+
+  return [...new Set(normalized)];
+}
+
+function getGroupQuery(groupId) {
+  const candidates = [{ groupId }];
+  if (mongoose.Types.ObjectId.isValid(groupId)) {
+    candidates.push({ _id: new mongoose.Types.ObjectId(groupId) });
+  }
+  return { $or: candidates };
+}
+
+function getRecordTimestamp(record) {
+  return (
+    record.recalculatedAt ||
+    record.lastUpdatedAt ||
+    record.updatedAt ||
+    record.createdAt ||
+    new Date(0)
+  );
+}
+
+function compareRecordsByRecency(a, b) {
+  return getRecordTimestamp(b).getTime() - getRecordTimestamp(a).getTime();
+}
+
+function roundTo(value, precision = 4) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function assertUsableRatio(record) {
+  const ratio = Number(record.contributionRatio);
+  if (!Number.isFinite(ratio) || ratio < 0 || ratio > 1) {
+    throw new FinalGradeRatioResolverError(
+      409,
+      'INVALID_CONTRIBUTION_RATIO',
+      `D6 contribution ratio is invalid for student ${record.studentId}.`,
+      {
+        studentId: String(record.studentId),
+        sprintId: String(record.sprintId),
+        contributionRecordId: record.contributionRecordId || String(record._id),
+        contributionRatio: record.contributionRatio,
+      }
+    );
+  }
+}
+
+async function loadGroup(groupId) {
+  if (!groupId || typeof groupId !== 'string' || groupId.trim() === '') {
+    throw new FinalGradeRatioResolverError(
+      400,
+      'INVALID_GROUP_ID',
+      'groupId must be a non-empty string.'
+    );
+  }
+
+  const group = await Group.findOne(getGroupQuery(groupId.trim())).lean();
+  if (!group) {
+    throw new FinalGradeRatioResolverError(
+      404,
+      'GROUP_NOT_FOUND',
+      `Group ${groupId} was not found.`
+    );
+  }
+
+  return group;
+}
+
+async function loadEnrolledStudentIds(group) {
+  const memberships = await GroupMembership.find({
+    groupId: group.groupId,
+    status: 'approved',
+  })
+    .select('studentId')
+    .lean();
+
+  if (memberships.length > 0) {
+    return [...new Set(memberships.map((membership) => String(membership.studentId)))];
+  }
+
+  const embeddedAcceptedMembers = (group.members || [])
+    .filter((member) => member && member.status === 'accepted' && member.userId)
+    .map((member) => String(member.userId));
+
+  return [...new Set(embeddedAcceptedMembers)];
+}
+
+function buildUserLookupQuery(studentIds) {
+  const validObjectIds = studentIds
+    .filter((studentId) => mongoose.Types.ObjectId.isValid(studentId))
+    .map((studentId) => new mongoose.Types.ObjectId(studentId));
+
+  const query = [
+    { userId: { $in: studentIds } },
+    { studentId: { $in: studentIds } },
+  ];
+
+  if (validObjectIds.length > 0) {
+    query.push({ _id: { $in: validObjectIds } });
+  }
+
+  return { $or: query };
+}
+
+function mapUsersByKnownIds(users) {
+  const usersById = new Map();
+  for (const user of users) {
+    const ids = [user.userId, user.studentId, user._id ? String(user._id) : null].filter(Boolean);
+    for (const id of ids) {
+      usersById.set(String(id), user);
+    }
+  }
+  return usersById;
+}
+
+async function buildGithubMappingWarnings(groupId, studentIds) {
+  if (studentIds.length === 0) {
+    return [];
+  }
+
+  const users = await User.find(buildUserLookupQuery(studentIds))
+    .select('userId studentId githubUsername')
+    .lean();
+  const usersById = mapUsersByKnownIds(users);
+
+  return studentIds
+    .filter((studentId) => {
+      const user = usersById.get(String(studentId));
+      return !user || !user.githubUsername;
+    })
+    .map((studentId) => ({
+      code: 'MISSING_GITHUB_MAPPING',
+      severity: 'warning',
+      groupId,
+      studentId,
+      message: `Student ${studentId} does not have a GitHub username mapping.`,
+    }));
+}
+
+function buildRatioQuery(groupId, studentIds, includeSprintIds) {
+  const query = {
+    groupId,
+    studentId: { $in: studentIds },
+  };
+
+  if (includeSprintIds.length > 0) {
+    query.sprintId = { $in: includeSprintIds };
+  }
+
+  return query;
+}
+
+function selectLatestRecords(studentIds, recordsByStudent) {
+  const selected = [];
+
+  for (const studentId of studentIds) {
+    const records = recordsByStudent.get(studentId) || [];
+    if (records.length > 0) {
+      records.sort(compareRecordsByRecency);
+      selected.push({
+        studentId,
+        records: [records[0]],
+        contributionRatio: Number(records[0].contributionRatio),
+      });
+    }
+  }
+
+  return selected;
+}
+
+function selectExplicitSprintRecords(studentIds, recordsByStudent) {
+  const selected = [];
+
+  for (const studentId of studentIds) {
+    const records = recordsByStudent.get(studentId) || [];
+    if (records.length > 0) {
+      const ratioTotal = records.reduce(
+        (sum, record) => sum + Number(record.contributionRatio),
+        0
+      );
+      selected.push({
+        studentId,
+        records,
+        contributionRatio: roundTo(ratioTotal / records.length),
+      });
+    }
+  }
+
+  return selected;
+}
+
+function formatSelectedStudent(entry) {
+  const recordsByRecency = [...entry.records].sort(compareRecordsByRecency);
+
+  return {
+    studentId: entry.studentId,
+    contributionRatio: entry.contributionRatio,
+    selectedSprintIds: recordsByRecency.map((record) => String(record.sprintId)),
+    contributionRecordIds: recordsByRecency.map((record) =>
+      record.contributionRecordId || String(record._id)
+    ),
+    sourceTimestamps: recordsByRecency.map((record) => ({
+      sprintId: String(record.sprintId),
+      recalculatedAt: record.recalculatedAt || null,
+      lastUpdatedAt: record.lastUpdatedAt || null,
+      updatedAt: record.updatedAt || null,
+    })),
+  };
+}
+
+async function resolveContributionRatiosForPreview(groupId, input = {}) {
+  const group = await loadGroup(groupId);
+  const includeSprintIds = normalizeStringArray(input.includeSprintIds, 'includeSprintIds');
+  const useLatestRatios = input.useLatestRatios !== false;
+  const mode = useLatestRatios ? 'latest' : 'explicit_sprints';
+
+  if (!useLatestRatios && includeSprintIds.length === 0) {
+    throw new FinalGradeRatioResolverError(
+      400,
+      'MISSING_INCLUDE_SPRINT_IDS',
+      'includeSprintIds is required when useLatestRatios is false.'
+    );
+  }
+
+  const enrolledStudentIds = await loadEnrolledStudentIds(group);
+  if (enrolledStudentIds.length === 0) {
+    throw new FinalGradeRatioResolverError(
+      404,
+      'NO_ENROLLED_STUDENTS',
+      `Group ${group.groupId} does not have enrolled students for final grade preview.`
+    );
+  }
+
+  const records = await ContributionRecord.find(
+    buildRatioQuery(group.groupId, enrolledStudentIds, includeSprintIds)
+  )
+    .sort({ recalculatedAt: -1, lastUpdatedAt: -1, updatedAt: -1 })
+    .lean();
+
+  records.forEach(assertUsableRatio);
+
+  const recordsByStudent = new Map();
+  for (const record of records) {
+    const studentId = String(record.studentId);
+    if (!recordsByStudent.has(studentId)) {
+      recordsByStudent.set(studentId, []);
+    }
+    recordsByStudent.get(studentId).push(record);
+  }
+
+  const selected = useLatestRatios
+    ? selectLatestRecords(enrolledStudentIds, recordsByStudent)
+    : selectExplicitSprintRecords(enrolledStudentIds, recordsByStudent);
+
+  const selectedStudentIds = new Set(selected.map((entry) => entry.studentId));
+  const missingStudentIds = enrolledStudentIds.filter(
+    (studentId) => !selectedStudentIds.has(studentId)
+  );
+
+  if (missingStudentIds.length > 0) {
+    throw new FinalGradeRatioResolverError(
+      404,
+      'MISSING_CONTRIBUTION_RATIOS',
+      'Required contribution ratios are missing for one or more enrolled students.',
+      {
+        groupId: group.groupId,
+        missingStudentIds,
+        includeSprintIds,
+        useLatestRatios,
+      }
+    );
+  }
+
+  const warnings = await buildGithubMappingWarnings(group.groupId, enrolledStudentIds);
+
+  return {
+    groupId: group.groupId,
+    students: selected.map(formatSelectedStudent),
+    warnings,
+    metadata: {
+      mode,
+      useLatestRatios,
+      includeSprintIds,
+      enrolledStudentCount: enrolledStudentIds.length,
+      generatedAt: new Date(),
+    },
+  };
+}
+
+module.exports = {
+  FinalGradeRatioResolverError,
+  resolveContributionRatiosForPreview,
+};

--- a/backend/src/services/finalGradePreviewService.js
+++ b/backend/src/services/finalGradePreviewService.js
@@ -1,0 +1,72 @@
+const { resolveContributionRatiosForPreview } = require('./finalGradeContributionRatioService');
+
+function roundTo(value, precision = 2) {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+}
+
+function normalizeWarningsByStudent(warnings = []) {
+  const warningsByStudent = new Map();
+  for (const warning of warnings) {
+    if (!warning || !warning.studentId) {
+      continue;
+    }
+
+    const studentId = String(warning.studentId);
+    if (!warningsByStudent.has(studentId)) {
+      warningsByStudent.set(studentId, []);
+    }
+
+    warningsByStudent.get(studentId).push({
+      code: warning.code,
+      severity: warning.severity,
+      message: warning.message,
+    });
+  }
+  return warningsByStudent;
+}
+
+async function buildFinalGradesPreview(groupId, input = {}) {
+  const {
+    includeSprintIds,
+    useLatestRatios,
+    includeDeliverableIds = [],
+    baseGroupScore: explicitBaseGroupScore,
+  } = input;
+
+  // Process 8.1 placeholder: until D4/D5 aggregation service is wired,
+  // default to a neutral base group score that keeps preview deterministic.
+  const baseGroupScore = Number.isFinite(Number(explicitBaseGroupScore))
+    ? Number(explicitBaseGroupScore)
+    : 100;
+
+  const ratioResolution = await resolveContributionRatiosForPreview(groupId, {
+    includeSprintIds,
+    useLatestRatios,
+  });
+  const warningsByStudent = normalizeWarningsByStudent(ratioResolution.warnings);
+
+  const students = ratioResolution.students.map((student) => ({
+    studentId: student.studentId,
+    contributionRatio: student.contributionRatio,
+    computedFinalGrade: roundTo(baseGroupScore * student.contributionRatio),
+    deliverableScoreBreakdown: {},
+    warnings: warningsByStudent.get(student.studentId) || [],
+  }));
+
+  return {
+    groupId: ratioResolution.groupId,
+    baseGroupScore,
+    students,
+    createdAt: new Date(),
+    // Keep rich resolver payload for internal observability and logging.
+    internal: {
+      includeDeliverableIds,
+      ratioResolution,
+    },
+  };
+}
+
+module.exports = {
+  buildFinalGradesPreview,
+};

--- a/backend/tests/final-grade-contribution-ratio-service.test.js
+++ b/backend/tests/final-grade-contribution-ratio-service.test.js
@@ -221,7 +221,7 @@ describe('Final grade contribution ratio resolver - Process 8.2', () => {
     expect(result.students[0].selectedSprintIds).toEqual(['sprint_1']);
   });
 
-  test('throws a typed 404 when an enrolled student has no ratio in scope', async () => {
+  test('throws a typed 422 when an enrolled student has no ratio in scope', async () => {
     const groupId = 'grp_ratio_missing';
     await createGroup(groupId);
     await createUser('usr_alice');
@@ -237,7 +237,7 @@ describe('Final grade contribution ratio resolver - Process 8.2', () => {
     });
 
     await expect(resolveContributionRatiosForPreview(groupId, {})).rejects.toMatchObject({
-      status: 404,
+      status: 422,
       code: 'MISSING_CONTRIBUTION_RATIOS',
       details: {
         missingStudentIds: ['usr_bob'],

--- a/backend/tests/final-grade-contribution-ratio-service.test.js
+++ b/backend/tests/final-grade-contribution-ratio-service.test.js
@@ -1,0 +1,332 @@
+process.env.NODE_ENV = 'test';
+
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const {
+  FinalGradeRatioResolverError,
+  resolveContributionRatiosForPreview,
+} = require('../src/services/finalGradeContributionRatioService');
+const ContributionRecord = require('../src/models/ContributionRecord');
+const Group = require('../src/models/Group');
+const GroupMembership = require('../src/models/GroupMembership');
+const User = require('../src/models/User');
+
+let mongod;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  await mongoose.connect(mongod.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongod) {
+    await mongod.stop();
+  }
+});
+
+beforeEach(async () => {
+  await Promise.all(
+    Object.keys(mongoose.connection.collections).map((key) =>
+      mongoose.connection.collections[key].deleteMany({})
+    )
+  );
+});
+
+async function createUser(userId, overrides = {}) {
+  return User.create({
+    userId,
+    email: `${userId}@example.com`,
+    hashedPassword: 'hashed-password-for-tests',
+    role: 'student',
+    githubUsername: `${userId}-gh`,
+    ...overrides,
+  });
+}
+
+async function createGroup(groupId, overrides = {}) {
+  return Group.create({
+    groupId,
+    groupName: `${groupId} Team`,
+    leaderId: overrides.leaderId || 'usr_leader',
+    status: 'active',
+    ...overrides,
+  });
+}
+
+async function addApprovedMembership(groupId, studentId) {
+  return GroupMembership.create({
+    groupId,
+    studentId,
+    status: 'approved',
+  });
+}
+
+async function addContribution({
+  groupId,
+  sprintId,
+  studentId,
+  contributionRatio,
+  recalculatedAt,
+  lastUpdatedAt,
+}) {
+  return ContributionRecord.create({
+    groupId,
+    sprintId,
+    studentId,
+    contributionRatio,
+    storyPointsAssigned: 10,
+    storyPointsCompleted: 5,
+    pullRequestsMerged: 1,
+    issuesResolved: 1,
+    commitsCount: 1,
+    recalculatedAt,
+    lastUpdatedAt,
+  });
+}
+
+describe('Final grade contribution ratio resolver - Process 8.2', () => {
+  test('selects the latest D6 ratio per enrolled student by recency fields', async () => {
+    const groupId = 'grp_ratio_latest';
+    await createGroup(groupId);
+    await createUser('usr_alice');
+    await createUser('usr_bob');
+    await addApprovedMembership(groupId, 'usr_alice');
+    await addApprovedMembership(groupId, 'usr_bob');
+
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 0.25,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_2',
+      studentId: 'usr_alice',
+      contributionRatio: 0.75,
+      recalculatedAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_bob',
+      contributionRatio: 0.6,
+      lastUpdatedAt: new Date('2026-03-01T00:00:00.000Z'),
+    });
+
+    const result = await resolveContributionRatiosForPreview(groupId, {
+      useLatestRatios: true,
+    });
+
+    expect(result.metadata.mode).toBe('latest');
+    expect(result.students).toHaveLength(2);
+
+    const alice = result.students.find((student) => student.studentId === 'usr_alice');
+    const bob = result.students.find((student) => student.studentId === 'usr_bob');
+
+    expect(alice.contributionRatio).toBe(0.75);
+    expect(alice.selectedSprintIds).toEqual(['sprint_2']);
+    expect(bob.contributionRatio).toBe(0.6);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test('averages explicit sprint ratios per student when useLatestRatios is false', async () => {
+    const groupId = 'grp_ratio_explicit';
+    await createGroup(groupId);
+    await createUser('usr_alice');
+    await createUser('usr_bob');
+    await addApprovedMembership(groupId, 'usr_alice');
+    await addApprovedMembership(groupId, 'usr_bob');
+
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 0.5,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_2',
+      studentId: 'usr_alice',
+      contributionRatio: 0.7,
+      recalculatedAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_bob',
+      contributionRatio: 0.2,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_2',
+      studentId: 'usr_bob',
+      contributionRatio: 0.4,
+      recalculatedAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_ignored',
+      studentId: 'usr_bob',
+      contributionRatio: 1,
+      recalculatedAt: new Date('2026-03-01T00:00:00.000Z'),
+    });
+
+    const result = await resolveContributionRatiosForPreview(groupId, {
+      useLatestRatios: false,
+      includeSprintIds: ['sprint_1', 'sprint_2'],
+    });
+
+    const alice = result.students.find((student) => student.studentId === 'usr_alice');
+    const bob = result.students.find((student) => student.studentId === 'usr_bob');
+
+    expect(result.metadata.mode).toBe('explicit_sprints');
+    expect(alice.contributionRatio).toBe(0.6);
+    expect(alice.selectedSprintIds).toEqual(['sprint_2', 'sprint_1']);
+    expect(bob.contributionRatio).toBe(0.3);
+    expect(bob.selectedSprintIds).toEqual(['sprint_2', 'sprint_1']);
+  });
+
+  test('restricts latest mode to includeSprintIds when provided', async () => {
+    const groupId = 'grp_ratio_latest_filtered';
+    await createGroup(groupId);
+    await createUser('usr_alice');
+    await addApprovedMembership(groupId, 'usr_alice');
+
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 0.4,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_2',
+      studentId: 'usr_alice',
+      contributionRatio: 0.9,
+      recalculatedAt: new Date('2026-02-01T00:00:00.000Z'),
+    });
+
+    const result = await resolveContributionRatiosForPreview(groupId, {
+      includeSprintIds: ['sprint_1'],
+    });
+
+    expect(result.students[0].contributionRatio).toBe(0.4);
+    expect(result.students[0].selectedSprintIds).toEqual(['sprint_1']);
+  });
+
+  test('throws a typed 404 when an enrolled student has no ratio in scope', async () => {
+    const groupId = 'grp_ratio_missing';
+    await createGroup(groupId);
+    await createUser('usr_alice');
+    await createUser('usr_bob');
+    await addApprovedMembership(groupId, 'usr_alice');
+    await addApprovedMembership(groupId, 'usr_bob');
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 0.8,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    await expect(resolveContributionRatiosForPreview(groupId, {})).rejects.toMatchObject({
+      status: 404,
+      code: 'MISSING_CONTRIBUTION_RATIOS',
+      details: {
+        missingStudentIds: ['usr_bob'],
+      },
+    });
+  });
+
+  test('surfaces non-blocking warnings for missing GitHub username mappings', async () => {
+    const groupId = 'grp_ratio_warning';
+    await createGroup(groupId);
+    await createUser('usr_alice', { githubUsername: null });
+    await addApprovedMembership(groupId, 'usr_alice');
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 0.8,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const result = await resolveContributionRatiosForPreview(groupId, {});
+
+    expect(result.students).toHaveLength(1);
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        code: 'MISSING_GITHUB_MAPPING',
+        severity: 'warning',
+        studentId: 'usr_alice',
+      }),
+    ]);
+  });
+
+  test('falls back to embedded accepted group members when membership rows are absent', async () => {
+    const groupId = 'grp_ratio_embedded';
+    await createGroup(groupId, {
+      members: [
+        { userId: 'usr_alice', role: 'leader', status: 'accepted', joinedAt: new Date() },
+        { userId: 'usr_pending', role: 'member', status: 'pending' },
+      ],
+    });
+    await createUser('usr_alice');
+    await addContribution({
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 0.8,
+      recalculatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+
+    const result = await resolveContributionRatiosForPreview(groupId, {});
+
+    expect(result.metadata.enrolledStudentCount).toBe(1);
+    expect(result.students[0].studentId).toBe('usr_alice');
+  });
+
+  test('validates invalid input and invalid D6 ratio values', async () => {
+    const groupId = 'grp_ratio_invalid';
+    await createGroup(groupId);
+    await createUser('usr_alice');
+    await addApprovedMembership(groupId, 'usr_alice');
+
+    await expect(
+      resolveContributionRatiosForPreview(groupId, {
+        useLatestRatios: false,
+        includeSprintIds: [],
+      })
+    ).rejects.toMatchObject({
+      status: 400,
+      code: 'MISSING_INCLUDE_SPRINT_IDS',
+    });
+
+    await mongoose.connection.db.collection('sprint_contributions').insertOne({
+      contributionRecordId: 'ctr_invalid_ratio',
+      groupId,
+      sprintId: 'sprint_1',
+      studentId: 'usr_alice',
+      contributionRatio: 1.4,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    try {
+      await resolveContributionRatiosForPreview(groupId, {});
+      throw new Error('Expected invalid ratio error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(FinalGradeRatioResolverError);
+      expect(error.status).toBe(409);
+      expect(error.code).toBe('INVALID_CONTRIBUTION_RATIO');
+      expect(error.details.studentId).toBe('usr_alice');
+    }
+  });
+});

--- a/backend/tests/final-grade-preview.integration.test.js
+++ b/backend/tests/final-grade-preview.integration.test.js
@@ -1,0 +1,325 @@
+process.env.NODE_ENV = 'test';
+
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../src/index');
+
+const Group = require('../src/models/Group');
+const GroupMembership = require('../src/models/GroupMembership');
+const ContributionRecord = require('../src/models/ContributionRecord');
+const User = require('../src/models/User');
+const { generateAccessToken } = require('../src/utils/jwt');
+
+describe('Final grade preview endpoint orchestration', () => {
+  jest.setTimeout(30000);
+
+  let mongod;
+  let coordinatorToken;
+  let assignedProfessorToken;
+  let unassignedProfessorToken;
+
+  beforeAll(async () => {
+    mongod = await MongoMemoryServer.create();
+    await mongoose.connect(mongod.getUri());
+
+    const coordinator = await User.create({
+      userId: 'usr_preview_coord',
+      email: 'preview.coordinator@example.com',
+      hashedPassword: 'hashed-password-for-tests',
+      role: 'coordinator',
+      emailVerified: true,
+      accountStatus: 'active',
+    });
+    const assignedProfessor = await User.create({
+      userId: 'usr_preview_prof_assigned',
+      email: 'preview.prof.assigned@example.com',
+      hashedPassword: 'hashed-password-for-tests',
+      role: 'professor',
+      emailVerified: true,
+      accountStatus: 'active',
+    });
+    const unassignedProfessor = await User.create({
+      userId: 'usr_preview_prof_unassigned',
+      email: 'preview.prof.unassigned@example.com',
+      hashedPassword: 'hashed-password-for-tests',
+      role: 'professor',
+      emailVerified: true,
+      accountStatus: 'active',
+    });
+
+    coordinatorToken = generateAccessToken(coordinator.userId, 'coordinator');
+    assignedProfessorToken = generateAccessToken(assignedProfessor.userId, 'professor');
+    unassignedProfessorToken = generateAccessToken(unassignedProfessor.userId, 'professor');
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      Group.deleteMany({ groupId: /^grp_preview_/ }),
+      GroupMembership.deleteMany({ groupId: /^grp_preview_/ }),
+      ContributionRecord.deleteMany({ groupId: /^grp_preview_/ }),
+      User.deleteMany({ userId: /^usr_preview_student_/ }),
+    ]);
+  });
+
+  afterAll(async () => {
+    await User.deleteMany({
+      userId: {
+        $in: ['usr_preview_coord', 'usr_preview_prof_assigned', 'usr_preview_prof_unassigned'],
+      },
+    });
+    await mongoose.disconnect();
+    if (mongod) {
+      await mongod.stop();
+    }
+  });
+
+  test('orchestrates preview flow and embeds warnings per student', async () => {
+    const groupId = 'grp_preview_success';
+
+    await Group.create({
+      groupId,
+      groupName: 'Preview Success Group',
+      leaderId: 'usr_preview_student_alice',
+      status: 'active',
+    });
+
+    await User.create({
+      userId: 'usr_preview_student_alice',
+      email: 'preview.alice@example.com',
+      hashedPassword: 'hashed-password-for-tests',
+      role: 'student',
+      githubUsername: null,
+      emailVerified: true,
+      accountStatus: 'active',
+    });
+
+    await GroupMembership.create({
+      groupId,
+      studentId: 'usr_preview_student_alice',
+      status: 'approved',
+    });
+
+    await ContributionRecord.create({
+      groupId,
+      sprintId: 'sprint_preview_1',
+      studentId: 'usr_preview_student_alice',
+      contributionRatio: 0.8,
+      storyPointsAssigned: 10,
+      storyPointsCompleted: 8,
+      pullRequestsMerged: 1,
+      issuesResolved: 1,
+      commitsCount: 1,
+      recalculatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      lastUpdatedAt: new Date('2026-04-01T00:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        requestedBy: 'usr_preview_coord',
+        useLatestRatios: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.groupId).toBe(groupId);
+    expect(response.body.baseGroupScore).toBe(100);
+    expect(Array.isArray(response.body.students)).toBe(true);
+    expect(response.body.students).toHaveLength(1);
+    expect(response.body.students[0]).toMatchObject({
+      studentId: 'usr_preview_student_alice',
+      contributionRatio: 0.8,
+      computedFinalGrade: 80,
+    });
+    expect(response.body.students[0].warnings).toEqual([
+      expect.objectContaining({
+        code: 'MISSING_GITHUB_MAPPING',
+        severity: 'warning',
+      }),
+    ]);
+  });
+
+  test('ignores spoofed requestedBy and derives identity from authenticated token', async () => {
+    const groupId = 'grp_preview_spoofing_guard';
+
+    await Group.create({
+      groupId,
+      groupName: 'Preview Spoofing Guard Group',
+      leaderId: 'usr_preview_student_alice',
+      professorId: 'usr_preview_prof_assigned',
+      advisorId: 'usr_preview_prof_assigned',
+      status: 'active',
+    });
+
+    await User.create({
+      userId: 'usr_preview_student_alice',
+      email: 'preview.alice3@example.com',
+      hashedPassword: 'hashed-password-for-tests',
+      role: 'student',
+      githubUsername: null,
+      emailVerified: true,
+      accountStatus: 'active',
+    });
+
+    await GroupMembership.create({
+      groupId,
+      studentId: 'usr_preview_student_alice',
+      status: 'approved',
+    });
+
+    await ContributionRecord.create({
+      groupId,
+      sprintId: 'sprint_preview_1',
+      studentId: 'usr_preview_student_alice',
+      contributionRatio: 0.9,
+      storyPointsAssigned: 10,
+      storyPointsCompleted: 9,
+      pullRequestsMerged: 1,
+      issuesResolved: 1,
+      commitsCount: 1,
+      recalculatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      lastUpdatedAt: new Date('2026-04-01T00:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${assignedProfessorToken}`)
+      .send({
+        requestedBy: 'usr_actor_spoof_attempt',
+        useLatestRatios: true,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.groupId).toBe(groupId);
+    expect(response.body.students).toHaveLength(1);
+  });
+
+  test('returns 422 when any enrolled student is missing ratios', async () => {
+    const groupId = 'grp_preview_missing_ratio';
+
+    await Group.create({
+      groupId,
+      groupName: 'Preview Missing Ratio Group',
+      leaderId: 'usr_preview_student_alice',
+      status: 'active',
+    });
+
+    await User.insertMany([
+      {
+        userId: 'usr_preview_student_alice',
+        email: 'preview.alice2@example.com',
+        hashedPassword: 'hashed-password-for-tests',
+        role: 'student',
+        githubUsername: 'alice-gh',
+        emailVerified: true,
+        accountStatus: 'active',
+      },
+      {
+        userId: 'usr_preview_student_bob',
+        email: 'preview.bob@example.com',
+        hashedPassword: 'hashed-password-for-tests',
+        role: 'student',
+        githubUsername: 'bob-gh',
+        emailVerified: true,
+        accountStatus: 'active',
+      },
+    ]);
+
+    await GroupMembership.insertMany([
+      {
+        groupId,
+        studentId: 'usr_preview_student_alice',
+        status: 'approved',
+      },
+      {
+        groupId,
+        studentId: 'usr_preview_student_bob',
+        status: 'approved',
+      },
+    ]);
+
+    await ContributionRecord.create({
+      groupId,
+      sprintId: 'sprint_preview_1',
+      studentId: 'usr_preview_student_alice',
+      contributionRatio: 0.7,
+      storyPointsAssigned: 10,
+      storyPointsCompleted: 7,
+      pullRequestsMerged: 1,
+      issuesResolved: 1,
+      commitsCount: 1,
+      recalculatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      lastUpdatedAt: new Date('2026-04-01T00:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        requestedBy: 'usr_preview_coord',
+        useLatestRatios: true,
+      });
+
+    expect(response.status).toBe(422);
+    expect(response.body.code).toBe('MISSING_CONTRIBUTION_RATIOS');
+    expect(response.body.details.missingStudentIds).toEqual(['usr_preview_student_bob']);
+  });
+
+  test('returns 403 when professor is not assigned to target group', async () => {
+    const groupId = 'grp_preview_forbidden_professor';
+
+    await Group.create({
+      groupId,
+      groupName: 'Preview Forbidden Professor Group',
+      leaderId: 'usr_preview_student_alice',
+      professorId: 'usr_preview_prof_assigned',
+      advisorId: 'usr_preview_prof_assigned',
+      status: 'active',
+    });
+
+    await User.create({
+      userId: 'usr_preview_student_alice',
+      email: 'preview.alice4@example.com',
+      hashedPassword: 'hashed-password-for-tests',
+      role: 'student',
+      githubUsername: 'alice-gh',
+      emailVerified: true,
+      accountStatus: 'active',
+    });
+
+    await GroupMembership.create({
+      groupId,
+      studentId: 'usr_preview_student_alice',
+      status: 'approved',
+    });
+
+    await ContributionRecord.create({
+      groupId,
+      sprintId: 'sprint_preview_1',
+      studentId: 'usr_preview_student_alice',
+      contributionRatio: 0.85,
+      storyPointsAssigned: 10,
+      storyPointsCompleted: 8.5,
+      pullRequestsMerged: 1,
+      issuesResolved: 1,
+      commitsCount: 1,
+      recalculatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      lastUpdatedAt: new Date('2026-04-01T00:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${unassignedProfessorToken}`)
+      .send({
+        requestedBy: 'usr_preview_prof_unassigned',
+        useLatestRatios: true,
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe(
+      'Access denied: You are not assigned as an advisor or professor for this group.'
+    );
+    expect(response.body.code).toBe('FORBIDDEN_GROUP_ACCESS');
+  });
+});

--- a/docs/apispec2_8.yaml
+++ b/docs/apispec2_8.yaml
@@ -291,6 +291,26 @@ components:
             type: number
             format: float
           description: Optional mapping of deliverable IDs to their aggregate scores
+        warnings:
+          type: array
+          description: Optional non-blocking per-student operational warnings (e.g., missing GitHub mapping)
+          items:
+            $ref: '#/components/schemas/FinalGradePreviewWarning'
+
+    FinalGradePreviewWarning:
+      type: object
+      required:
+        - code
+        - severity
+        - message
+      properties:
+        code:
+          type: string
+        severity:
+          type: string
+          enum: [warning]
+        message:
+          type: string
 
     FinalGradeApproval:
       type: object


### PR DESCRIPTION
Adds a backend Process 8.2 resolver for final grade preview contribution ratios. The resolver reads D6 ContributionRecord data, supports latest-ratio and explicit sprint filtering modes, validates enrolled group members have ratios, and returns warnings for missing GitHub mappings.

Also adds focused Jest coverage for latest selection, explicit sprint averaging, missing ratios, GitHub mapping warnings, embedded member fallback, and invalid ratio/input handling.
Closes #249 