### PR TITLE
Unify student page UI styling

### DIFF
--- a/frontend/src/components/AdviseeRequestForm.css
+++ b/frontend/src/components/AdviseeRequestForm.css
@@ -1,199 +1,33 @@
-.advisee-request-page {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2rem;
-  background: radial-gradient(circle at top left, #1a1c2c 0%, #0d0e14 100%);
-  color: #fff;
+.advisor-form {
+  margin-top: 2px;
 }
 
-.form-container {
-  width: 100%;
-  max-width: 600px;
-  background: rgba(255, 255, 255, 0.03);
-  backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 24px;
-  padding: 3rem;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
-  animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
-}
-
-@keyframes slideUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-.form-header h1 {
-  font-size: 2.5rem;
-  font-weight: 800;
-  margin-bottom: 0.5rem;
-  background: linear-gradient(135deg, #fff 0%, #94a3b8 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-}
-
-.form-header p {
-  color: #94a3b8;
-  margin-bottom: 2rem;
-}
-
-.warning-banner {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  background: rgba(245, 158, 11, 0.1);
-  border: 1px solid rgba(245, 158, 11, 0.2);
-  color: #f59e0b;
-  padding: 1rem;
-  border-radius: 12px;
-  margin-bottom: 1.5rem;
-  font-size: 0.9rem;
-}
-
-.error-banner {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.2);
-  color: #ef4444;
-  padding: 1rem;
-  border-radius: 12px;
-  margin-bottom: 1.5rem;
-  font-size: 0.9rem;
-}
-
-.form-group {
-  margin-bottom: 1.5rem;
-}
-
-.form-group label {
-  display: block;
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: #cbd5e1;
-  margin-bottom: 0.5rem;
-}
-
-.form-group select,
-.form-group textarea {
-  width: 100%;
-  background: rgba(15, 23, 42, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  padding: 0.75rem 1rem;
-  color: #fff;
-  font-family: inherit;
-  font-size: 1rem;
-  transition: all 0.2s ease;
-}
-
-.form-group select:focus,
-.form-group textarea:focus {
-  outline: none;
-  border-color: #6366f1;
-  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.1);
-  background: rgba(15, 23, 42, 0.8);
-}
-
-.form-group select:disabled,
-.form-group textarea:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.form-actions {
-  display: flex;
-  gap: 1rem;
-  margin-top: 2rem;
-}
-
-.cancel-btn {
-  flex: 1;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  color: #fff;
-  padding: 0.75rem;
-  border-radius: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.cancel-btn:hover {
-  background: rgba(255, 255, 255, 0.05);
-}
-
-.submit-btn {
-  flex: 2;
-  background: linear-gradient(135deg, #6366f1 0%, #4338ca 100%);
-  border: none;
-  color: #fff;
-  padding: 0.75rem;
-  border-radius: 12px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-}
-
-.submit-btn:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: 0 10px 15px -3px rgba(99, 102, 241, 0.3);
-}
-
-.submit-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  filter: grayscale(0.5);
-}
-
-/* Success State */
-.form-container.success {
+.advisee-success-card {
   text-align: center;
+  padding: 40px 28px;
 }
 
 .success-icon {
-  width: 64px;
-  height: 64px;
-  background: rgba(34, 197, 94, 0.1);
-  color: #22c55e;
-  border-radius: 50%;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto 18px;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 2rem;
-  margin: 0 auto 1.5rem;
-  animation: scaleIn 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  border-radius: 50%;
+  background: #dcfce7;
+  color: #166534;
+  font-size: 28px;
+  font-weight: 800;
 }
 
-@keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.5); }
-  to { opacity: 1; transform: scale(1); }
+.advisee-success-card h2 {
+  color: #1a1a2e;
+  margin-bottom: 8px;
 }
 
 .redirect-hint {
-  font-size: 0.85rem;
-  color: #64748b;
-  margin-top: 1rem;
-}
-
-/* Loading State */
-.loading {
-  text-align: center;
-  padding: 4rem 2rem;
-}
-
-.spinner {
-  width: 40px;
-  height: 40px;
-  border: 3px solid rgba(99, 102, 241, 0.1);
-  border-top-color: #6366f1;
-  border-radius: 50%;
-  margin: 0 auto 1.5rem;
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
+  color: #9ca3af;
+  font-size: 13px;
+  margin-top: 12px;
 }

--- a/frontend/src/components/AdviseeRequestForm.js
+++ b/frontend/src/components/AdviseeRequestForm.js
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useAuthStore from '../store/authStore';
 import { getGroup } from '../api/groupService';
 import { getProfessors, submitAdvisorRequest, checkAdvisorWindow } from '../api/advisorService';
+import './PageShell.css';
 import './AdviseeRequestForm.css';
 
 /**
@@ -30,20 +31,17 @@ const AdviseeRequestForm = () => {
       setIsLoading(true);
       setError(null);
       try {
-        // 1. Security Check: Verify group membership and leader status
         const group = await getGroup(groupId);
         if (group.leaderId !== user.userId) {
-          // Redirect if not the leader
           navigate(`/groups/${groupId}`, { replace: true });
           return;
         }
 
-        // 2. Fetch required data in parallel
         const [profList, winStatus] = await Promise.all([
           getProfessors(),
           checkAdvisorWindow(),
         ]);
-        
+
         setProfessors(profList);
         setWindowInfo(winStatus);
 
@@ -72,16 +70,14 @@ const AdviseeRequestForm = () => {
       await submitAdvisorRequest({
         groupId,
         professorId: selectedProfessor,
-        message: message.trim() || undefined
+        message: message.trim() || undefined,
       });
-      
+
       setSuccess(true);
-      
-      // Redirect after success
+
       setTimeout(() => {
         navigate(`/groups/${groupId}`);
       }, 3000);
-      
     } catch (err) {
       console.error('Submission failed:', err);
 
@@ -103,19 +99,16 @@ const AdviseeRequestForm = () => {
 
   if (isLoading) {
     return (
-      <div className="advisee-request-page">
-        <div className="form-container loading">
-          <div className="spinner"></div>
-          <p>Loading advisor association details...</p>
-        </div>
+      <div className="student-page-shell narrow">
+        <div className="student-card student-loading">Loading advisor association details...</div>
       </div>
     );
   }
 
   if (success) {
     return (
-      <div className="advisee-request-page">
-        <div className="form-container success">
+      <div className="student-page-shell narrow">
+        <div className="student-card advisee-success-card">
           <div className="success-icon">✓</div>
           <h2>Request Submitted!</h2>
           <p>Your advisee request has been sent to the professor for review.</p>
@@ -126,35 +119,36 @@ const AdviseeRequestForm = () => {
   }
 
   return (
-    <div className="advisee-request-page">
-      <div className="form-container">
-        <header className="form-header">
+    <div className="student-page-shell narrow">
+      <header className="student-page-header">
+        <div>
+          <p className="student-page-kicker">Groups</p>
           <h1>Request Advisor</h1>
           <p>Select a professor to request as an advisor for your group.</p>
-        </header>
+        </div>
+      </header>
 
+      <div className="student-card">
         {!windowInfo.open && windowInfo.open !== null && (
-          <div className="warning-banner">
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-            </svg>
-            <span>The association window is closed. Submissions are temporarily disabled.</span>
+          <div className="student-alert warning">
+            The association window is closed. Submissions are temporarily disabled.
           </div>
         )}
 
-        {error && <div className="error-banner">{error}</div>}
+        {error && <div className="student-alert error">{error}</div>}
 
-        <form onSubmit={handleSubmit} className="advisor-form">
-          <div className="form-group">
+        <form onSubmit={handleSubmit} className="student-form advisor-form">
+          <div className="student-form-group">
             <label htmlFor="professor">Select Professor</label>
             <select
               id="professor"
+              className="student-select"
               value={selectedProfessor}
               onChange={(e) => setSelectedProfessor(e.target.value)}
               required
               disabled={!windowInfo.open || isSubmitting || scheduleBoundaryLocked}
             >
-              <option value="">-- Choose a Professor --</option>
+              <option value="">Choose a professor</option>
               {professors.map((p) => (
                 <option key={p.userId} value={p.userId}>
                   {p.name}
@@ -163,22 +157,23 @@ const AdviseeRequestForm = () => {
             </select>
           </div>
 
-          <div className="form-group">
+          <div className="student-form-group">
             <label htmlFor="message">Message (Optional)</label>
             <textarea
               id="message"
+              className="student-textarea"
               value={message}
               onChange={(e) => setMessage(e.target.value)}
               placeholder="Explain your project goals or why you'd like this professor to advise you..."
               rows="4"
               disabled={!windowInfo.open || isSubmitting || scheduleBoundaryLocked}
-            ></textarea>
+            />
           </div>
 
-          <div className="form-actions">
+          <div className="student-actions">
             <button
               type="button"
-              className="cancel-btn"
+              className="student-btn secondary"
               onClick={() => navigate(`/groups/${groupId}`)}
               disabled={isSubmitting}
             >
@@ -186,7 +181,7 @@ const AdviseeRequestForm = () => {
             </button>
             <button
               type="submit"
-              className="submit-btn"
+              className="student-btn primary"
               disabled={!windowInfo.open || !selectedProfessor || isSubmitting || scheduleBoundaryLocked}
             >
               {isSubmitting ? 'Submitting...' : 'Submit Request'}

--- a/frontend/src/components/AdvisorAssociationPanel.css
+++ b/frontend/src/components/AdvisorAssociationPanel.css
@@ -8,7 +8,8 @@
 .advisor-association-container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 40px 24px;
+  padding: 32px 24px;
+  min-height: 100vh;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
@@ -24,23 +25,31 @@
 /* ═══════════════════════════════════════════ Header ═══════════════════════════════════════════ */
 
 .panel-header {
-  margin-bottom: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 28px;
+  background: #ffffff;
+  padding: 24px 28px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.08);
+  border-left: 4px solid #667eea;
   text-align: left;
 }
 
 .panel-header h1 {
-  font-size: 32px;
+  font-size: 26px;
   font-weight: 700;
   color: #1a1a2e;
-  margin: 0 0 8px 0;
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  margin: 0 0 4px 0;
+  background: none;
+  -webkit-text-fill-color: currentColor;
 }
 
+.panel-header p,
 .panel-header .subtitle {
-  font-size: 16px;
+  font-size: 14px;
   color: #6b7280;
   margin: 0;
   font-weight: 400;
@@ -82,6 +91,12 @@
   color: #166534;
 }
 
+.alert-warning {
+  background-color: #fffbeb;
+  border: 1px solid #fcd34d;
+  color: #92400e;
+}
+
 .alert-icon {
   font-weight: 700;
   display: inline-flex;
@@ -94,11 +109,11 @@
 
 .section {
   background: white;
-  border: 1px solid #e5e7eb;
+  border: 1px solid #f3f4f6;
   border-radius: 12px;
-  padding: 28px;
-  margin-bottom: 28px;
-  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.08);
+  padding: 22px 24px;
+  margin-bottom: 20px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
 }
 
 .section-title {
@@ -121,6 +136,51 @@
   font-size: 16px;
 }
 
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.status-card,
+.request-form {
+  background: white;
+  border: 1px solid #f3f4f6;
+  border-radius: 12px;
+  padding: 22px 24px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
+}
+
+.status-card h3,
+.request-form h3,
+.sanitization-box h3 {
+  margin: 0 0 14px;
+  color: #374151;
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.assigned-info p {
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.btn-release {
+  padding: 8px 14px;
+  background: white;
+  color: #b91c1c;
+  border: 1.5px solid #fca5a5;
+  border-radius: 8px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.request-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 /* ═══════════════════════════════════════════ Groups Table ═══════════════════════════════════════════ */
 
 .groups-table-wrapper {
@@ -136,15 +196,17 @@
 }
 
 .groups-table thead {
-  background: linear-gradient(135deg, #667eea, #764ba2);
-  color: white;
+  background: #fafafa;
+  color: #9ca3af;
 }
 
 .groups-table th {
-  padding: 16px 20px;
+  padding: 10px 14px;
   text-align: left;
-  font-weight: 600;
-  border-bottom: 2px solid #e5e7eb;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  border-bottom: 1px solid #f3f4f6;
 }
 
 .groups-table tbody tr {
@@ -157,7 +219,7 @@
 }
 
 .groups-table td {
-  padding: 16px 20px;
+  padding: 12px 14px;
   vertical-align: middle;
 }
 
@@ -188,7 +250,7 @@
   color: white;
   border: none;
   padding: 8px 16px;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
   font-weight: 600;
   font-size: 13px;
@@ -270,9 +332,9 @@
 
 .form-control {
   width: 100%;
-  padding: 12px 16px;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
+  padding: 11px 14px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
   font-size: 14px;
   font-family: inherit;
   transition: all 0.2s ease;
@@ -300,9 +362,9 @@
 /* ═══════════════════════════════════════════ Buttons ═══════════════════════════════════════════ */
 
 .btn {
-  padding: 12px 24px;
+  padding: 10px 18px;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   font-weight: 600;
   font-size: 14px;
   cursor: pointer;
@@ -342,11 +404,11 @@
 }
 
 .btn-sanitize {
-  background: linear-gradient(135deg, #ec4899, #d946ef);
+  background: linear-gradient(135deg, #667eea, #764ba2);
   color: white;
-  padding: 14px 28px;
+  padding: 12px 18px;
   font-size: 15px;
-  box-shadow: 0 2px 4px rgba(236, 72, 153, 0.2);
+  box-shadow: 0 2px 4px rgba(102, 126, 234, 0.2);
   width: 100%;
 }
 
@@ -369,10 +431,12 @@
 
 .sanitization-box {
   background: white;
-  padding: 20px;
-  border-radius: 8px;
-  margin-top: 16px;
-  border-left: 4px solid #ec4899;
+  padding: 22px 24px;
+  border-radius: 12px;
+  margin-top: 20px;
+  border: 1px solid #f3f4f6;
+  border-left: 4px solid #667eea;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
 }
 
 .warning-text {
@@ -407,7 +471,8 @@
 
 /* ═══════════════════════════════════════════ Loading ═══════════════════════════════════════════ */
 
-.loading-spinner {
+.loading-spinner,
+.loading-state {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -416,7 +481,8 @@
   font-size: 16px;
 }
 
-.loading-spinner::before {
+.loading-spinner::before,
+.loading-state::before {
   content: '';
   width: 40px;
   height: 40px;
@@ -437,7 +503,14 @@
 
 @media (max-width: 768px) {
   .advisor-association-container {
-    padding: 24px 16px;
+    padding: 16px;
+  }
+
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+    border-left: none;
+    border-top: 4px solid #667eea;
   }
 
   .panel-header h1 {
@@ -459,6 +532,10 @@
 
   .form-actions {
     flex-direction: column;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
   }
 
   .form-actions .btn {

--- a/frontend/src/components/AdvisorAssociationPanel.js
+++ b/frontend/src/components/AdvisorAssociationPanel.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import {
   submitAdvisorRequest,
   releaseAdvisor,
@@ -9,6 +9,7 @@ import {
 } from '../api/advisorService';
 import { getGroup, getAllGroups, advisorSanitization } from '../api/groupService';
 import useAuthStore from '../store/authStore';
+import './PageShell.css';
 import './AdvisorAssociationPanel.css';
 
 /**
@@ -19,7 +20,6 @@ import './AdvisorAssociationPanel.css';
  */
 const AdvisorAssociationPanel = () => {
   const { group_id: groupId } = useParams();
-  const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
 
   // --- Shared State ---

--- a/frontend/src/components/PageShell.css
+++ b/frontend/src/components/PageShell.css
@@ -1,0 +1,368 @@
+.student-page-shell {
+  min-height: 100vh;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  color: #1f2937;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.student-page-shell.narrow {
+  max-width: 760px;
+}
+
+.student-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 28px;
+  background: #ffffff;
+  padding: 24px 28px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.08);
+  border-left: 4px solid #667eea;
+}
+
+.student-page-header h1 {
+  margin: 0 0 4px;
+  font-size: 26px;
+  font-weight: 700;
+  color: #1a1a2e;
+}
+
+.student-page-header p,
+.student-page-subtitle {
+  margin: 0;
+  color: #6b7280;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.student-page-kicker {
+  color: #667eea;
+  font-size: 12px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+.student-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 22px 24px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
+  border: 1px solid #f3f4f6;
+}
+
+.student-card + .student-card {
+  margin-top: 20px;
+}
+
+.deliverable-upload-stage {
+  margin-top: 20px;
+}
+
+.student-card-header {
+  margin: -22px -24px 20px;
+  padding: 18px 24px;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.student-card-header h2,
+.student-card h2,
+.student-card h3 {
+  margin: 0;
+  color: #374151;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.student-card-header p,
+.student-card p {
+  color: #6b7280;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.student-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.student-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.student-form-group label {
+  color: #333333;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.student-form-group .required {
+  color: #e74c3c;
+}
+
+.student-form-group .optional {
+  color: #9ca3af;
+  font-weight: 500;
+  text-transform: none;
+}
+
+.field-error {
+  color: #e74c3c;
+  font-size: 12px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.field-meta-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: #9ca3af;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.student-input,
+.student-select,
+.student-textarea {
+  width: 100%;
+  padding: 11px 14px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #1f2937;
+  font: inherit;
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.student-textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.student-input:focus,
+.student-select:focus,
+.student-textarea:focus {
+  outline: none;
+  border-color: #667eea;
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.12);
+}
+
+.student-input:disabled,
+.student-select:disabled,
+.student-textarea:disabled {
+  background: #f9fafb;
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.student-input.error,
+.student-select.error,
+.student-textarea.error {
+  border-color: #e74c3c;
+}
+
+.student-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.student-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: 1.5px solid transparent;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.student-btn.primary {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #ffffff;
+}
+
+.student-btn.secondary {
+  background: #ffffff;
+  color: #667eea;
+  border-color: #667eea;
+}
+
+.student-btn.danger {
+  background: #ffffff;
+  color: #b91c1c;
+  border-color: #fca5a5;
+}
+
+.student-btn.neutral {
+  background: #f3f4f6;
+  color: #4b5563;
+  border-color: #f3f4f6;
+}
+
+.student-btn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+
+.student-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.student-btn.full-width {
+  width: 100%;
+}
+
+.inline-reset-button {
+  margin-left: 12px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  text-decoration: underline;
+}
+
+.student-alert {
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.student-alert.error {
+  background: #fff1f2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+}
+
+.student-alert.success {
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  color: #166534;
+}
+
+.student-alert.warning {
+  background: #fffbeb;
+  border: 1px solid #fcd34d;
+  color: #92400e;
+}
+
+.student-loading,
+.student-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 260px;
+  color: #6b7280;
+  text-align: center;
+}
+
+.student-table-wrap {
+  overflow-x: auto;
+}
+
+.student-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.student-table thead {
+  background: #fafafa;
+}
+
+.student-table th {
+  padding: 10px 14px;
+  text-align: left;
+  font-size: 11px;
+  font-weight: 700;
+  color: #9ca3af;
+  text-transform: uppercase;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.student-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid #f9fafb;
+  font-size: 14px;
+  color: #374151;
+}
+
+.student-table tbody tr:hover {
+  background: #fafbff;
+}
+
+.student-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.student-badge.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.student-badge.warning {
+  background: #fef9c3;
+  color: #854d0e;
+}
+
+.student-badge.info {
+  background: #dbeafe;
+  color: #0c4a6e;
+}
+
+.student-badge.danger {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.student-badge.muted {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+@media (max-width: 640px) {
+  .student-page-shell {
+    padding: 16px;
+  }
+
+  .student-page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    border-left: none;
+    border-top: 4px solid #667eea;
+  }
+
+  .student-actions {
+    flex-direction: column;
+  }
+
+  .student-btn {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/deliverables/DeliverableSubmissionForm.jsx
+++ b/frontend/src/components/deliverables/DeliverableSubmissionForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import useAuthStore from '../../store/authStore';
 import { validateGroupForSubmission } from '../../api/deliverableService';
+import '../PageShell.css';
 
 /**
  * DeliverableSubmissionForm Component
@@ -8,8 +9,6 @@ import { validateGroupForSubmission } from '../../api/deliverableService';
 const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
   const user = useAuthStore((state) => state.user);
   const groupId = user?.groupId;
-
-  console.log(user)
 
   // Form inputs
   const [deliverableType, setDeliverableType] = useState('');
@@ -92,7 +91,7 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
 
   if (formState === 'token_received' && FileUploadWidget && validationToken) {
     return (
-      <div className="w-full">
+      <div className="deliverable-upload-stage">
         <FileUploadWidget
           validationToken={validationToken}
           groupId={groupId}
@@ -105,52 +104,40 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
   }
 
   return (
-    <div className="w-full max-w-xl mx-auto">
-      <div className="bg-white p-8 rounded-3xl border border-slate-100 shadow-sm">
-        <h2 className="text-2xl font-bold text-slate-800 mb-2">Initiate Submission</h2>
-        <p className="text-slate-500 mb-8 text-sm">Select the deliverable type and provide sprint details to proceed.</p>
+    <div className="student-card">
+      <div className="student-card-header">
+        <h2>Initiate Submission</h2>
+        <p>Select the deliverable type and provide sprint details to proceed.</p>
+      </div>
 
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-100 rounded-2xl flex items-start gap-3">
-            <div className="text-red-500 mt-0.5">
-              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <div className="flex-1">
-              <p className="text-sm font-bold text-red-800">{error}</p>
+          <div className="student-alert error">
+            <strong>{error}</strong>
               {errorCode === 'NETWORK_ERROR' && (
                 <button
+                  type="button"
                   onClick={handleRetry}
-                  className="mt-2 text-xs font-bold text-red-600 underline"
+                  className="inline-reset-button"
                 >
                   Try Again
                 </button>
               )}
-            </div>
           </div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-6 text-gray-800">
+        <form onSubmit={handleSubmit} className="student-form">
 
           {/* DELIVERABLE TYPE */}
-          <div className="gap-2 flex flex-col items-start">
-            <label
-              htmlFor="deliverable-type"
-              className="text-start mb-[6px] font-semibold text-[#333] text-sm"
-            >
-              DELIVERABLE TYPE <span className="text-red-500">*</span>
+          <div className="student-form-group">
+            <label htmlFor="deliverable-type">
+              DELIVERABLE TYPE <span className="required">*</span>
             </label>
 
             <select
               id="deliverable-type"
               value={deliverableType}
               onChange={(e) => setDeliverableType(e.target.value)}
-              className={`w-full px-[14px] py-[11px] border-2 rounded-md text-[0.95rem] font-medium transition-colors duration-200 focus:outline-none
-      ${fieldErrors.deliverableType
-                  ? "border-[#e74c3c] focus:ring-4 focus:ring-[rgba(231,76,60,0.1)]"
-                  : "border-[#e0e0e0] focus:border-[#667eea] focus:ring-4 focus:ring-[rgba(102,126,234,0.12)]"
-                }`}
+              className={`student-select ${fieldErrors.deliverableType ? 'error' : ''}`}
             >
               <option value="">Select a type...</option>
               <option value="proposal">Proposal</option>
@@ -161,19 +148,16 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
             </select>
 
             {fieldErrors.deliverableType && (
-              <p className="text-xs text-red-500 font-bold">
+              <p className="field-error">
                 {fieldErrors.deliverableType}
               </p>
             )}
           </div>
 
           {/* SPRINT ID */}
-          <div className="gap-2 flex flex-col items-start">
-            <label
-              htmlFor="sprint-id"
-              className="text-start mb-[6px] font-semibold text-[#333] text-sm"
-            >
-              SPRINT ID <span className="text-red-500">*</span>
+          <div className="student-form-group">
+            <label htmlFor="sprint-id">
+              SPRINT ID <span className="required">*</span>
             </label>
 
             <input
@@ -182,27 +166,20 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
               value={sprintId}
               onChange={(e) => setSprintId(e.target.value)}
               placeholder="e.g. Sprint-01"
-              className={`w-full px-[14px] py-[11px] border-2 rounded-md text-[0.95rem] font-medium transition-colors duration-200 focus:outline-none
-      ${fieldErrors.sprintId
-                  ? "border-[#e74c3c] focus:ring-4 focus:ring-[rgba(231,76,60,0.1)]"
-                  : "border-[#e0e0e0] focus:border-[#667eea] focus:ring-4 focus:ring-[rgba(102,126,234,0.12)]"
-                }`}
+              className={`student-input ${fieldErrors.sprintId ? 'error' : ''}`}
             />
 
             {fieldErrors.sprintId && (
-              <p className="text-xs text-red-500 font-bold">
+              <p className="field-error">
                 {fieldErrors.sprintId}
               </p>
             )}
           </div>
 
           {/* DESCRIPTION */}
-          <div className="gap-2 flex flex-col items-start">
-            <label
-              htmlFor="description"
-              className="text-start mb-[6px] font-semibold text-[#333] text-sm"
-            >
-              DESCRIPTION <span className="text-slate-300">(Optional)</span>
+          <div className="student-form-group">
+            <label htmlFor="description">
+              DESCRIPTION <span className="optional">(Optional)</span>
             </label>
 
             <textarea
@@ -210,22 +187,18 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder="10-500 characters..."
-              className={`w-full px-[14px] py-[11px] border-2 rounded-md text-[0.95rem] transition-colors duration-200 focus:outline-none min-h-[120px]
-      ${fieldErrors.description
-                  ? "border-[#e74c3c] focus:ring-4 focus:ring-[rgba(231,76,60,0.1)]"
-                  : "border-[#e0e0e0] focus:border-[#667eea] focus:ring-4 focus:ring-[rgba(102,126,234,0.12)]"
-                }`}
+              className={`student-textarea ${fieldErrors.description ? 'error' : ''}`}
             />
 
-            <div className="flex justify-between items-center text-[10px] font-bold uppercase tracking-wider">
+            <div className="field-meta-row">
               {fieldErrors.description ? (
-                <span className="text-red-500">{fieldErrors.description}</span>
+                <span className="field-error">{fieldErrors.description}</span>
               ) : (
-                <span className="text-slate-400">Contextual notes</span>
+                <span>Contextual notes</span>
               )}
               <span
                 className={
-                  description.length > 500 ? "text-red-500" : "text-slate-400"
+                  description.length > 500 ? 'field-error' : ''
                 }
               >
                 {description.length}/500
@@ -237,7 +210,7 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
           <button
             type="submit"
             disabled={isSubmitDisabled}
-            className={`${isSubmitDisabled ? "opacity-50 cursor-not-allowed" : "opacity-100 cursor-pointer"} w-full p-[13px] bg-gradient-to-br from-[#667eea] to-[#764ba2] text-white rounded-md text-base font-semibold transition-opacity duration-200 mt-2`}
+            className="student-btn primary full-width"
           >
             {formState === "loading"
               ? "Validating..."
@@ -245,7 +218,6 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
           </button>
 
         </form>
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/StudentFinalGradesPage.css
+++ b/frontend/src/pages/StudentFinalGradesPage.css
@@ -1,51 +1,61 @@
 .student-final-grades-page {
   min-height: 100vh;
-  background: #f8fafc;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
   color: #1f2937;
-  padding: 32px 28px 48px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 .student-final-grades-header {
-  align-items: flex-start;
+  align-items: center;
   display: flex;
   gap: 20px;
   justify-content: space-between;
-  margin: 0 auto 22px;
-  max-width: 1080px;
+  margin: 0 0 28px;
+  background: #ffffff;
+  padding: 24px 28px;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.08);
+  border-left: 4px solid #667eea;
 }
 
 .student-final-grades-kicker {
-  color: #2563eb;
+  color: #667eea;
   font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0;
   margin: 0 0 6px;
   text-transform: uppercase;
 }
 
 .student-final-grades-header h1 {
-  color: #111827;
-  font-size: 28px;
+  color: #1a1a2e;
+  font-size: 26px;
+  font-weight: 700;
   line-height: 1.2;
   margin: 0;
 }
 
 .student-final-grades-meta {
-  color: #64748b;
+  color: #6b7280;
   font-size: 14px;
-  margin: 8px 0 0;
+  margin: 6px 0 0;
 }
 
 .student-final-grades-button {
-  background: #2563eb;
-  border: 1px solid #2563eb;
-  border-radius: 6px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border: none;
+  border-radius: 8px;
   color: #ffffff;
   cursor: pointer;
   font-size: 14px;
-  font-weight: 600;
-  min-height: 38px;
-  padding: 8px 14px;
+  font-weight: 700;
+  min-height: 40px;
+  padding: 10px 18px;
+}
+
+.student-final-grades-button:hover:not(:disabled) {
+  opacity: 0.88;
 }
 
 .student-final-grades-button:disabled {
@@ -60,20 +70,20 @@
 .student-final-grades-panel {
   margin-left: auto;
   margin-right: auto;
-  max-width: 1080px;
 }
 
 .student-final-grades-state,
 .student-final-grades-empty {
   background: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
+  border: 1px solid #f3f4f6;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
   color: #64748b;
   padding: 24px;
 }
 
 .student-final-grades-empty h2 {
-  color: #111827;
+  color: #1a1a2e;
   font-size: 18px;
   margin: 0 0 6px;
 }
@@ -84,10 +94,10 @@
 
 .student-final-grades-error {
   background: #fff1f2;
-  border: 1px solid #fecdd3;
-  border-radius: 8px;
-  color: #9f1239;
-  padding: 20px 22px;
+  border: 1px solid #fca5a5;
+  border-radius: 10px;
+  color: #991b1b;
+  padding: 18px 20px;
 }
 
 .student-final-grades-error h2 {
@@ -101,22 +111,27 @@
 
 .student-final-grades-summary {
   display: grid;
-  gap: 14px;
+  gap: 20px;
   grid-template-columns: minmax(240px, 0.85fr) minmax(0, 1.6fr);
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .student-final-grades-score,
 .student-final-grades-facts > div {
   background: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  padding: 18px;
+  border: 1px solid #f3f4f6;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
+  padding: 20px 22px;
+}
+
+.student-final-grades-score {
+  border-left: 4px solid #667eea;
 }
 
 .student-final-grades-score span,
 .student-final-grades-facts span {
-  color: #64748b;
+  color: #9ca3af;
   display: block;
   font-size: 12px;
   font-weight: 700;
@@ -125,7 +140,7 @@
 }
 
 .student-final-grades-score strong {
-  color: #111827;
+  color: #1a1a2e;
   display: block;
   font-size: 44px;
   line-height: 1;
@@ -138,33 +153,34 @@
 }
 
 .student-final-grades-facts strong {
-  color: #111827;
+  color: #1f2937;
   display: block;
   font-size: 18px;
-  line-height: 1.2;
+  line-height: 1.25;
   overflow-wrap: anywhere;
 }
 
 .student-final-grades-panel {
   background: #ffffff;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
+  border: 1px solid #f3f4f6;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
   overflow: hidden;
 }
 
 .student-final-grades-panel-header {
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid #f3f4f6;
   padding: 18px 20px;
 }
 
 .student-final-grades-panel-header h2 {
-  color: #111827;
+  color: #374151;
   font-size: 18px;
   margin: 0;
 }
 
 .student-final-grades-panel-header p {
-  color: #64748b;
+  color: #6b7280;
   font-size: 13px;
   margin: 5px 0 0;
 }
@@ -181,19 +197,23 @@
 
 .student-final-grades-table th,
 .student-final-grades-table td {
-  border-bottom: 1px solid #eef2f7;
-  font-size: 13px;
-  padding: 13px 16px;
+  border-bottom: 1px solid #f9fafb;
+  font-size: 14px;
+  padding: 12px 14px;
   text-align: left;
   vertical-align: middle;
 }
 
 .student-final-grades-table th {
-  background: #f8fafc;
-  color: #475569;
-  font-size: 12px;
+  background: #fafafa;
+  color: #9ca3af;
+  font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
+}
+
+.student-final-grades-table tbody tr:hover {
+  background: #fafbff;
 }
 
 .student-final-grades-table tbody tr:last-child td {
@@ -212,16 +232,18 @@
 
 @media (max-width: 760px) {
   .student-final-grades-page {
-    padding: 22px 16px 36px;
-  }
-
-  .student-final-grades-header,
-  .student-final-grades-summary {
-    grid-template-columns: 1fr;
+    padding: 16px;
   }
 
   .student-final-grades-header {
+    align-items: flex-start;
     flex-direction: column;
+    border-left: none;
+    border-top: 4px solid #667eea;
+  }
+
+  .student-final-grades-summary {
+    grid-template-columns: 1fr;
   }
 
   .student-final-grades-button {
@@ -234,4 +256,3 @@
     grid-template-columns: 1fr;
   }
 }
-

--- a/frontend/src/pages/StudentFinalGradesPage.jsx
+++ b/frontend/src/pages/StudentFinalGradesPage.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { getMyFinalGrades } from '../api/finalGradeService';
+import '../components/PageShell.css';
 import './StudentFinalGradesPage.css';
 
 const formatNumber = (value, fractionDigits = 2) => {

--- a/frontend/src/pages/SubmitDeliverablePage.jsx
+++ b/frontend/src/pages/SubmitDeliverablePage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DeliverableSubmissionForm from '../components/deliverables/DeliverableSubmissionForm';
 import FileUploadWidget from '../components/deliverables/FileUploadWidget';
+import '../components/PageShell.css';
 
 /**
  * Page wrapper for the deliverable submission process.
@@ -8,10 +9,15 @@ import FileUploadWidget from '../components/deliverables/FileUploadWidget';
  */
 const SubmitDeliverablePage = () => {
   return (
-    <div className="page p-8">
-      <div className="max-w-4xl mx-auto">
-        <DeliverableSubmissionForm FileUploadWidget={FileUploadWidget} />
-      </div>
+    <div className="student-page-shell narrow">
+      <header className="student-page-header">
+        <div>
+          <p className="student-page-kicker">Deliverables</p>
+          <h1>Submit Deliverable</h1>
+          <p>Validate your group and upload the required project artifact.</p>
+        </div>
+      </header>
+      <DeliverableSubmissionForm FileUploadWidget={FileUploadWidget} />
     </div>
   );
 };


### PR DESCRIPTION
Updated student-facing pages to match the Create Group and Group Dashboard visual style. Added a shared page shell stylesheet, restyled Advisor Request, Advisor Panel, Submit Deliverable, and Student Final Grades with consistent white cards, compact headers, gradient primary buttons, alerts, form controls, and dashboard-style tables.

Build verified with npm.cmd run build. Existing lint warnings remain unrelated or pre-existing.