### PR TITLE
fix: resolve sidebar toggle, layout, and UI alignment issues (#298)  

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -100,6 +100,8 @@ body {
   display: flex;
   min-height: 100vh;
   width: 100%;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background-attachment: fixed;
 }
 
 .app-layout-sidebar {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -39,10 +39,7 @@ import CoordinatorFinalGradePublishPanel from './pages/CoordinatorFinalGradePubl
 import ProfessorGradeReviewEntry from './pages/ProfessorGradeReviewEntry.jsx';
 import CoordinatorAdvisorInbox from './pages/CoordinatorAdvisorInbox.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
-const RootRoute = () => {
-  const { isAuthenticated } = useAuthStore();
-  return <Navigate to={isAuthenticated ? '/dashboard' : '/auth/method-selection'} replace />;
-};
+import RootRoute from './components/RootRoute';
 const Unauthorized = () => (
   <div className="page error" data-testid="unauthorized-page">
     403 Forbidden - Coordinator access required

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import useAuthStore from './store/authStore';
 import ProtectedRoute from './components/ProtectedRoute';
-import RootRoute from './components/RootRoute';
 import AuthMethodSelection from './components/AuthMethodSelection';
 import LoginForm from './components/LoginForm';
 import OnboardingStepper from './components/onboarding/OnboardingStepper';
@@ -40,6 +39,10 @@ import CoordinatorFinalGradePublishPanel from './pages/CoordinatorFinalGradePubl
 import ProfessorGradeReviewEntry from './pages/ProfessorGradeReviewEntry.jsx';
 import CoordinatorAdvisorInbox from './pages/CoordinatorAdvisorInbox.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
+const RootRoute = () => {
+  const { isAuthenticated } = useAuthStore();
+  return <Navigate to={isAuthenticated ? '/dashboard' : '/auth/method-selection'} replace />;
+};
 const Unauthorized = () => (
   <div className="page error" data-testid="unauthorized-page">
     403 Forbidden - Coordinator access required
@@ -49,6 +52,7 @@ const NotFound = () => <div className="page error">Page Not Found</div>;
 
 function App() {
   const { isAuthenticated } = useAuthStore();
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
 
   return (
     <Router
@@ -59,9 +63,15 @@ function App() {
     >
       <div className="app-layout">
         <div className="app-layout-sidebar">
-          <Sidebar />
+          <Sidebar isCollapsed={sidebarCollapsed} onToggle={() => setSidebarCollapsed(prev => !prev)} />
         </div>
-        <div className="app-layout-content" style={{ marginLeft: isAuthenticated ? '250px' : '0' }}>
+        <div
+          className="app-layout-content"
+          style={{
+            marginLeft: isAuthenticated ? (sidebarCollapsed ? '80px' : '260px') : '0',
+            transition: 'margin-left 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+          }}
+        >
           <Routes>
             <Route path="/" element={<RootRoute />} />
             <Route path="/auth/method-selection" element={<AuthMethodSelection />} />

--- a/frontend/src/components/AdviseeRequestForm.css
+++ b/frontend/src/components/AdviseeRequestForm.css
@@ -23,31 +23,28 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+.form-header {
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 32px;
+  padding-bottom: 28px;
+  text-align: center;
+}
+
 .form-header h1 {
   color: #333;
   font-size: 2.15rem;
   font-weight: 700;
   margin: 0 0 8px;
   line-height: 1.35;
-  text-align: left;
+  text-align: center;
 }
 
 .form-header p {
   color: #4b5563;
   font-size: 1rem;
   line-height: 1.55;
-  margin: 0 0 28px;
+  margin: 0;
   text-align: center;
-}
-
-.form-header {
-  align-items: flex-start;
-  border-bottom: 1px solid #e5e7eb;
-  display: grid;
-  gap: 28px;
-  grid-template-columns: 0.85fr 1.35fr;
-  margin-bottom: 32px;
-  padding-bottom: 28px;
 }
 
 .warning-banner {

--- a/frontend/src/components/AdviseeRequestForm.css
+++ b/frontend/src/components/AdviseeRequestForm.css
@@ -24,10 +24,13 @@
 }
 
 .form-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
   border-bottom: 1px solid #e5e7eb;
   margin-bottom: 32px;
   padding-bottom: 28px;
-  text-align: center;
 }
 
 .form-header h1 {
@@ -36,7 +39,6 @@
   font-weight: 700;
   margin: 0 0 8px;
   line-height: 1.35;
-  text-align: center;
 }
 
 .form-header p {
@@ -44,7 +46,6 @@
   font-size: 1rem;
   line-height: 1.55;
   margin: 0;
-  text-align: center;
 }
 
 .warning-banner {

--- a/frontend/src/components/AdviseeRequestForm.js
+++ b/frontend/src/components/AdviseeRequestForm.js
@@ -306,9 +306,9 @@ const AdviseeRequestForm = () => {
   return (
     <div className="advisee-request-page">
       <div className="form-container">
-        <header className="form-header" style={{ display: 'block', textAlign: 'center' }}>
-          <h1 style={{ textAlign: 'center' }}>Request Advisor</h1>
-          <p style={{ textAlign: 'center' }}>Select a professor to request as an advisor for your group.</p>
+        <header className="form-header">
+          <h1>Request Advisor</h1>
+          <p>Select a professor to request as an advisor for your group.</p>
         </header>
 
         {!windowInfo.open && windowInfo.open !== null && (

--- a/frontend/src/components/AdviseeRequestForm.js
+++ b/frontend/src/components/AdviseeRequestForm.js
@@ -306,9 +306,9 @@ const AdviseeRequestForm = () => {
   return (
     <div className="advisee-request-page">
       <div className="form-container">
-        <header className="form-header">
-          <h1>Request Advisor</h1>
-          <p>Select a professor to request as an advisor for your group.</p>
+        <header className="form-header" style={{ display: 'block', textAlign: 'center' }}>
+          <h1 style={{ textAlign: 'center' }}>Request Advisor</h1>
+          <p style={{ textAlign: 'center' }}>Select a professor to request as an advisor for your group.</p>
         </header>
 
         {!windowInfo.open && windowInfo.open !== null && (

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import useAuthStore from '../../store/authStore';
 import { normalizeGroupId } from '../../utils/groupId';
@@ -11,8 +11,7 @@ const isLikelyConcreteGroupId = (value) => {
   return true;
 };
 
-const Sidebar = () => {
-  const [isCollapsed, setIsCollapsed] = useState(false);
+const Sidebar = ({ isCollapsed, onToggle }) => {
   const { user, isAuthenticated, clearAuth } = useAuthStore();
   const navigate = useNavigate();
   const location = useLocation();
@@ -238,7 +237,7 @@ const Sidebar = () => {
           <div className="mx-auto h-8 w-8 bg-indigo-500 rounded-lg flex items-center justify-center text-white font-bold">S</div>
         )}
         <button
-          onClick={() => setIsCollapsed(!isCollapsed)}
+          onClick={onToggle}
           className="p-1.5 rounded-lg hover:bg-slate-800 text-slate-500 hover:text-white transition-colors"
         >
           <svg className={`h-5 w-5 transition-transform duration-300 ${isCollapsed ? 'rotate-180' : ''}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary

- **Sidebar toggle broken (#298):** `isCollapsed` state was local to
  `Sidebar.jsx`, so `App.js` always applied a hardcoded `marginLeft:
  250px` to the content area regardless of collapse state. Fixed by
  lifting state to `App.js` and passing `isCollapsed` / `onToggle` as
  props; content margin now animates between 260 px and 80 px with the
  same cubic-bezier easing as the sidebar itself to avoid the white-strip
  flicker during transition.
- **RootRoute missing:** Component was imported/used at the `/` route but
  never defined, causing an ESLint compile error on startup. Added inline
  definition that redirects authenticated users to `/dashboard` and
  unauthenticated users to `/auth/method-selection`.
- **App background:** Replaced the `#0f172a` dark fill on `.app-layout`
  with the site-wide purple-pink gradient (`135deg, #667eea → #764ba2`,
  `background-attachment: fixed`) so transparent page areas match the
  Create Group page aesthetic.
- **AdviseeRequestForm header alignment:** Header was rendered as a
  two-column CSS grid (`0.85fr 1.35fr`), placing the title and subtitle
  side by side. Removed the grid, set `text-align: center` on the
  container and both children so they stack vertically as intended.

## Test plan

- [x] Log in and verify sidebar toggle button collapses/expands the
  sidebar smoothly with no white gap or layout jump
- [x] Navigate to `/` while logged out → redirects to
  `/auth/method-selection`; while logged in → redirects to `/dashboard`
- [x] Verify no ESLint compile error on `npm start`
- [x] Check that pages without their own background (Dashboard, Profile,
  etc.) show the purple-pink gradient instead of black
- [x] Open `/groups/:id/advisor-request` and confirm "Request Advisor"
  title and subtitle are centered and stacked vertically