### PR TITLE
fix: resolve View Submission page failure after file upload

### DIFF
--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -767,6 +767,58 @@ const notifyDeliverableHandler = async (req, res) => {
   });
 };
 
+/**
+ * GET /api/deliverables/:deliverableId/download
+ *
+ * Stream the stored file to the requester.
+ * Students may only download deliverables belonging to their own group.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const downloadDeliverableHandler = async (req, res) => {
+  const { deliverableId } = req.params;
+  const { role, userId } = req.user;
+
+  let deliverable;
+  try {
+    deliverable = await Deliverable.findOne({ deliverableId }).lean();
+  } catch (err) {
+    console.error('[downloadDeliverableHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!deliverable) {
+    return res.status(404).json({ code: 'DELIVERABLE_NOT_FOUND', message: 'Deliverable not found' });
+  }
+
+  if (role === 'student') {
+    const ok = await studentBelongsToGroup(userId, deliverable.groupId);
+    if (!ok) {
+      return res.status(403).json({ code: 'FORBIDDEN', message: 'Students can only download their own group deliverables' });
+    }
+  }
+
+  if (!fs.existsSync(deliverable.filePath)) {
+    return res.status(404).json({ code: 'FILE_NOT_FOUND', message: 'File not found on disk' });
+  }
+
+  const downloadName = `${deliverable.deliverableType}_v${deliverable.version}.${deliverable.format}`;
+  res.setHeader('Content-Disposition', `attachment; filename="${downloadName}"`);
+  res.setHeader('Content-Length', deliverable.fileSize);
+
+  const mimeMap = {
+    pdf: 'application/pdf',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    doc: 'application/msword',
+    md: 'text/markdown',
+    zip: 'application/zip',
+  };
+  res.setHeader('Content-Type', mimeMap[deliverable.format] || 'application/octet-stream');
+
+  fs.createReadStream(deliverable.filePath).pipe(res);
+};
+
 module.exports = {
   validateGroup,
   submitDeliverable,
@@ -777,4 +829,5 @@ module.exports = {
   getDeliverableHandler,
   retractDeliverableHandler,
   notifyDeliverableHandler,
+  downloadDeliverableHandler,
 };

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -15,6 +15,7 @@ const {
   getDeliverableHandler,
   retractDeliverableHandler,
   notifyDeliverableHandler,
+  downloadDeliverableHandler,
 } = require('../controllers/deliverableController');
 const { updateCommentHandler, replyToCommentHandler } = require('../controllers/reviewController');
 const { addComment, getComments } = require('../controllers/reviewController');
@@ -35,6 +36,13 @@ router.get('/', listDeliverablesHandler);
  * Students can only view deliverables belonging to their own group.
  */
 router.get('/:deliverableId', getDeliverableHandler);
+
+/**
+ * GET /api/deliverables/:deliverableId/download
+ * Stream the stored file to the requester.
+ * Students may only download deliverables belonging to their own group.
+ */
+router.get('/:deliverableId/download', downloadDeliverableHandler);
 
 /**
  * POST /api/deliverables/validate-group

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -175,7 +175,7 @@ function App() {
             />
             <Route
               path="/dashboard/reviews/:deliverableId"
-              element={<ProtectedRoute component={ReviewPage} requiredRoles={['professor', 'coordinator', 'committee_member', 'admin']} />}
+              element={<ProtectedRoute component={ReviewPage} requiredRoles={['student', 'professor', 'coordinator', 'committee_member', 'admin']} />}
             />
             <Route
               path="/dashboard/reviews"

--- a/frontend/src/api/reviewAPI.js
+++ b/frontend/src/api/reviewAPI.js
@@ -142,6 +142,19 @@ export const getCommitteeCandidates = async () => {
   return response.data;
 };
 
+/**
+ * GET /api/v1/deliverables/:deliverableId/download
+ * Download the stored file for a deliverable
+ * @param {string} deliverableId
+ * @returns {Promise<AxiosResponse>} Response with blob data
+ */
+export const downloadDeliverable = async (deliverableId) => {
+  const response = await apiClient.get(`/deliverables/${deliverableId}/download`, {
+    responseType: 'blob',
+  });
+  return response;
+};
+
 export default {
   getDeliverableDetails,
   getComments,
@@ -153,4 +166,5 @@ export default {
   assignReview,
   getReviews,
   getCommitteeCandidates,
+  downloadDeliverable,
 };

--- a/frontend/src/components/deliverables/FileUploadWidget.jsx
+++ b/frontend/src/components/deliverables/FileUploadWidget.jsx
@@ -223,12 +223,8 @@ const FileUploadWidget = ({
   };
 
   const handleViewSubmission = () => {
-    // Route the student back to their group dashboard (the canonical place
-    // that lists submissions). The standalone "/dashboard/deliverables/:id"
-    // page does not exist in the router, so navigating there 404s.
-    const targetGroupId = successData?.groupId || groupId;
-    if (targetGroupId) {
-      navigate(`/groups/${targetGroupId}`);
+    if (successData?.deliverableId) {
+      navigate(`/dashboard/reviews/${successData.deliverableId}`);
     } else {
       navigate('/dashboard');
     }

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { getDeliverableDetails, getComments } from '../api/reviewAPI';
+import { getDeliverableDetails, getComments, downloadDeliverable } from '../api/reviewAPI';
 import CommentThread from '../components/reviews/CommentThread';
 import AddCommentForm from '../components/reviews/AddCommentForm';
 import useAuthStore from '../store/authStore';
@@ -101,6 +101,23 @@ const ReviewPage = () => {
       fetchComments();
     }
   }, [deliverableId, fetchDeliverable, fetchComments]);
+
+  // Handle file download
+  const handleDownload = async () => {
+    try {
+      const response = await downloadDeliverable(deliverableId);
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${deliverable.deliverableType}_v${deliverable.version}.${deliverable.format}`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Download failed:', err);
+    }
+  };
 
   // Handle comment added or updated
   const handleCommentUpdated = () => {
@@ -218,7 +235,7 @@ const ReviewPage = () => {
                 <div>
                   <h3 className="text-sm font-medium text-gray-700">Submitted At</h3>
                   <p className="text-gray-900 mt-1">
-                    {formatDate(deliverable.createdAt)}
+                    {formatDate(deliverable.submittedAt)}
                   </p>
                 </div>
 
@@ -265,6 +282,15 @@ const ReviewPage = () => {
                       <strong>Size:</strong> {(deliverable.fileSize / 1024 / 1024).toFixed(2)} MB
                     </p>
                   </div>
+                  <button
+                    onClick={handleDownload}
+                    className="mt-3 w-full px-3 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 flex items-center justify-center gap-2"
+                  >
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+                    </svg>
+                    Download File
+                  </button>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
- Navigate to /dashboard/reviews/:deliverableId on submission success instead of the group dashboard
- Add student role to ReviewPage route so students can access their own submission view
- Fix deliverable.createdAt → submittedAt (API never returned createdAt, causing Invalid Date)
- Add Download File button to ReviewPage with blob streaming
- Add GET /api/deliverables/:deliverableId/download backend endpoint