### PR TITLE
Implement coordinator final grade approval flow

### DIFF
--- a/backend/src/controllers/finalGradeController.js
+++ b/backend/src/controllers/finalGradeController.js
@@ -6,6 +6,7 @@ const Group = require('../models/Group');
 const AuditLog = require('../models/AuditLog');
 const { FinalGrade, FINAL_GRADE_STATUS } = require('../models/FinalGrade');
 const { publishFinalGrades } = require('../services/publishService');
+const { v4: uuidv4 } = require('uuid');
 
 const PREVIEW_FORBIDDEN_MESSAGE =
   'Forbidden - only the Coordinator role or authorized Professor/Advisor roles may preview final grades';
@@ -19,6 +20,82 @@ const isCoordinator = (req) => req?.user?.role === 'coordinator';
 const hasValidSystemToken = (req) =>
   typeof req?.headers?.['x-system-auth'] === 'string' &&
   req.headers['x-system-auth'] === process.env.INTERNAL_SYSTEM_TOKEN;
+
+const buildPublishCycle = (groupId) =>
+  `cycle_${String(groupId).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 32)}_${uuidv4().split('-')[0]}`;
+
+const persistPreviewForApproval = async ({
+  groupId,
+  preview,
+  publishCycle,
+  coordinatorId
+}) => {
+  const students = Array.isArray(preview?.students) ? preview.students : [];
+
+  if (students.length === 0) {
+    const error = new Error('Preview does not contain student grade entries to approve');
+    error.statusCode = 404;
+    error.code = 'NO_PREVIEW_STUDENTS';
+    throw error;
+  }
+
+  const hasTerminalGrades = await FinalGrade.hasTerminalGrades(groupId, publishCycle);
+  if (hasTerminalGrades) {
+    const error = new Error('Grades for this group and cycle are already approved, rejected, or published');
+    error.statusCode = 409;
+    error.code = 'CYCLE_ALREADY_TERMINAL';
+    throw error;
+  }
+
+  const now = new Date();
+
+  for (const student of students) {
+    await FinalGrade.findOneAndUpdate(
+      {
+        groupId,
+        publishCycle,
+        studentId: student.studentId,
+        status: FINAL_GRADE_STATUS.PENDING
+      },
+      {
+        $set: {
+          groupId,
+          publishCycle,
+          studentId: student.studentId,
+          baseGroupScore: preview.baseGroupScore,
+          individualRatio: student.contributionRatio,
+          computedFinalGrade: student.computedFinalGrade,
+          status: FINAL_GRADE_STATUS.PENDING,
+          updatedAt: now
+        },
+        $setOnInsert: {
+          finalGradeId: `fg_${uuidv4().split('-')[0]}`,
+          createdAt: now
+        }
+      },
+      {
+        upsert: true,
+        new: true,
+        runValidators: true
+      }
+    );
+  }
+
+  try {
+    await AuditLog.create({
+      action: 'FINAL_GRADE_PREVIEW_PERSISTED',
+      actorId: coordinatorId,
+      groupId,
+      payload: {
+        publishCycle,
+        studentCount: students.length,
+        persistedAt: now
+      }
+    });
+  } catch (_error) {
+    // Non-fatal audit telemetry
+  }
+};
 
 /**
  * Controller for Process 8.1 - Final Grade Preview
@@ -64,6 +141,15 @@ const previewFinalGradesHandler = async (req, res) => {
 
     const { generatePreview, PreviewError } = require('../services/finalGradePreviewService');
 
+    const wantsApprovalSnapshot = req.body?.persistForApproval === true;
+
+    if (wantsApprovalSnapshot && !isCoordinator(req)) {
+      return res.status(403).json({
+        message: APPROVAL_FORBIDDEN_MESSAGE,
+        code: 'UNAUTHORIZED_ROLE'
+      });
+    }
+
     const previewOptions = {
       ...req.body,
       requestedBy: req.user.userId,
@@ -71,9 +157,42 @@ const previewFinalGradesHandler = async (req, res) => {
     };
 
     const preview = await generatePreview(groupId, previewOptions);
-    return res.status(200).json({
+    const createdAt = new Date();
+    const responsePayload = {
       ...preview,
-      createdAt: new Date()
+      groupId: preview.groupId || groupId,
+      createdAt
+    };
+
+    if (wantsApprovalSnapshot) {
+      const publishCycle =
+        typeof req.body?.publishCycle === 'string' && req.body.publishCycle.trim() !== ''
+          ? req.body.publishCycle.trim()
+          : buildPublishCycle(groupId);
+
+      try {
+        await persistPreviewForApproval({
+          groupId,
+          preview: responsePayload,
+          publishCycle,
+          coordinatorId: req.user.userId
+        });
+      } catch (error) {
+        if (error.statusCode) {
+          return res.status(error.statusCode).json({
+            message: error.message,
+            code: error.code || 'PREVIEW_PERSIST_FAILED'
+          });
+        }
+        throw error;
+      }
+
+      responsePayload.publishCycle = publishCycle;
+      responsePayload.persistedForApproval = true;
+    }
+
+    return res.status(200).json({
+      ...responsePayload
     });
 
   } catch (error) {
@@ -107,7 +226,7 @@ const approveGroupGradesHandler = async (req, res) => {
     }
 
     const { groupId } = req.params;
-    const { publishCycle, decision, overrideEntries, reason } = req.body;
+    let { publishCycle, decision, overrideEntries, reason } = req.body;
     const coordinatorId = req.user.userId;
 
     if (!groupId || typeof groupId !== 'string' || groupId.trim() === '') {
@@ -125,10 +244,19 @@ const approveGroupGradesHandler = async (req, res) => {
     }
 
     if (!publishCycle || typeof publishCycle !== 'string' || publishCycle.trim() === '') {
-      return res.status(422).json({
-        message: 'publishCycle is required',
-        code: 'MISSING_PUBLISH_CYCLE'
-      });
+      const latestPending = await FinalGrade.findOne({
+        groupId,
+        status: FINAL_GRADE_STATUS.PENDING
+      }).sort({ updatedAt: -1, createdAt: -1 }).lean();
+
+      publishCycle = latestPending?.publishCycle || null;
+
+      if (!publishCycle) {
+        return res.status(422).json({
+          message: 'publishCycle is required',
+          code: 'MISSING_PUBLISH_CYCLE'
+        });
+      }
     }
 
     if (!decision || !['approve', 'reject'].includes(decision)) {

--- a/backend/src/controllers/finalGradeController.js
+++ b/backend/src/controllers/finalGradeController.js
@@ -24,6 +24,15 @@ const hasValidSystemToken = (req) =>
 const buildPublishCycle = (groupId) =>
   `cycle_${String(groupId).replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 32)}_${uuidv4().split('-')[0]}`;
 
+const normalizeApprovalDecision = (decision) => {
+  if (typeof decision !== 'string') return null;
+  const normalized = decision.trim().toLowerCase();
+  if (normalized === 'approved') return 'approve';
+  if (normalized === 'rejected') return 'reject';
+  if (normalized === 'approve' || normalized === 'reject') return normalized;
+  return null;
+};
+
 const persistPreviewForApproval = async ({
   groupId,
   preview,
@@ -48,6 +57,15 @@ const persistPreviewForApproval = async ({
   }
 
   const now = new Date();
+  const incomingStudentIds = students.map((student) => student.studentId);
+
+  // Refresh pending snapshot for this cycle to avoid stale/duplicate pending states.
+  await FinalGrade.deleteMany({
+    groupId,
+    publishCycle,
+    status: FINAL_GRADE_STATUS.PENDING,
+    studentId: { $nin: incomingStudentIds }
+  });
 
   for (const student of students) {
     await FinalGrade.findOneAndUpdate(
@@ -259,12 +277,14 @@ const approveGroupGradesHandler = async (req, res) => {
       }
     }
 
-    if (!decision || !['approve', 'reject'].includes(decision)) {
+    const normalizedDecision = normalizeApprovalDecision(decision);
+    if (!normalizedDecision) {
       return res.status(422).json({
-        message: 'decision must be "approve" or "reject"',
+        message: 'decision must be one of "approve", "reject", "APPROVED", or "REJECTED"',
         code: 'INVALID_DECISION'
       });
     }
+    decision = normalizedDecision;
 
     console.log(`[Issue #253] Approval attempt - Group: ${groupId}, Coordinator: ${coordinatorId}, Decision: ${decision}`);
 

--- a/backend/src/services/approvalService.js
+++ b/backend/src/services/approvalService.js
@@ -101,9 +101,10 @@ const validateOverrideEntries = (overrideEntries = []) => {
       );
     }
 
-    if (!entry.comment || typeof entry.comment !== 'string' || entry.comment.trim() === '') {
+    const overrideReason = entry.overrideReason ?? entry.comment;
+    if (!overrideReason || typeof overrideReason !== 'string' || overrideReason.trim() === '') {
       throw new GradeApprovalError(
-        `Override entry ${index}: comment is required`,
+        `Override entry ${index}: overrideReason is required`,
         422,
         'MISSING_OVERRIDE_REASON'
       );
@@ -144,9 +145,10 @@ const createOverrideMap = (overrideEntries = []) => {
   const map = {};
 
   overrideEntries.forEach((entry) => {
+    const overrideReason = entry.overrideReason ?? entry.comment ?? null;
     map[entry.studentId] = {
       overriddenFinalGrade: entry.overriddenFinalGrade,
-      comment: entry.comment || null
+      overrideReason
     };
   });
 
@@ -324,13 +326,13 @@ const approveGroupGrades = async (
           finalGrade.originalFinalGrade = finalGrade.computedFinalGrade;
           finalGrade.overriddenFinalGrade = studentOverride.overriddenFinalGrade;
           finalGrade.overriddenBy = coordinatorId;
-          finalGrade.overrideComment = studentOverride.comment;
+          finalGrade.overrideComment = studentOverride.overrideReason;
           finalGrade.overrideEntries = [
             {
               studentId,
               originalFinalGrade: finalGrade.computedFinalGrade,
               overriddenFinalGrade: studentOverride.overriddenFinalGrade,
-              comment: studentOverride.comment,
+              comment: studentOverride.overrideReason,
               overriddenAt: new Date()
             }
           ];
@@ -364,7 +366,7 @@ const approveGroupGrades = async (
               publishCycle,
               originalGrade: computedFinalGrade,
               overriddenGrade: studentOverride.overriddenFinalGrade,
-              comment: studentOverride.comment
+              overrideReason: studentOverride.overrideReason
             }
           });
         }
@@ -451,7 +453,7 @@ const approveGroupGrades = async (
     };
   } catch (error) {
     // ISSUE #253: Abort transaction on any error
-    if (session) {
+    if (session && session.inTransaction()) {
       await session.abortTransaction();
     }
 

--- a/backend/src/services/approvalService.js
+++ b/backend/src/services/approvalService.js
@@ -29,6 +29,11 @@ const AuditLog = require('../models/AuditLog');
 const Group = require('../models/Group');
 const { v4: uuidv4 } = require('uuid');
 
+const supportsMongoTransactions = () => {
+  const topologyType = FinalGrade.db?.client?.topology?.description?.type;
+  return ['ReplicaSetWithPrimary', 'Sharded'].includes(topologyType);
+};
+
 /**
  * ISSUE #253: Error class for grade approval specific errors
  * Used to distinguish approval errors from general application errors
@@ -262,8 +267,12 @@ const approveGroupGrades = async (
   // =========================================================================
   // ISSUE #253: START ATOMIC TRANSACTION
   // =========================================================================
-  const session = await FinalGrade.startSession();
-  session.startTransaction();
+  const shouldUseTransaction = supportsMongoTransactions();
+  const session = shouldUseTransaction ? await FinalGrade.startSession() : null;
+
+  if (session) {
+    session.startTransaction();
+  }
 
   try {
     const createdGrades = [];
@@ -295,7 +304,11 @@ const approveGroupGrades = async (
           computedFinalGrade,
           finalGradeId: uuidv4().split('-')[0]
         },
-        { upsert: true, new: true, session }
+        {
+          upsert: true,
+          new: true,
+          ...(session ? { session } : {})
+        }
       );
 
       // ISSUE #253: Apply approval decision
@@ -379,16 +392,18 @@ const approveGroupGrades = async (
       }
 
       // ISSUE #253: Save within transaction
-      await finalGrade.save({ session });
+      await finalGrade.save(session ? { session } : undefined);
       createdGrades.push(finalGrade);
     }
 
     // ISSUE #253: Create all audit logs within transaction
     // Ensures consistency: if we update grades, we must log it
-    await AuditLog.insertMany(auditLogs, { session });
+    await AuditLog.insertMany(auditLogs, session ? { session } : undefined);
 
     // ISSUE #253: Commit transaction
-    await session.commitTransaction();
+    if (session) {
+      await session.commitTransaction();
+    }
 
     // =========================================================================
     // ISSUE #253: END ATOMIC TRANSACTION
@@ -436,8 +451,9 @@ const approveGroupGrades = async (
     };
   } catch (error) {
     // ISSUE #253: Abort transaction on any error
-    await session.abortTransaction();
-    session.endSession();
+    if (session) {
+      await session.abortTransaction();
+    }
 
     if (error instanceof GradeApprovalError) {
       throw error;
@@ -449,7 +465,9 @@ const approveGroupGrades = async (
       'TRANSACTION_FAILED'
     );
   } finally {
-    session.endSession();
+    if (session) {
+      session.endSession();
+    }
   }
 };
 

--- a/backend/tests/final-grade-approval-preview-bridge.test.js
+++ b/backend/tests/final-grade-approval-preview-bridge.test.js
@@ -144,7 +144,7 @@ describe('Final grade preview approval bridge', () => {
             studentId: 'student-1',
             originalFinalGrade: 80,
             overriddenFinalGrade: 85,
-            comment: 'Coordinator adjustment'
+            overrideReason: 'Coordinator adjustment'
           }
         ],
         reason: 'Approved with adjustment'
@@ -176,6 +176,44 @@ describe('Final grade preview approval bridge', () => {
 
     const finalGrades = await FinalGrade.find({ groupId });
     expect(finalGrades).toHaveLength(0);
+  });
+
+  it('refreshes same-cycle pending snapshot and removes stale pending rows', async () => {
+    await seedPreviewInputs();
+
+    await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        persistForApproval: true,
+        publishCycle: 'cycle-refresh',
+        useLatestRatios: false
+      });
+
+    await FinalGrade.create({
+      finalGradeId: 'fg_stale_cycle_refresh',
+      groupId,
+      publishCycle: 'cycle-refresh',
+      studentId: 'stale-student',
+      baseGroupScore: 70,
+      individualRatio: 0.5,
+      computedFinalGrade: 35,
+      status: FINAL_GRADE_STATUS.PENDING
+    });
+
+    await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        persistForApproval: true,
+        publishCycle: 'cycle-refresh',
+        useLatestRatios: false
+      });
+
+    const finalGrades = await FinalGrade.find({ groupId, publishCycle: 'cycle-refresh' }).lean();
+    expect(finalGrades).toHaveLength(1);
+    expect(finalGrades[0].studentId).toBe('student-1');
+    expect(finalGrades[0].status).toBe(FINAL_GRADE_STATUS.PENDING);
   });
 
   it('reject decision creates a terminal rejected state that blocks publishing', async () => {

--- a/backend/tests/final-grade-approval-preview-bridge.test.js
+++ b/backend/tests/final-grade-approval-preview-bridge.test.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const request = require('supertest');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const app = require('../src/index');
+const Deliverable = require('../src/models/Deliverable');
+const Evaluation = require('../src/models/Evaluation');
+const ContributionRecord = require('../src/models/ContributionRecord');
+const Group = require('../src/models/Group');
+const { FinalGrade, FINAL_GRADE_STATUS } = require('../src/models/FinalGrade');
+const { generateAccessToken } = require('../src/utils/jwt');
+
+let mongoServer;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+afterEach(async () => {
+  await Promise.all(
+    Object.values(mongoose.connection.collections).map((collection) =>
+      collection.deleteMany({})
+    )
+  );
+});
+
+describe('Final grade preview approval bridge', () => {
+  const groupId = 'grp-approval-bridge';
+  const coordinatorToken = generateAccessToken('coord-1', 'coordinator');
+  const studentToken = generateAccessToken('student-1', 'student');
+
+  const seedPreviewInputs = async () => {
+    await Group.create({
+      groupId,
+      groupName: 'Approval Bridge Group',
+      leaderId: 'student-1',
+      members: [
+        {
+          userId: 'student-1',
+          role: 'leader',
+          status: 'accepted',
+          joinedAt: new Date()
+        }
+      ],
+      status: 'active'
+    });
+
+    await Deliverable.create({
+      deliverableId: 'del-final',
+      groupId,
+      submittedBy: 'student-1',
+      deliverableType: 'final_report',
+      filePath: '/tmp/final.pdf',
+      fileSize: 100,
+      fileHash: 'hash-final',
+      format: 'pdf',
+      status: 'accepted',
+      submittedAt: new Date()
+    });
+
+    await Evaluation.create({
+      evaluationId: 'eval-final',
+      deliverableId: 'del-final',
+      groupId,
+      evaluatorId: 'prof-1',
+      score: 80,
+      status: 'completed'
+    });
+
+    await ContributionRecord.create({
+      contributionRecordId: 'ctr-student-1',
+      sprintId: 'sprint-1',
+      studentId: 'student-1',
+      groupId,
+      contributionRatio: 1
+    });
+  };
+
+  it('keeps standard preview read-only by default', async () => {
+    await seedPreviewInputs();
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({ useLatestRatios: false });
+
+    expect(response.status).toBe(200);
+    expect(response.body.groupId).toBe(groupId);
+    expect(response.body.publishCycle).toBeUndefined();
+
+    const finalGrades = await FinalGrade.find({ groupId });
+    expect(finalGrades).toHaveLength(0);
+  });
+
+  it('persists pending approval rows when requested by a coordinator', async () => {
+    await seedPreviewInputs();
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        persistForApproval: true,
+        publishCycle: 'cycle-2026',
+        useLatestRatios: false
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.publishCycle).toBe('cycle-2026');
+    expect(response.body.persistedForApproval).toBe(true);
+
+    const finalGrades = await FinalGrade.find({ groupId, publishCycle: 'cycle-2026' });
+    expect(finalGrades).toHaveLength(1);
+    expect(finalGrades[0].status).toBe(FINAL_GRADE_STATUS.PENDING);
+    expect(finalGrades[0].computedFinalGrade).toBe(80);
+  });
+
+  it('allows approval with overrides after a persisted preview', async () => {
+    await seedPreviewInputs();
+
+    await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        persistForApproval: true,
+        publishCycle: 'cycle-override',
+        useLatestRatios: false
+      });
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/approval`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        publishCycle: 'cycle-override',
+        decision: 'approve',
+        overrideEntries: [
+          {
+            studentId: 'student-1',
+            originalFinalGrade: 80,
+            overriddenFinalGrade: 85,
+            comment: 'Coordinator adjustment'
+          }
+        ],
+        reason: 'Approved with adjustment'
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.publishCycle).toBe('cycle-override');
+    expect(response.body.overridesApplied).toBe(1);
+
+    const savedGrade = await FinalGrade.findOne({ groupId, publishCycle: 'cycle-override' });
+    expect(savedGrade.status).toBe(FINAL_GRADE_STATUS.APPROVED);
+    expect(savedGrade.overriddenFinalGrade).toBe(85);
+  });
+
+  it('rejects approval persistence for non-coordinators', async () => {
+    await seedPreviewInputs();
+
+    const response = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${studentToken}`)
+      .send({
+        persistForApproval: true,
+        publishCycle: 'cycle-forbidden',
+        useLatestRatios: false
+      });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('FORBIDDEN_PREVIEW_ACCESS');
+
+    const finalGrades = await FinalGrade.find({ groupId });
+    expect(finalGrades).toHaveLength(0);
+  });
+
+  it('reject decision creates a terminal rejected state that blocks publishing', async () => {
+    await seedPreviewInputs();
+
+    await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/preview`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        persistForApproval: true,
+        publishCycle: 'cycle-reject',
+        useLatestRatios: false
+      });
+
+    const rejectResponse = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/approval`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({
+        publishCycle: 'cycle-reject',
+        decision: 'reject',
+        reason: 'Needs recalculation'
+      });
+
+    expect(rejectResponse.status).toBe(200);
+
+    const publishResponse = await request(app)
+      .post(`/api/v1/groups/${groupId}/final-grades/publish`)
+      .set('Authorization', `Bearer ${coordinatorToken}`)
+      .send({ notifyStudents: false, notifyFaculty: false });
+
+    expect(publishResponse.status).toBe(422);
+  });
+});

--- a/backend/tests/final-grade-approval.test.js
+++ b/backend/tests/final-grade-approval.test.js
@@ -258,7 +258,7 @@ describe('[ISSUE #253] Final Grade Approval Workflow', () => {
               studentId: studentUser1._id.toString(),
               originalFinalGrade: 68,
               overriddenFinalGrade: 75,
-              comment: 'Exceptional contribution in sprint'
+              overrideReason: 'Exceptional contribution in sprint'
             }
           ],
           reason: 'Approved with manual adjustment'
@@ -560,7 +560,7 @@ describe('[ISSUE #253] Final Grade Approval Workflow', () => {
               studentId: studentUser1._id.toString(),
               originalFinalGrade: 76.5,
               overriddenFinalGrade: 80,
-              comment: 'Strong contribution'
+              overrideReason: 'Strong contribution'
             }
           ]
         });

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,6 +35,7 @@ import SprintContributionDashboard from './pages/SprintContributionDashboard.jsx
 import CommitteeFinalResults from './pages/CommitteeFinalResults.jsx';
 import StudentFinalGradesPage from './pages/StudentFinalGradesPage.jsx';
 import FinalGradeReviewPanel from './pages/FinalGradeReviewPanel.jsx';
+import CoordinatorFinalGradeApprovalPanel from './pages/CoordinatorFinalGradeApprovalPanel.jsx';
 import CoordinatorFinalGradePublishPanel from './pages/CoordinatorFinalGradePublishPanel.jsx';
 
 
@@ -147,6 +148,10 @@ function App() {
             <Route
               path="/groups/:groupId/final-grades/review"
               element={<ProtectedRoute component={FinalGradeReviewPanel} requiredRoles={['professor', 'advisor']} />}
+            />
+            <Route
+              path="/groups/:groupId/final-grades/approval"
+              element={<ProtectedRoute component={CoordinatorFinalGradeApprovalPanel} requiredRoles={['coordinator', 'admin']} />}
             />
             <Route
               path="/groups/:groupId/final-grades/publish"

--- a/frontend/src/__tests__/CoordinatorFinalGradeApprovalPanel.test.jsx
+++ b/frontend/src/__tests__/CoordinatorFinalGradeApprovalPanel.test.jsx
@@ -115,7 +115,7 @@ describe('CoordinatorFinalGradeApprovalPanel', () => {
             studentId: 'student-1',
             originalFinalGrade: 80,
             overriddenFinalGrade: 85,
-            comment: 'Strong contribution',
+            overrideReason: 'Strong contribution',
           },
         ],
       });

--- a/frontend/src/__tests__/CoordinatorFinalGradeApprovalPanel.test.jsx
+++ b/frontend/src/__tests__/CoordinatorFinalGradeApprovalPanel.test.jsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import CoordinatorFinalGradeApprovalPanel from '../pages/CoordinatorFinalGradeApprovalPanel';
+import { approveFinalGrades, previewFinalGrades } from '../api/finalGradeService';
+
+jest.mock('../api/finalGradeService', () => ({
+  approveFinalGrades: jest.fn(),
+  previewFinalGrades: jest.fn(),
+}));
+
+const previewFixture = {
+  groupId: 'group-1',
+  publishCycle: 'cycle-1',
+  persistedForApproval: true,
+  baseGroupScore: 80,
+  students: [
+    {
+      studentId: 'student-1',
+      contributionRatio: 1,
+      computedFinalGrade: 80,
+    },
+  ],
+  createdAt: '2026-04-25T12:00:00.000Z',
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={['/groups/group-1/final-grades/approval']}>
+      <Routes>
+        <Route
+          path="/groups/:groupId/final-grades/approval"
+          element={<CoordinatorFinalGradeApprovalPanel />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('CoordinatorFinalGradeApprovalPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    previewFinalGrades.mockResolvedValue(previewFixture);
+    approveFinalGrades.mockResolvedValue({
+      success: true,
+      groupId: 'group-1',
+      publishCycle: 'cycle-1',
+      decision: 'approve',
+      totalStudents: 1,
+      overridesApplied: 0,
+      message: 'Successfully approved grades for 1 students',
+    });
+  });
+
+  it('generates preview and displays student grade rows', async () => {
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /Generate Preview/i }));
+
+    expect(previewFinalGrades).toHaveBeenCalledWith('group-1', {
+      persistForApproval: true,
+      publishCycle: undefined,
+      useLatestRatios: false,
+    });
+
+    expect(await screen.findByText('student-1')).toBeInTheDocument();
+    expect(screen.getByText('cycle-1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Approve/i })).toBeInTheDocument();
+  });
+
+  it('validates override grade and reason before saving', async () => {
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /Generate Preview/i }));
+    await screen.findByText('student-1');
+
+    await userEvent.click(screen.getByRole('button', { name: /Override/i }));
+    await userEvent.clear(screen.getByLabelText(/Override grade/i));
+    await userEvent.type(screen.getByLabelText(/Override grade/i), '101');
+    await userEvent.click(screen.getByRole('button', { name: /Save Override/i }));
+
+    expect(await screen.findByText(/between 0 and 100/i)).toBeInTheDocument();
+
+    await userEvent.clear(screen.getByLabelText(/Override grade/i));
+    await userEvent.type(screen.getByLabelText(/Override grade/i), '85');
+    await userEvent.click(screen.getByRole('button', { name: /Save Override/i }));
+
+    expect(await screen.findByText(/Override reason is required/i)).toBeInTheDocument();
+  });
+
+  it('submits approval with publishCycle and override entries', async () => {
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /Generate Preview/i }));
+    await screen.findByText('student-1');
+
+    await userEvent.click(screen.getByRole('button', { name: /Override/i }));
+    await userEvent.type(screen.getByLabelText(/Override grade/i), '85');
+    await userEvent.type(screen.getByLabelText(/Override reason/i), 'Strong contribution');
+    await userEvent.click(screen.getByRole('button', { name: /Save Override/i }));
+
+    expect(await screen.findByText('Strong contribution')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/Approval note/i), 'Looks good');
+    await userEvent.click(screen.getByRole('button', { name: /^Approve$/i }));
+
+    await waitFor(() => {
+      expect(approveFinalGrades).toHaveBeenCalledWith('group-1', {
+        publishCycle: 'cycle-1',
+        decision: 'approve',
+        reason: 'Looks good',
+        overrideEntries: [
+          {
+            studentId: 'student-1',
+            originalFinalGrade: 80,
+            overriddenFinalGrade: 85,
+            comment: 'Strong contribution',
+          },
+        ],
+      });
+    });
+
+    expect(await screen.findByText(/Grades Approved/i)).toBeInTheDocument();
+  });
+
+  it('submits rejection with publishCycle and reason', async () => {
+    approveFinalGrades.mockResolvedValueOnce({
+      success: true,
+      groupId: 'group-1',
+      publishCycle: 'cycle-1',
+      decision: 'reject',
+      totalStudents: 1,
+      overridesApplied: 0,
+      message: 'Successfully rejected grades for 1 students',
+    });
+
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /Generate Preview/i }));
+    await screen.findByText('student-1');
+    await userEvent.type(screen.getByLabelText(/Reject reason/i), 'Needs recalculation');
+    await userEvent.click(screen.getByRole('button', { name: /^Reject$/i }));
+
+    await waitFor(() => {
+      expect(approveFinalGrades).toHaveBeenCalledWith('group-1', {
+        publishCycle: 'cycle-1',
+        decision: 'reject',
+        reason: 'Needs recalculation',
+        overrideEntries: [],
+      });
+    });
+
+    expect(await screen.findByText(/Grades Rejected/i)).toBeInTheDocument();
+  });
+
+  it('shows coordinator-only messaging for forbidden API responses', async () => {
+    previewFinalGrades.mockRejectedValueOnce({
+      response: {
+        status: 403,
+        data: {
+          message: 'Forbidden - only the Coordinator role may approve final grades',
+        },
+      },
+    });
+
+    renderPage();
+
+    await userEvent.click(screen.getByRole('button', { name: /Generate Preview/i }));
+
+    expect(
+      await screen.findByText(/only the Coordinator role may approve final grades/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/api/finalGradeService.js
+++ b/frontend/src/api/finalGradeService.js
@@ -64,6 +64,24 @@ export const getMyFinalGrades = async () => {
 };
 
 /**
+ * Generate a final grade preview for coordinator review.
+ * POST /groups/:groupId/final-grades/preview
+ */
+export const previewFinalGrades = async (groupId, payload = {}) => {
+  const response = await apiClient.post(`/groups/${groupId}/final-grades/preview`, payload);
+  return response.data;
+};
+
+/**
+ * Submit the coordinator approval/rejection decision for a final grade preview.
+ * POST /groups/:groupId/final-grades/approval
+ */
+export const approveFinalGrades = async (groupId, payload) => {
+  const response = await apiClient.post(`/groups/${groupId}/final-grades/approval`, payload);
+  return response.data;
+};
+
+/**
  * Get final grade approval summary for a group.
  * GET /groups/:groupId/final-grades/summary
  */
