### PR TITLE
feat: replace sprint ID text input with multi-select dropdown

### DIFF
--- a/backend/scripts/seed-test-student.js
+++ b/backend/scripts/seed-test-student.js
@@ -27,7 +27,7 @@ const Group          = require('../src/models/Group');
 const Committee      = require('../src/models/Committee');
 const ScheduleWindow = require('../src/models/ScheduleWindow');
 const SprintConfig   = require('../src/models/SprintConfig');
-const Deliverable    = require('../src/models/Deliverable');
+const SprintRecord   = require('../src/models/SprintRecord');
 const { hashPassword }        = require('../src/utils/password');
 const { generateAccessToken } = require('../src/utils/jwt');
 
@@ -47,8 +47,8 @@ async function run() {
   await Group.deleteOne({ groupName: 'Test Group' });
   await Committee.deleteOne({ committeeName: 'Test Committee' });
   await ScheduleWindow.deleteMany({ createdBy: 'seed-test-student' });
-  await SprintConfig.deleteMany({ sprintId: 'sprint_1' });
-  await Deliverable.deleteMany({ groupId: /^grp_test_/ });
+  await SprintConfig.deleteMany({ sprintId: { $in: ['sprint_1', 'sprint_2'] } });
+  await SprintRecord.deleteMany({ groupId: /^grp_test_/ });
 
   // ── Create student user ───────────────────────────────────────────────────
   const userId = `usr_${uuidv4().split('-')[0]}`;
@@ -100,53 +100,18 @@ async function run() {
     });
   }
 
-  // ── Seed SprintConfig (D8) — future deadline for Process 5.4 ────────────
+  // ── Seed SprintConfig (D8) — future deadlines for Process 5.4 ───────────
   const deadlineDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
-  await SprintConfig.create({
-    sprintId: 'sprint_1',
-    deliverableType: 'proposal',
-    deadline: deadlineDate,
-    description: 'Test sprint — seeded for local dev',
-  });
+  for (const sprintId of ['sprint_1', 'sprint_2']) {
+    for (const deliverableType of ['proposal', 'statement_of_work', 'demo', 'interim_report', 'final_report']) {
+      await SprintConfig.create({ sprintId, deliverableType, deadline: deadlineDate, description: 'Test sprint — seeded for local dev' });
+    }
+  }
 
