### PR TITLE
feat: implement GitHub OAuth login flow and error handling

### DIFF
--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -22,6 +22,24 @@ setInterval(() => {
   }
 }, 5 * 60 * 1000).unref();
 
+const getGithubConfigError = () => {
+  if (!process.env.GITHUB_CLIENT_ID) return 'GITHUB_CLIENT_ID';
+  if (!process.env.GITHUB_CLIENT_SECRET) return 'GITHUB_CLIENT_SECRET';
+  if (!process.env.GITHUB_REDIRECT_URI) return 'GITHUB_REDIRECT_URI';
+  return null;
+};
+
+const buildGithubAuthorizationUrl = (state) => {
+  const redirectUri = process.env.GITHUB_REDIRECT_URI;
+  return (
+    `https://github.com/login/oauth/authorize` +
+    `?client_id=${process.env.GITHUB_CLIENT_ID}` +
+    `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+    `&state=${state}` +
+    `&scope=read:user`
+  );
+};
+
 /**
  * Login with email and password
  */
@@ -267,9 +285,21 @@ const registerStudent = async (req, res) => {
 
     // Add GitHub OAuth URL if requested
     if (connectGithub) {
-      const state = crypto.randomBytes(16).toString('hex');
-      // Store state in session or cache (TODO: implement)
-      response.githubOauthUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${process.env.GITHUB_REDIRECT_URI}&state=${state}&scope=user`;
+      const configError = getGithubConfigError();
+      if (configError) {
+        return res.status(500).json({
+          code: 'GITHUB_CONFIG_MISSING',
+          message: `GitHub OAuth is not configured. Missing ${configError}.`,
+        });
+      }
+
+      const state = crypto.randomBytes(32).toString('hex');
+      oauthStateStore.set(state, {
+        userId: user.userId,
+        mode: 'link',
+        expiresAt: Date.now() + 10 * 60 * 1000,
+      });
+      response.githubOauthUrl = buildGithubAuthorizationUrl(state);
     }
 
     return res.status(201).json(response);
@@ -412,20 +442,23 @@ const logout = async (req, res) => {
  */
 const initiateGithubOAuth = async (req, res) => {
   try {
+    const configError = getGithubConfigError();
+    if (configError) {
+      return res.status(500).json({
+        code: 'GITHUB_CONFIG_MISSING',
+        message: `GitHub OAuth is not configured. Missing ${configError}.`,
+      });
+    }
+
     const state = crypto.randomBytes(32).toString('hex');
 
     oauthStateStore.set(state, {
       userId: req.user.userId,
+      mode: 'link',
       expiresAt: Date.now() + 10 * 60 * 1000,
     });
 
-    const redirectUri = process.env.GITHUB_REDIRECT_URI;
-    const authorizationUrl =
-      `https://github.com/login/oauth/authorize` +
-      `?client_id=${process.env.GITHUB_CLIENT_ID}` +
-      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&state=${state}` +
-      `&scope=read:user`;
+    const authorizationUrl = buildGithubAuthorizationUrl(state);
 
     return res.status(200).json({ authorizationUrl, state });
   } catch (error) {
@@ -433,6 +466,39 @@ const initiateGithubOAuth = async (req, res) => {
     res.status(500).json({
       code: 'SERVER_ERROR',
       message: 'Failed to initiate GitHub OAuth',
+    });
+  }
+};
+
+/**
+ * Initiate GitHub OAuth login (public)
+ * Returns the GitHub authorization URL for sign-in.
+ */
+const initiateGithubLoginOAuth = async (req, res) => {
+  try {
+    const configError = getGithubConfigError();
+    if (configError) {
+      return res.status(500).json({
+        code: 'GITHUB_CONFIG_MISSING',
+        message: `GitHub OAuth is not configured. Missing ${configError}.`,
+      });
+    }
+
+    const state = crypto.randomBytes(32).toString('hex');
+
+    oauthStateStore.set(state, {
+      mode: 'login',
+      expiresAt: Date.now() + 10 * 60 * 1000,
+    });
+
+    const authorizationUrl = buildGithubAuthorizationUrl(state);
+
+    return res.status(200).json({ authorizationUrl, state });
+  } catch (error) {
+    console.error('GitHub OAuth login initiation error:', error);
+    res.status(500).json({
+      code: 'SERVER_ERROR',
+      message: 'Failed to initiate GitHub OAuth login',
     });
   }
 };
@@ -470,6 +536,8 @@ const githubOAuthCallback = async (req, res) => {
       return redirectError('INVALID_STATE');
     }
 
+    const mode = stateData.mode || 'link';
+
     // Consume state (one-time use)
     const { userId } = stateData;
     oauthStateStore.delete(state);
@@ -477,6 +545,11 @@ const githubOAuthCallback = async (req, res) => {
     // Exchange authorization code for GitHub access token
     let githubAccessToken;
     try {
+      const configError = getGithubConfigError();
+      if (configError) {
+        return redirectError('GITHUB_CONFIG_MISSING');
+      }
+
       const tokenResponse = await axios.post(
         'https://github.com/login/oauth/access_token',
         {
@@ -520,7 +593,61 @@ const githubOAuthCallback = async (req, res) => {
       return redirectError('GITHUB_API_FAILED');
     }
 
-    // Load the authenticated user who initiated the OAuth flow
+    if (mode === 'login') {
+      const user = await User.findOne({ githubId });
+      if (!user) {
+        return redirectError('GITHUB_NOT_LINKED');
+      }
+
+      if (user.lockedUntil && user.lockedUntil > new Date()) {
+        return redirectError('ACCOUNT_LOCKED');
+      }
+
+      if (user.accountStatus === 'suspended') {
+        return redirectError('ACCOUNT_SUSPENDED');
+      }
+
+      user.loginAttempts = 0;
+      user.lockedUntil = null;
+      user.lastLogin = new Date();
+      await user.save();
+
+      const tokens = generateTokenPair(user.userId, user.role);
+
+      let groupId = null;
+      if (user.role === 'student') {
+        groupId = await resolveStudentAffiliatedGroupId(user.userId, {
+          statusIn: ['active', 'pending_validation'],
+        });
+      }
+
+      const refreshTokenDoc = new RefreshToken({
+        userId: user.userId,
+        token: tokens.refreshToken,
+        expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        userAgent: req.headers['user-agent'],
+        ipAddress: req.ip,
+        lastUsedAt: new Date(),
+      });
+      await refreshTokenDoc.save();
+
+      const query = new URLSearchParams({
+        status: 'logged_in',
+        accessToken: tokens.accessToken,
+        refreshToken: tokens.refreshToken,
+        userId: user.userId,
+        email: user.email,
+        role: user.role,
+        emailVerified: String(user.emailVerified),
+        accountStatus: user.accountStatus,
+        requiresPasswordChange: String(user.requiresPasswordChange || false),
+        ...(groupId ? { groupId } : {}),
+      });
+
+      return res.redirect(`${callbackBase}?${query.toString()}`);
+    }
+
+    // Linking flow
     const user = await User.findOne({ userId });
     if (!user) {
       return redirectError('USER_NOT_FOUND');
@@ -1131,6 +1258,7 @@ module.exports = {
   logout,
   changePassword,
   initiateGithubOAuth,
+  initiateGithubLoginOAuth,
   githubOAuthCallback,
   requestPasswordReset,
   validatePasswordResetToken,

--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -988,8 +988,21 @@ const professorOnboard = async (req, res) => {
     };
 
     if (connectGithub) {
-      const state = crypto.randomBytes(16).toString('hex');
-      response.githubOauthUrl = `https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_CLIENT_ID}&redirect_uri=${process.env.GITHUB_REDIRECT_URI}&state=${state}&scope=user`;
+      const configError = getGithubConfigError();
+      if (configError) {
+        return res.status(500).json({
+          code: 'GITHUB_CONFIG_MISSING',
+          message: `GitHub OAuth is not configured. Missing ${configError}.`,
+        });
+      }
+
+      const state = crypto.randomBytes(32).toString('hex');
+      oauthStateStore.set(state, {
+        userId: user.userId,
+        mode: 'link',
+        expiresAt: Date.now() + 10 * 60 * 1000,
+      });
+      response.githubOauthUrl = buildGithubAuthorizationUrl(state);
     }
 
     return res.status(200).json(response);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -8,6 +8,7 @@ const {
   logout,
   changePassword,
   initiateGithubOAuth,
+  initiateGithubLoginOAuth,
   githubOAuthCallback,
   requestPasswordReset,
   validatePasswordResetToken,
@@ -24,6 +25,7 @@ router.post('/login', loginWithPassword);
 router.post('/register', registerStudent);
 router.post('/refresh', refreshAccessToken);
 router.get('/github/oauth/callback', githubOAuthCallback);
+router.post('/github/oauth/login', initiateGithubLoginOAuth);
 router.post('/password-reset/request', requestPasswordReset);
 router.post('/password-reset/validate-token', validatePasswordResetToken);
 router.post('/password-reset/confirm', confirmPasswordReset);

--- a/frontend/src/__tests__/GitHubCallbackHandler.test.js
+++ b/frontend/src/__tests__/GitHubCallbackHandler.test.js
@@ -8,12 +8,24 @@ import useAuthStore from '../store/authStore';
 import useOnboardingStore from '../store/onboardingStore';
 import * as onboardingService from '../api/onboardingService';
 
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 jest.mock('../store/authStore');
 jest.mock('../store/onboardingStore');
 jest.mock('../api/onboardingService');
 
 describe('GitHubCallbackHandler', () => {
   const mockSetUser = jest.fn();
+  const mockSetAuth = jest.fn();
+  const mockSetRequiresPasswordChange = jest.fn();
   const mockSetStepComplete = jest.fn();
 
   beforeEach(() => {
@@ -23,6 +35,8 @@ describe('GitHubCallbackHandler', () => {
     useAuthStore.mockReturnValue({
       user: { id: '123', email: 'test@example.com' },
       setUser: mockSetUser,
+      setAuth: mockSetAuth,
+      setRequiresPasswordChange: mockSetRequiresPasswordChange,
     });
 
     // Mock useOnboardingStore - it's a zustand hook, so mock as a hook
@@ -39,6 +53,69 @@ describe('GitHubCallbackHandler', () => {
 
     // Mock onboardingService
     onboardingService.completeOnboarding = jest.fn().mockResolvedValue({});
+    mockNavigate.mockClear();
+  });
+
+  describe('Login Callback', () => {
+    it('sets auth and redirects to dashboard on logged_in', async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            '/auth/github/callback?status=logged_in&accessToken=acc&refreshToken=ref&userId=usr&email=test@example.com&role=student&emailVerified=true&accountStatus=active',
+          ]}
+        >
+          <GitHubCallbackHandler />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(mockSetAuth).toHaveBeenCalledWith(
+          {
+            userId: 'usr',
+            email: 'test@example.com',
+            role: 'student',
+            groupId: null,
+            emailVerified: true,
+            accountStatus: 'active',
+          },
+          'acc',
+          'ref'
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard', { replace: true });
+      });
+    });
+
+    it('shows error when logged_in is missing required params', async () => {
+      render(
+        <MemoryRouter initialEntries={['/auth/github/callback?status=logged_in&accessToken=acc']}>
+          <GitHubCallbackHandler />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Invalid Callback')).toBeInTheDocument();
+      });
+    });
+
+    it('redirects professor to setup when requiresPasswordChange=true', async () => {
+      render(
+        <MemoryRouter
+          initialEntries={[
+            '/auth/github/callback?status=logged_in&accessToken=acc&refreshToken=ref&userId=usr&email=prof@example.com&role=professor&emailVerified=true&accountStatus=active&requiresPasswordChange=true',
+          ]}
+        >
+          <GitHubCallbackHandler />
+        </MemoryRouter>
+      );
+
+      await waitFor(() => {
+        expect(mockSetRequiresPasswordChange).toHaveBeenCalledWith(true);
+        expect(mockNavigate).toHaveBeenCalledWith('/professor/setup', { replace: true });
+      });
+    });
   });
 
   describe('Success State', () => {

--- a/frontend/src/api/authService.js
+++ b/frontend/src/api/authService.js
@@ -59,6 +59,14 @@ export const initiateGithubOAuth = async (redirectUri) => {
 };
 
 /**
+ * Initiate GitHub OAuth login (public)
+ */
+export const initiateGithubLogin = async () => {
+  const response = await apiClient.post('/auth/github/oauth/login');
+  return response.data;
+};
+
+/**
  * Get account information
  */
 export const getAccount = async (userId) => {
@@ -153,6 +161,7 @@ const authService = {
   refreshAccessToken,
   logoutUser,
   initiateGithubOAuth,
+  initiateGithubLogin,
   getAccount,
   updateAccount,
   validatePasswordResetToken,

--- a/frontend/src/components/AuthMethodSelection.js
+++ b/frontend/src/components/AuthMethodSelection.js
@@ -11,8 +11,10 @@ const AuthMethodSelection = () => {
   const [searchParams] = useSearchParams();
   const isRegistration = searchParams.get('register') === 'true';
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
 
   const handleLocalAuth = () => {
+    setError('');
     if (isRegistration) {
       navigate('/onboarding');
     } else {
@@ -20,11 +22,22 @@ const AuthMethodSelection = () => {
     }
   };
 
-  const handleGithubOAuth = () => {
+  const handleGithubOAuth = async () => {
     setLoading(true);
-    // TODO: Implement GitHub OAuth flow
-    // For now, navigate to a placeholder
-    navigate('/auth/github-oauth');
+    setError('');
+    if (isRegistration) {
+      navigate('/onboarding?connectGithub=true');
+      return;
+    }
+
+    try {
+      const { initiateGithubLogin } = await import('../api/authService');
+      const data = await initiateGithubLogin();
+      window.location.href = data.authorizationUrl;
+    } catch (err) {
+      setError(err.response?.data?.message || 'Failed to start GitHub sign-in');
+      setLoading(false);
+    }
   };
 
   return (
@@ -35,6 +48,8 @@ const AuthMethodSelection = () => {
           <p className="subtitle">
             {isRegistration ? 'Create your account' : 'Sign in to your account'}
           </p>
+
+          {error && <div className="alert alert-error">{error}</div>}
 
           <div className="auth-methods">
             {/* Local Authentication */}

--- a/frontend/src/components/AuthMethodSelection.js
+++ b/frontend/src/components/AuthMethodSelection.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { initiateGithubLogin } from '../api/authService';
 import './AuthMethodSelection.css';
 
 /**
@@ -23,15 +24,14 @@ const AuthMethodSelection = () => {
   };
 
   const handleGithubOAuth = async () => {
-    setLoading(true);
     setError('');
     if (isRegistration) {
       navigate('/onboarding?connectGithub=true');
       return;
     }
 
+    setLoading(true);
     try {
-      const { initiateGithubLogin } = await import('../api/authService');
       const data = await initiateGithubLogin();
       window.location.href = data.authorizationUrl;
     } catch (err) {

--- a/frontend/src/components/GitHubCallbackHandler.js
+++ b/frontend/src/components/GitHubCallbackHandler.js
@@ -34,6 +34,18 @@ const ERROR_MESSAGES = {
     title: 'GitHub API Error',
     message: 'Could not retrieve your GitHub profile. GitHub may be temporarily unavailable. Please try again.',
   },
+  GITHUB_NOT_LINKED: {
+    title: 'GitHub Account Not Linked',
+    message: 'No account is linked to this GitHub profile. Please register first or link GitHub from your account settings.',
+  },
+  ACCOUNT_LOCKED: {
+    title: 'Account Locked',
+    message: 'Your account is temporarily locked. Please try again later or use password login.',
+  },
+  ACCOUNT_SUSPENDED: {
+    title: 'Account Suspended',
+    message: 'Your account is suspended. Please contact support for help.',
+  },
   USER_NOT_FOUND: {
     title: 'Session Error',
     message: 'Your session could not be found. Please log in again and retry.',
@@ -46,6 +58,10 @@ const ERROR_MESSAGES = {
     title: 'Server Error',
     message: 'An unexpected server error occurred. Please try again in a moment.',
   },
+  GITHUB_CONFIG_MISSING: {
+    title: 'GitHub OAuth Not Configured',
+    message: 'GitHub login is not configured on the server. Please contact support.',
+  },
 };
 
 const FALLBACK_ERROR = {
@@ -56,7 +72,7 @@ const FALLBACK_ERROR = {
 const GitHubCallbackHandler = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { user, setUser } = useAuthStore();
+  const { user, setUser, setAuth, setRequiresPasswordChange } = useAuthStore();
   const { setStepComplete } = useOnboardingStore();
 
   const [phase, setPhase] = useState('loading'); // 'loading' | 'success' | 'error'
@@ -68,6 +84,48 @@ const GitHubCallbackHandler = () => {
     const status = searchParams.get('status');
     const username = searchParams.get('githubUsername');
     const errorCode = searchParams.get('error');
+
+    if (status === 'logged_in') {
+      const accessToken = searchParams.get('accessToken');
+      const refreshToken = searchParams.get('refreshToken');
+      const userId = searchParams.get('userId');
+      const email = searchParams.get('email');
+      const role = searchParams.get('role');
+      const groupId = searchParams.get('groupId') || null;
+      const emailVerified = searchParams.get('emailVerified') === 'true';
+      const accountStatus = searchParams.get('accountStatus');
+      const requiresPasswordChange = searchParams.get('requiresPasswordChange') === 'true';
+
+      if (!accessToken || !refreshToken || !userId || !email || !role) {
+        setErrorInfo(ERROR_MESSAGES.MISSING_PARAMS || FALLBACK_ERROR);
+        setPhase('error');
+        return;
+      }
+
+      setAuth(
+        {
+          userId,
+          email,
+          role,
+          groupId,
+          emailVerified,
+          accountStatus,
+        },
+        accessToken,
+        refreshToken
+      );
+
+      if (requiresPasswordChange) {
+        setRequiresPasswordChange(true);
+        if (role === 'professor') {
+          navigate('/professor/setup', { replace: true });
+          return;
+        }
+      }
+
+      navigate('/dashboard', { replace: true });
+      return;
+    }
 
     if (status === 'linked' && username) {
       setGithubUsername(username);

--- a/frontend/src/components/onboarding/OnboardingStepper.js
+++ b/frontend/src/components/onboarding/OnboardingStepper.js
@@ -445,7 +445,7 @@ const Step4 = ({ onFinish, onBack, autoStartGithub }) => {
   const [loading, setLoading] = useState(false);
   const [apiError, setApiError] = useState('');
 
-  const handleLinkGithub = async () => {
+  const handleLinkGithub = useCallback(async () => {
     setLoading(true);
     setApiError('');
     try {
@@ -456,14 +456,14 @@ const Step4 = ({ onFinish, onBack, autoStartGithub }) => {
       setApiError(err.response?.data?.message || 'Failed to initiate GitHub OAuth');
       setLoading(false);
     }
-  };
+  }, [setApiError, setLoading]);
 
   useEffect(() => {
     if (autoStartGithub && !autoStarted) {
       setAutoStarted(true);
       handleLinkGithub();
     }
-  }, [autoStartGithub, autoStarted]);
+  }, [autoStartGithub, autoStarted, handleLinkGithub]);
 
   const handleSkip = async () => {
     setLoading(true);

--- a/frontend/src/components/onboarding/OnboardingStepper.js
+++ b/frontend/src/components/onboarding/OnboardingStepper.js
@@ -438,9 +438,10 @@ const Step3 = ({ onNext, onBack, urlToken }) => {
 // ─────────────────────────────────────────────
 // Step 4: Link GitHub (optional)
 // ─────────────────────────────────────────────
-const Step4 = ({ onFinish, onBack }) => {
+const Step4 = ({ onFinish, onBack, autoStartGithub }) => {
   const { setStepComplete } = useOnboardingStore();
   const { user } = useAuthStore();
+  const [autoStarted, setAutoStarted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [apiError, setApiError] = useState('');
 
@@ -449,13 +450,20 @@ const Step4 = ({ onFinish, onBack }) => {
     setApiError('');
     try {
       const { initiateGithubOAuth } = await import('../../api/authService');
-      const data = await initiateGithubOAuth(window.location.origin + '/auth/github/oauth/callback');
+      const data = await initiateGithubOAuth(window.location.origin + '/auth/github/callback');
       window.location.href = data.authorizationUrl;
     } catch (err) {
       setApiError(err.response?.data?.message || 'Failed to initiate GitHub OAuth');
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (autoStartGithub && !autoStarted) {
+      setAutoStarted(true);
+      handleLinkGithub();
+    }
+  }, [autoStartGithub, autoStarted]);
 
   const handleSkip = async () => {
     setLoading(true);
@@ -511,6 +519,7 @@ const OnboardingStepper = () => {
   const { user } = useAuthStore();
 
   const urlToken = searchParams.get('step') === 'verify-email' ? searchParams.get('token') : null;
+  const autoStartGithub = searchParams.get('connectGithub') === 'true';
 
   // Handle email verification deep-link: /onboarding?step=verify-email&token=xxx
   useEffect(() => {
@@ -551,7 +560,7 @@ const OnboardingStepper = () => {
       case 3:
         return <Step3 onNext={nextStep} onBack={previousStep} urlToken={urlToken} />;
       case 4:
-        return <Step4 onFinish={handleCompleteAndFinish} onBack={previousStep} />;
+        return <Step4 onFinish={handleCompleteAndFinish} onBack={previousStep} autoStartGithub={autoStartGithub} />;
       default:
         return null;
     }


### PR DESCRIPTION
Summary

Add a dedicated GitHub OAuth login initiation endpoint and support login-mode callbacks.
Persist OAuth state for registration and linking flows, and surface config errors early.
Wire the frontend “Continue with GitHub” button to the real OAuth flow and handle login redirects.
Changes

Implement public GitHub OAuth login initiation and callback handling with token issuance.
Add missing-config validation for GitHub OAuth settings.
Update frontend auth method selection, callback handler, and onboarding GitHub step auto-start.