@@ -82,6 +100,8 @@ export const publishFinalGrades = async (groupId, payload) => {
 };
 
 const finalGradeService = {
+  previewFinalGrades,
+  approveFinalGrades,
   getCommitteeFinalResults,
   getMyFinalGrades,
   getGroupApprovalSummary,

--- a/frontend/src/components/CoordinatorPanel.js
+++ b/frontend/src/components/CoordinatorPanel.js
@@ -458,6 +458,22 @@ const CoordinatorPanel = () => {
                         </td>
                         <td style={{ padding: '12px' }}>
                           <button
+                            onClick={() => navigate(`/groups/${group.groupId}/final-grades/approval`)}
+                            style={{
+                              padding: '4px 8px',
+                              backgroundColor: '#0366d6',
+                              color: 'white',
+                              border: 'none',
+                              borderRadius: '4px',
+                              cursor: 'pointer',
+                              fontSize: '11px',
+                              fontWeight: '600',
+                              marginRight: '6px'
+                            }}
+                          >
+                            Review
+                          </button>
+                          <button
                             onClick={() => navigate(`/groups/${group.groupId}/final-grades/publish`)}
                             style={{
                               padding: '4px 8px',

--- a/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.css
+++ b/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.css
@@ -1,0 +1,320 @@
+.approval-page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 28px;
+  color: #111827;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.approval-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.approval-kicker {
+  margin: 0 0 6px;
+  color: #4b5563;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.approval-header h1,
+.approval-result h1 {
+  margin: 0 0 8px;
+  font-size: 30px;
+}
+
+.approval-header p,
+.approval-result p,
+.approval-empty p {
+  margin: 0;
+  color: #6b7280;
+}
+
+.approval-secondary-link,
+.approval-primary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 6px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.approval-secondary-link {
+  border: 1px solid #d1d5db;
+  color: #374151;
+  background: #ffffff;
+}
+
+.approval-primary-link {
+  margin-top: 24px;
+  background: #1d4ed8;
+  color: #ffffff;
+}
+
+.approval-alert,
+.approval-modal-error {
+  margin-bottom: 18px;
+  padding: 12px 14px;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.approval-empty,
+.approval-table-section,
+.approval-decision-panel,
+.approval-result {
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 22px;
+}
+
+.approval-empty {
+  max-width: 620px;
+}
+
+.approval-empty h2,
+.approval-section-heading h2 {
+  margin: 0 0 8px;
+  font-size: 20px;
+}
+
+.approval-empty label,
+.approval-decision-panel label,
+.approval-modal label {
+  display: block;
+  margin: 18px 0 8px;
+  color: #374151;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.approval-empty input,
+.approval-decision-panel textarea,
+.approval-modal input,
+.approval-modal textarea {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font: inherit;
+  box-sizing: border-box;
+}
+
+.approval-decision-panel textarea,
+.approval-modal textarea {
+  min-height: 86px;
+  resize: vertical;
+}
+
+.approval-empty button,
+.approval-section-heading button,
+.approval-row-actions button,
+.approval-modal-actions button,
+.approval-decision-actions button {
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111827;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+.approval-empty button {
+  margin-top: 18px;
+  padding: 11px 18px;
+  background: #1d4ed8;
+  color: #ffffff;
+  border-color: #1d4ed8;
+}
+
+.approval-summary,
+.approval-result-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.approval-summary div,
+.approval-result-grid div {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 16px;
+  background: #f9fafb;
+}
+
+.approval-summary span,
+.approval-result-grid dt {
+  display: block;
+  margin-bottom: 8px;
+  color: #6b7280;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.approval-summary strong,
+.approval-result-grid dd {
+  margin: 0;
+  color: #111827;
+  font-size: 18px;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.approval-section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.approval-section-heading button {
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.approval-table-wrap {
+  overflow-x: auto;
+}
+
+.approval-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 840px;
+}
+
+.approval-table th,
+.approval-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid #e5e7eb;
+  text-align: left;
+  vertical-align: top;
+}
+
+.approval-table th {
+  color: #4b5563;
+  font-size: 13px;
+  background: #f9fafb;
+}
+
+.approval-row-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.approval-row-actions button {
+  min-height: 32px;
+  padding: 0 10px;
+}
+
+.approval-row-actions .danger {
+  border-color: transparent;
+  color: #b91c1c;
+}
+
+.approval-decision-panel {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+  margin-top: 20px;
+}
+
+.approval-decision-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.approval-decision-actions button,
+.approval-modal-actions button {
+  min-height: 40px;
+  padding: 0 16px;
+}
+
+.approval-approve {
+  border-color: #15803d !important;
+  background: #15803d !important;
+  color: #ffffff !important;
+}
+
+.approval-reject {
+  border-color: #b91c1c !important;
+  background: #b91c1c !important;
+  color: #ffffff !important;
+}
+
+.approval-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: rgba(17, 24, 39, 0.58);
+}
+
+.approval-modal {
+  width: min(100%, 480px);
+  max-height: calc(100vh - 40px);
+  overflow-y: auto;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 24px;
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.22);
+}
+
+.approval-modal h2 {
+  margin: 0 0 6px;
+}
+
+.approval-modal-comparison {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 16px 0 4px;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 12px;
+  background: #f9fafb;
+}
+
+.approval-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+@media (max-width: 760px) {
+  .approval-page {
+    padding: 18px;
+  }
+
+  .approval-header,
+  .approval-section-heading {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .approval-summary,
+  .approval-result-grid,
+  .approval-decision-panel {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.jsx
+++ b/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.jsx
@@ -1,0 +1,384 @@
+import React, { useMemo, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { approveFinalGrades, previewFinalGrades } from '../api/finalGradeService';
+import './CoordinatorFinalGradeApprovalPanel.css';
+
+const formatNumber = (value, fractionDigits = 2) => {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return '-';
+  return number.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: fractionDigits,
+  });
+};
+
+const resolveApiError = (error, fallback) => {
+  const status = error?.response?.status;
+  const data = error?.response?.data;
+  const message = data?.message || data?.error || error?.message;
+
+  if (status === 403 || error?.code === 'FORBIDDEN' || error?.code === 'UNAUTHORIZED_ROLE') {
+    return 'Forbidden - only the Coordinator role may approve final grades';
+  }
+
+  if (status === 404) {
+    return message || 'Final grade preview data is missing. Generate a preview after prerequisite grades and ratios are ready.';
+  }
+
+  if (status === 409) {
+    return message || 'These grades are already approved, rejected, published, or otherwise locked.';
+  }
+
+  if (status === 422) {
+    return message || 'Please check the approval fields and try again.';
+  }
+
+  return message || fallback;
+};
+
+const normalizeStudents = (preview) => (Array.isArray(preview?.students) ? preview.students : []);
+
+const CoordinatorFinalGradeApprovalPanel = () => {
+  const { groupId } = useParams();
+  const [preview, setPreview] = useState(null);
+  const [publishCycle, setPublishCycle] = useState('');
+  const [loadingPreview, setLoadingPreview] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [approvalResult, setApprovalResult] = useState(null);
+  const [decisionReason, setDecisionReason] = useState('');
+  const [rejectReason, setRejectReason] = useState('');
+  const [overrides, setOverrides] = useState({});
+  const [activeStudent, setActiveStudent] = useState(null);
+  const [overrideGrade, setOverrideGrade] = useState('');
+  const [overrideComment, setOverrideComment] = useState('');
+  const [overrideError, setOverrideError] = useState('');
+
+  const students = useMemo(() => normalizeStudents(preview), [preview]);
+  const overrideCount = Object.keys(overrides).length;
+
+  const handleGeneratePreview = async () => {
+    setLoadingPreview(true);
+    setError('');
+    setApprovalResult(null);
+
+    try {
+      const data = await previewFinalGrades(groupId, {
+        persistForApproval: true,
+        publishCycle: publishCycle.trim() || undefined,
+        useLatestRatios: false,
+      });
+      setPreview(data);
+      setPublishCycle(data.publishCycle || publishCycle);
+      setOverrides({});
+    } catch (err) {
+      setError(resolveApiError(err, 'Failed to generate final grade preview.'));
+    } finally {
+      setLoadingPreview(false);
+    }
+  };
+
+  const openOverrideModal = (student) => {
+    const existing = overrides[student.studentId];
+    setActiveStudent(student);
+    setOverrideGrade(existing?.overriddenFinalGrade ?? '');
+    setOverrideComment(existing?.comment ?? '');
+    setOverrideError('');
+  };
+
+  const closeOverrideModal = () => {
+    setActiveStudent(null);
+    setOverrideGrade('');
+    setOverrideComment('');
+    setOverrideError('');
+  };
+
+  const saveOverride = () => {
+    if (!activeStudent) return;
+
+    const nextGrade = Number(overrideGrade);
+    const originalGrade = Number(activeStudent.computedFinalGrade);
+
+    if (!Number.isFinite(nextGrade) || nextGrade < 0 || nextGrade > 100) {
+      setOverrideError('Override grade must be a number between 0 and 100.');
+      return;
+    }
+
+    if (Number.isFinite(originalGrade) && nextGrade === originalGrade) {
+      setOverrideError('Override grade must differ from the computed grade.');
+      return;
+    }
+
+    if (!overrideComment.trim()) {
+      setOverrideError('Override reason is required.');
+      return;
+    }
+
+    setOverrides((current) => ({
+      ...current,
+      [activeStudent.studentId]: {
+        studentId: activeStudent.studentId,
+        originalFinalGrade: activeStudent.computedFinalGrade,
+        overriddenFinalGrade: nextGrade,
+        comment: overrideComment.trim(),
+      },
+    }));
+    closeOverrideModal();
+  };
+
+  const removeOverride = (studentId) => {
+    setOverrides((current) => {
+      const next = { ...current };
+      delete next[studentId];
+      return next;
+    });
+  };
+
+  const submitDecision = async (decision) => {
+    setSubmitting(true);
+    setError('');
+    setApprovalResult(null);
+
+    try {
+      const payload = {
+        publishCycle,
+        decision,
+        reason: decision === 'reject' ? rejectReason.trim() : decisionReason.trim(),
+        overrideEntries: decision === 'approve' ? Object.values(overrides) : [],
+      };
+
+      const result = await approveFinalGrades(groupId, payload);
+      setApprovalResult(result);
+    } catch (err) {
+      setError(resolveApiError(err, `Failed to ${decision} final grades.`));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (approvalResult) {
+    return (
+      <div className="approval-page">
+        <section className="approval-result" aria-live="polite">
+          <p className="approval-kicker">Approval snapshot recorded</p>
+          <h1>{approvalResult.decision === 'reject' ? 'Grades Rejected' : 'Grades Approved'}</h1>
+          <dl className="approval-result-grid">
+            <div>
+              <dt>Group</dt>
+              <dd>{approvalResult.groupId || groupId}</dd>
+            </div>
+            <div>
+              <dt>Publish cycle</dt>
+              <dd>{approvalResult.publishCycle || publishCycle}</dd>
+            </div>
+            <div>
+              <dt>Students</dt>
+              <dd>{approvalResult.totalStudents ?? students.length}</dd>
+            </div>
+            <div>
+              <dt>Overrides</dt>
+              <dd>{approvalResult.overridesApplied ?? 0}</dd>
+            </div>
+          </dl>
+          <p>{approvalResult.message || 'The coordinator decision has been saved.'}</p>
+          {approvalResult.decision !== 'reject' && (
+            <Link className="approval-primary-link" to={`/groups/${groupId}/final-grades/publish`}>
+              Continue to publish
+            </Link>
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <div className="approval-page">
+      <header className="approval-header">
+        <div>
+          <p className="approval-kicker">Coordinator final grade approval</p>
+          <h1>Preview & Approve Grades</h1>
+          <p>Group {groupId}</p>
+        </div>
+        <Link className="approval-secondary-link" to={`/groups/${groupId}/final-grades/publish`}>
+          Publish wizard
+        </Link>
+      </header>
+
+      {error && (
+        <div className="approval-alert" role="alert">
+          {error}
+        </div>
+      )}
+
+      {!preview && (
+        <section className="approval-empty">
+          <h2>Generate an approval preview</h2>
+          <p>Build the coordinator review snapshot from the latest deliverable scores and contribution ratios.</p>
+          <label htmlFor="publish-cycle">Publish cycle</label>
+          <input
+            id="publish-cycle"
+            type="text"
+            value={publishCycle}
+            onChange={(event) => setPublishCycle(event.target.value)}
+            placeholder="Optional. A cycle ID will be generated."
+          />
+          <button type="button" onClick={handleGeneratePreview} disabled={loadingPreview}>
+            {loadingPreview ? 'Generating preview' : 'Generate Preview'}
+          </button>
+        </section>
+      )}
+
+      {preview && (
+        <>
+          <section className="approval-summary" aria-label="Preview summary">
+            <div>
+              <span>Base group score</span>
+              <strong>{formatNumber(preview.baseGroupScore)}</strong>
+            </div>
+            <div>
+              <span>Students</span>
+              <strong>{students.length}</strong>
+            </div>
+            <div>
+              <span>Publish cycle</span>
+              <strong>{publishCycle}</strong>
+            </div>
+            <div>
+              <span>Overrides</span>
+              <strong>{overrideCount}</strong>
+            </div>
+          </section>
+
+          <section className="approval-table-section">
+            <div className="approval-section-heading">
+              <h2>Student grade review</h2>
+              <button type="button" onClick={handleGeneratePreview} disabled={loadingPreview || submitting}>
+                {loadingPreview ? 'Refreshing' : 'Regenerate Preview'}
+              </button>
+            </div>
+
+            <div className="approval-table-wrap">
+              <table className="approval-table">
+                <thead>
+                  <tr>
+                    <th>Student ID</th>
+                    <th>Contribution ratio</th>
+                    <th>Computed grade</th>
+                    <th>Override grade</th>
+                    <th>Reviewed grade</th>
+                    <th>Override reason</th>
+                    <th>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {students.map((student) => {
+                    const override = overrides[student.studentId];
+                    const reviewedGrade = override?.overriddenFinalGrade ?? student.computedFinalGrade;
+
+                    return (
+                      <tr key={student.studentId}>
+                        <td>{student.studentId}</td>
+                        <td>{formatNumber(student.contributionRatio, 4)}</td>
+                        <td>{formatNumber(student.computedFinalGrade)}</td>
+                        <td>{override ? formatNumber(override.overriddenFinalGrade) : '-'}</td>
+                        <td>{formatNumber(reviewedGrade)}</td>
+                        <td>{override?.comment || '-'}</td>
+                        <td>
+                          <div className="approval-row-actions">
+                            <button type="button" onClick={() => openOverrideModal(student)}>
+                              {override ? 'Edit' : 'Override'}
+                            </button>
+                            {override && (
+                              <button type="button" className="link-button danger" onClick={() => removeOverride(student.studentId)}>
+                                Remove
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="approval-decision-panel">
+            <div>
+              <label htmlFor="approval-reason">Approval note</label>
+              <textarea
+                id="approval-reason"
+                value={decisionReason}
+                onChange={(event) => setDecisionReason(event.target.value)}
+                placeholder="Optional approval context"
+              />
+            </div>
+            <div>
+              <label htmlFor="reject-reason">Reject reason</label>
+              <textarea
+                id="reject-reason"
+                value={rejectReason}
+                onChange={(event) => setRejectReason(event.target.value)}
+                placeholder="Required context for a rejection decision"
+              />
+            </div>
+            <div className="approval-decision-actions">
+              <button
+                type="button"
+                className="approval-reject"
+                onClick={() => submitDecision('reject')}
+                disabled={submitting || !publishCycle}
+              >
+                {submitting ? 'Submitting' : 'Reject'}
+              </button>
+              <button
+                type="button"
+                className="approval-approve"
+                onClick={() => submitDecision('approve')}
+                disabled={submitting || !publishCycle}
+              >
+                {submitting ? 'Submitting' : 'Approve'}
+              </button>
+            </div>
+          </section>
+        </>
+      )}
+
+      {activeStudent && (
+        <div className="approval-modal-backdrop" role="presentation">
+          <div className="approval-modal" role="dialog" aria-modal="true" aria-labelledby="override-title">
+            <h2 id="override-title">Student Grade Override</h2>
+            <p>Student {activeStudent.studentId}</p>
+            <div className="approval-modal-comparison">
+              <span>Computed grade</span>
+              <strong>{formatNumber(activeStudent.computedFinalGrade)}</strong>
+            </div>
+            <label htmlFor="override-grade">Override grade</label>
+            <input
+              id="override-grade"
+              type="number"
+              min="0"
+              max="100"
+              step="0.01"
+              value={overrideGrade}
+              onChange={(event) => setOverrideGrade(event.target.value)}
+            />
+            <label htmlFor="override-comment">Override reason</label>
+            <textarea
+              id="override-comment"
+              value={overrideComment}
+              onChange={(event) => setOverrideComment(event.target.value)}
+            />
+            {overrideError && <div className="approval-modal-error">{overrideError}</div>}
+            <div className="approval-modal-actions">
+              <button type="button" onClick={closeOverrideModal}>Cancel</button>
+              <button type="button" className="approval-approve" onClick={saveOverride}>Save Override</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CoordinatorFinalGradeApprovalPanel;

--- a/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.jsx
+++ b/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.jsx
@@ -82,7 +82,7 @@ const CoordinatorFinalGradeApprovalPanel = () => {
     const existing = overrides[student.studentId];
     setActiveStudent(student);
     setOverrideGrade(existing?.overriddenFinalGrade ?? '');
-    setOverrideComment(existing?.comment ?? '');
+    setOverrideComment(existing?.overrideReason ?? '');
     setOverrideError('');
   };
 
@@ -120,7 +120,7 @@ const CoordinatorFinalGradeApprovalPanel = () => {
         studentId: activeStudent.studentId,
         originalFinalGrade: activeStudent.computedFinalGrade,
         overriddenFinalGrade: nextGrade,
-        comment: overrideComment.trim(),
+        overrideReason: overrideComment.trim(),
       },
     }));
     closeOverrideModal();
@@ -135,6 +135,10 @@ const CoordinatorFinalGradeApprovalPanel = () => {
   };
 
   const submitDecision = async (decision) => {
+    if (submitting) {
+      return;
+    }
+
     setSubmitting(true);
     setError('');
     setApprovalResult(null);
@@ -282,7 +286,7 @@ const CoordinatorFinalGradeApprovalPanel = () => {
                         <td>{formatNumber(student.computedFinalGrade)}</td>
                         <td>{override ? formatNumber(override.overriddenFinalGrade) : '-'}</td>
                         <td>{formatNumber(reviewedGrade)}</td>
-                        <td>{override?.comment || '-'}</td>
+                        <td>{override?.overrideReason || '-'}</td>
                         <td>
                           <div className="approval-row-actions">
                             <button type="button" onClick={() => openOverrideModal(student)}>


### PR DESCRIPTION
What changed:

Added backend preview persistence bridge in finalGradeController.js (line 24): persistForApproval: true now creates pending FinalGrade rows and returns publishCycle; normal preview remains read-only. 

Made approval service transaction-aware in approvalService.js (line 32), so it still uses transactions on replica sets but works in local standalone Mongo/test environments. 

Added coordinator approval UI route at /groups/:groupId/final-grades/approval in App.js (line 153). 

Added the new approval page in CoordinatorFinalGradeApprovalPanel.jsx (line 1), including preview generation, override modal validation, approve/reject submission, and success state. 

Added frontend API helpers in finalGradeService.js (line 65). Added “Review” entry point from the coordinator group table in CoordinatorPanel.js (line 461).

 Added focused backend and frontend tests.
 Closes #252 