-  // ── Seed test Deliverable records (D4) for GET endpoints ─────────────────
-  const deliverableId1 = `DEL-test-${uuidv4().split('-')[0]}`;
-  const deliverableId2 = `DEL-test-${uuidv4().split('-')[0]}`;
-
-  await Deliverable.create([
-    {
-      deliverableId: deliverableId1,
-      committeeId,
-      groupId,
-      studentId: userId,
-      type: 'proposal',
-      sprintId: 'sprint_1',
-      version: 1,
-      storageRef: '/uploads/permanent/test-proposal.pdf',
-      status: 'accepted',
-      submittedAt: new Date(),
-      validationHistory: [
-        { step: 'format_validation',   passed: true,  checkedAt: new Date(), failureReasons: [] },
-        { step: 'deadline_validation', passed: true,  checkedAt: new Date(), failureReasons: [] },
-        { step: 'storage',             passed: true,  checkedAt: new Date(), failureReasons: [] },
-      ],
-    },
-    {
-      deliverableId: deliverableId2,
-      committeeId,
-      groupId,
-      studentId: userId,
-      type: 'proposal',
-      sprintId: 'sprint_1',
-      version: 2,
-      storageRef: '/uploads/permanent/test-proposal-v2.pdf',
-      status: 'submitted',
-      submittedAt: new Date(),
-      validationHistory: [
-        { step: 'format_validation',   passed: true,  checkedAt: new Date(), failureReasons: [] },
-        { step: 'deadline_validation', passed: true,  checkedAt: new Date(), failureReasons: [] },
-      ],
-    },
+  // ── Seed SprintRecords (D6) — populates the sprint multi-select dropdown ──
+  await SprintRecord.create([
+    { sprintId: 'sprint_1', groupId, status: 'in_progress' },
+    { sprintId: 'sprint_2', groupId, status: 'pending' },
   ]);
 
   // ── Coordinator JWT for retract endpoint ──────────────────────────────────
@@ -166,8 +131,7 @@ async function run() {
   console.log(`  password : ${TEST_PASSWORD}`);
   console.log(`  userId   : ${userId}`);
   console.log(`  groupId       : ${groupId}`);
-  console.log(`  deliverableId1: ${deliverableId1}  (status: accepted — use this to test retract)`);
-  console.log(`  deliverableId2: ${deliverableId2}  (status: submitted)`);
+  console.log(`  sprints       : sprint_1 (in_progress), sprint_2 (pending)`);
   console.log(`  JWT (student) : ${token}`);
   console.log(`  JWT (coord)   : ${coordToken}`);
   console.log('─────────────────────────────────────────────────────────────');

--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -193,7 +193,19 @@ const validateGroup = async (req, res) => {
  */
 const submitDeliverable = async (req, res) => {
   const userId = req.user?.userId;
-  const { groupId, deliverableType, sprintId, description } = req.body;
+  const { groupId, deliverableType, sprintId: rawSprintId, sprintIds: rawSprintIds, description } = req.body;
+
+  // Normalise sprint selection: multer gives a string for one value, array for many.
+  // Also fall back to legacy sprintId field.
+  let sprintIds = null;
+  if (Array.isArray(rawSprintIds) && rawSprintIds.length) {
+    sprintIds = rawSprintIds;
+  } else if (typeof rawSprintIds === 'string' && rawSprintIds) {
+    sprintIds = [rawSprintIds];
+  } else if (rawSprintId) {
+    sprintIds = [rawSprintId];
+  }
+  const sprintId = sprintIds?.[0] ?? null; // primary sprint used for deadline validation
 
   // 1. File must be present (multer handles 413/415 before this point)
   if (!req.file) {
@@ -207,7 +219,7 @@ const submitDeliverable = async (req, res) => {
   if (!groupId || !deliverableType || !sprintId) {
     return res.status(400).json({
       code: 'INVALID_REQUEST',
-      message: 'groupId, deliverableType, and sprintId are required',
+      message: 'groupId, deliverableType, and at least one sprintId are required',
     });
   }
 
@@ -285,6 +297,7 @@ const submitDeliverable = async (req, res) => {
       groupId,
       deliverableType,
       sprintId,
+      sprintIds,
       submittedBy: userId,
       description: description || null,
       tempFilePath: req.file.path,

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -1824,6 +1824,35 @@ const createAdvisorRequest = async (req, res) => {
   }
 };
 
+/**
+ * GET /api/v1/groups/:groupId/sprints
+ *
+ * Returns the list of sprints available for a group, sourced from SprintRecord (D6).
+ * Used to populate the sprint multi-select dropdown on the deliverable submission form.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const getGroupSprints = async (req, res) => {
+  const { groupId } = req.params;
+
+  let sprints;
+  try {
+    sprints = await SprintRecord.find({ groupId })
+      .select('sprintId status createdAt')
+      .sort({ createdAt: 1 })
+      .lean();
+  } catch (err) {
+    console.error('[getGroupSprints] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  return res.status(200).json({
+    sprints: sprints.map((s) => ({ sprintId: s.sprintId, status: s.status })),
+    total: sprints.length,
+  });
+};
+
 module.exports = {
   forwardApprovalResults,
   createGroup,
@@ -1836,4 +1865,5 @@ module.exports = {
   createAdvisorRequest,
   getSprintContributionSummary,
   getGroupCommitteeStatus,
+  getGroupSprints,
 };

--- a/backend/src/models/Deliverable.js
+++ b/backend/src/models/Deliverable.js
@@ -37,6 +37,10 @@ const deliverableSchema = new mongoose.Schema(
       type: String,
       default: null,
     },
+    sprintIds: {
+      type: [String],
+      default: undefined,
+    },
     submittedBy: {
       type: String,
       required: true,

--- a/backend/src/models/DeliverableStaging.js
+++ b/backend/src/models/DeliverableStaging.js
@@ -33,6 +33,10 @@ const deliverableStagingSchema = new mongoose.Schema(
       type: String,
       required: true,
     },
+    sprintIds: {
+      type: [String],
+      default: undefined,
+    },
     submittedBy: {
       type: String,
       required: true,

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -18,7 +18,8 @@ const {
   createMemberRequest,
   decideMemberRequest,
   coordinatorOverride,
-  transferAdvisor
+  transferAdvisor,
+  getGroupSprints,
 } = require('../controllers/groups');
 
 const { 
@@ -85,6 +86,9 @@ router.get('/:groupId', authMiddleware, getGroup);
  * GET /api/v1/groups/:groupId/committee-status — Committee status lookup (From your branch)
  */
 router.get('/:groupId/committee-status', authMiddleware, getGroupCommitteeStatus);
+
+// GET /api/v1/groups/:groupId/sprints — list available sprints for deliverable submission
+router.get('/:groupId/sprints', authMiddleware, getGroupSprints);
 
 // GET /api/v1/groups/:groupId/sprints/:sprintId/contributions — read-only Process 7.x summary
 router.get(

--- a/backend/src/services/storageService.js
+++ b/backend/src/services/storageService.js
@@ -122,7 +122,7 @@ const persistDeliverableFile = (stagingRecord) => {
  * @returns {Promise<import('../models/Deliverable').default>} Created Deliverable document
  */
 const createFinalRecord = async (stagingRecord, savedPath, session) => {
-  const { groupId, deliverableType, sprintId, submittedBy, description, fileHash, fileSize } = stagingRecord;
+  const { groupId, deliverableType, sprintId, sprintIds, submittedBy, description, fileHash, fileSize } = stagingRecord;
 
   const priorCount = await Deliverable.countDocuments({ groupId, deliverableType }).session(session ?? null);
   const version = priorCount + 1;
@@ -136,6 +136,7 @@ const createFinalRecord = async (stagingRecord, savedPath, session) => {
         groupId,
         deliverableType,
         sprintId: sprintId || null,
+        sprintIds: sprintIds?.length ? sprintIds : undefined,
         submittedBy,
         description: description || null,
         filePath: savedPath,

--- a/frontend/src/api/deliverableService.js
+++ b/frontend/src/api/deliverableService.js
@@ -64,6 +64,25 @@ export const submitDeliverable = async (groupId, formData) => {
 };
 
 /**
+ * Fetch available sprints for a group (used to populate the sprint multi-select).
+ * @param {string} groupId
+ * @returns {Promise<{ sprints: Array<{ sprintId: string, status: string }>, total: number }>}
+ */
+export const getGroupSprints = async (groupId) => {
+  const safeGroupId = normalizeGroupId(groupId);
+  if (!safeGroupId) return { sprints: [], total: 0 };
+  try {
+    const response = await apiClient.get(`/groups/${safeGroupId}/sprints`);
+    return response.data;
+  } catch (error) {
+    if (error.response?.status === 403 || error.response?.status === 404) {
+      return { sprints: [], total: 0 };
+    }
+    throw error;
+  }
+};
+
+/**
  * Fetch existing deliverables for a group.
  * @param {string} groupId
  * @returns {Promise<object>}

--- a/frontend/src/components/deliverables/DeliverableSubmissionForm.jsx
+++ b/frontend/src/components/deliverables/DeliverableSubmissionForm.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import useAuthStore from '../../store/authStore';
-import { validateGroupForSubmission } from '../../api/deliverableService';
+import { validateGroupForSubmission, getGroupSprints } from '../../api/deliverableService';
 import { normalizeGroupId } from '../../utils/groupId';
 
 /**
@@ -12,8 +12,15 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
 
   // Form inputs
   const [deliverableType, setDeliverableType] = useState('');
-  const [sprintId, setSprintId] = useState('');
+  const [selectedSprints, setSelectedSprints] = useState([]);
   const [description, setDescription] = useState('');
+
+  // Sprint dropdown data
+  const [availableSprints, setAvailableSprints] = useState([]);
+  const [sprintsLoading, setSprintsLoading] = useState(false);
+  const [sprintsError, setSprintsError] = useState(null);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef(null);
 
   // Form state management
   const [formState, setFormState] = useState('initial'); // initial, loading, token_received, error
@@ -26,12 +33,40 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
   // Field-level error tracking
   const [fieldErrors, setFieldErrors] = useState({});
 
+  // Fetch available sprints for this group on mount
+  useEffect(() => {
+    if (!groupId) return;
+    setSprintsLoading(true);
+    setSprintsError(null);
+    getGroupSprints(groupId)
+      .then(({ sprints }) => setAvailableSprints(sprints || []))
+      .catch(() => setSprintsError('Failed to load sprints'))
+      .finally(() => setSprintsLoading(false));
+  }, [groupId]);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSprintToggle = (sprintId) => {
+    setSelectedSprints((prev) =>
+      prev.includes(sprintId) ? prev.filter((s) => s !== sprintId) : [...prev, sprintId]
+    );
+  };
+
   /**
    * Determine if submit button should be disabled
    */
   const isSubmitDisabled =
     !deliverableType ||
-    !sprintId ||
+    selectedSprints.length === 0 ||
     (Boolean(lockedReason) && !devBypass) ||
     formState === 'loading' ||
     formState === 'token_received';
@@ -49,7 +84,7 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
     // Validate required fields
     const errors = {};
     if (!deliverableType) errors.deliverableType = 'Deliverable type is required';
-    if (!sprintId) errors.sprintId = 'Sprint ID is required';
+    if (selectedSprints.length === 0) errors.sprintId = 'At least one sprint is required';
     if (description && (description.length < 10 || description.length > 500)) {
       errors.description = 'Description must be between 10 and 500 characters';
     }
@@ -107,6 +142,15 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
     setError(null);
   };
 
+  // Compute sprint trigger button label
+  let triggerLabel = 'Select sprint(s)...';
+  if (sprintsLoading) triggerLabel = 'Loading sprints...';
+  else if (sprintsError) triggerLabel = 'Failed to load sprints';
+  else if (availableSprints.length === 0) triggerLabel = 'No sprints available';
+  else if (selectedSprints.length === 1) triggerLabel = selectedSprints[0];
+  else if (selectedSprints.length > 1) triggerLabel = `${selectedSprints.length} sprints selected`;
+  const triggerIsPlaceholder = selectedSprints.length === 0;
+
   if (formState === 'token_received' && FileUploadWidget && validationToken) {
     return (
       <div className="w-full">
@@ -114,7 +158,7 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
           validationToken={validationToken}
           groupId={groupId}
           deliverableType={deliverableType}
-          sprintId={sprintId}
+          sprintIds={selectedSprints}
           description={description}
         />
       </div>
@@ -196,38 +240,64 @@ const DeliverableSubmissionForm = ({ FileUploadWidget }) => {
             )}
           </div>
 
-          {/* SPRINT ID */}
+          {/* SPRINT(S) */}
           <div className="gap-2 flex flex-col items-start">
-            <label
-              htmlFor="sprint-id"
-              className="text-start mb-[6px] font-semibold text-[#333] text-sm"
-            >
-              SPRINT ID <span className="text-red-500">*</span>
-            </label>
+            <span className="text-start mb-[6px] font-semibold text-[#333] text-sm">
+              SPRINT(S) <span className="text-red-500">*</span>
+            </span>
 
-            <input
-              id="sprint-id"
-              type="text"
-              value={sprintId}
-              onChange={(e) => setSprintId(e.target.value)}
-              placeholder="e.g. Sprint-01"
-              className={`w-full px-[14px] py-[11px] border-2 rounded-md text-[0.95rem] font-medium transition-colors duration-200 focus:outline-none
-      ${fieldErrors.sprintId
-                  ? "border-[#e74c3c] focus:ring-4 focus:ring-[rgba(231,76,60,0.1)]"
-                  : "border-[#e0e0e0] focus:border-[#667eea] focus:ring-4 focus:ring-[rgba(102,126,234,0.12)]"
-                }`}
-            />
+            <div className="w-full relative" ref={dropdownRef}>
+              {/* Trigger button */}
+              <button
+                type="button"
+                onClick={() => setDropdownOpen((prev) => !prev)}
+                disabled={sprintsLoading || !!sprintsError || availableSprints.length === 0}
+                className={`w-full px-[14px] py-[11px] border-2 rounded-md text-[0.95rem] font-medium transition-colors duration-200 focus:outline-none text-left flex items-center justify-between
+                  ${fieldErrors.sprintId
+                    ? 'border-[#e74c3c] focus:ring-4 focus:ring-[rgba(231,76,60,0.1)]'
+                    : 'border-[#e0e0e0] focus:border-[#667eea] focus:ring-4 focus:ring-[rgba(102,126,234,0.12)]'}
+                  ${(sprintsLoading || !!sprintsError || availableSprints.length === 0) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+              >
+                <span className={triggerIsPlaceholder ? 'text-slate-400' : 'text-slate-700'}>
+                  {triggerLabel}
+                </span>
+                <svg
+                  className={`h-4 w-4 text-slate-400 transition-transform duration-200 ${dropdownOpen ? 'rotate-180' : ''}`}
+                  fill="none" viewBox="0 0 24 24" stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {/* Dropdown panel */}
+              {dropdownOpen && availableSprints.length > 0 && (
+                <div className="absolute z-10 w-full mt-1 bg-white border-2 border-[#e0e0e0] rounded-md shadow-lg overflow-hidden">
+                  {availableSprints.map((sprint) => (
+                    <label
+                      key={sprint.sprintId}
+                      className="flex items-center gap-3 px-4 py-[10px] cursor-pointer hover:bg-slate-50 transition-colors border-b border-slate-100 last:border-b-0"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedSprints.includes(sprint.sprintId)}
+                        onChange={() => handleSprintToggle(sprint.sprintId)}
+                        className="w-4 h-4 accent-[#667eea]"
+                      />
+                      <span className="text-[0.95rem] font-medium text-slate-700">
+                        {sprint.sprintId}
+                      </span>
+                      <span className="ml-auto text-xs text-slate-400 uppercase tracking-wider">
+                        {sprint.status}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
 
             {fieldErrors.sprintId && (
-              <p className="text-xs text-red-500 font-bold">
-                {fieldErrors.sprintId}
-              </p>
+              <p className="text-xs text-red-500 font-bold">{fieldErrors.sprintId}</p>
             )}
-            <p className="text-xs text-slate-500 mt-1 leading-relaxed">
-              Use the same <code className="text-slate-700">sprintId</code> as in Coordinator Sprint Dashboard / DB (e.g.{' '}
-              <code className="text-slate-700">sprint_1_1</code> from general seed or <code className="text-slate-700">sprint_1</code> from test scripts).
-              See <code className="text-slate-700">TEST-DATA-CHEATSHEET.md</code> § Deliverables.
-            </p>
           </div>
 
           {/* DESCRIPTION */}

--- a/frontend/src/components/deliverables/FileUploadWidget.jsx
+++ b/frontend/src/components/deliverables/FileUploadWidget.jsx
@@ -11,9 +11,10 @@ const FileUploadWidget = ({
   validationToken,
   groupId,
   deliverableType,
-  sprintId,
+  sprintIds,
   description,
 }) => {
+  const primarySprintId = sprintIds?.[0] ?? '';
   const navigate = useNavigate();
   const fileInputRef = useRef(null);
   const dragOverRef = useRef(false);
@@ -121,7 +122,7 @@ const FileUploadWidget = ({
       const formData = new FormData();
       formData.append('groupId', groupId);
       formData.append('deliverableType', deliverableType);
-      formData.append('sprintId', sprintId);
+      sprintIds.forEach((id) => formData.append('sprintIds', id));
       formData.append('file', file);
       if (description) formData.append('description', description);
 
@@ -138,7 +139,7 @@ const FileUploadWidget = ({
 
       activeStep = 3;
       setCurrentStep(3);
-      await validateDeadline(submitResponse.stagingId, sprintId, validationToken);
+      await validateDeadline(submitResponse.stagingId, primarySprintId, validationToken);
       setUploadProgress(75);
       setCompletedSteps([1, 2, 3]);
 
@@ -181,7 +182,7 @@ const FileUploadWidget = ({
 
         if (activeStep === 3) {
           setCurrentStep(3);
-          await validateDeadline(stagingId, sprintId, validationToken);
+          await validateDeadline(stagingId, primarySprintId, validationToken);
           setCompletedSteps([1, 2, 3]);
           setUploadProgress(75);
           activeStep = 4;
@@ -301,8 +302,8 @@ const FileUploadWidget = ({
                 <span className="text-indigo-600">{deliverableType.replace(/_/g, ' ')}</span>
               </div>
               <div>
-                <span className="text-slate-400 block mb-1">Sprint</span>
-                <span className="text-indigo-600">{sprintId}</span>
+                <span className="text-slate-400 block mb-1">Sprint(s)</span>
+                <span className="text-indigo-600">{sprintIds?.join(', ')}</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Add GET /api/v1/groups/:groupId/sprints endpoint to fetch available sprints from SprintRecord for a group
- Add sprintIds: [String] field to DeliverableStaging and Deliverable models alongside existing sprintId (primary, used for deadline validation)
- Update submitDeliverable controller to accept sprintIds array or legacy sprintId string; normalises multer's single-value string vs array behaviour
- Update storageService.createFinalRecord to carry sprintIds to final record
- Add getGroupSprints() to frontend deliverableService
- Replace sprint text input in DeliverableSubmissionForm with a custom dropdown: click-to-open, checkbox list, click-outside-to-close, chevron animation, and descriptive trigger label (N sprints selected)
- Update FileUploadWidget to accept sprintIds array; appends each ID to FormData and uses primary sprint for deadline validation
- Fix seed-test-student.js: remove broken Deliverable.create() using stale schema, seed SprintRecord and SprintConfig for sprint_1 and sprint_2