### PR TITLE
fix(profile, onboarding, advisor): resolve three security and correctness bugs (#337)

### DIFF
--- a/frontend/src/__tests__/AdviseeRequestForm.test.js
+++ b/frontend/src/__tests__/AdviseeRequestForm.test.js
@@ -18,6 +18,12 @@ const { getProfessors, submitAdvisorRequest, checkAdvisorWindow } = require('../
 const { getGroup } = require('../api/groupService');
 const { useParams, useNavigate } = require('react-router-dom');
 
+// Helper: open the custom dropdown and click the named option.
+const selectProfessor = async (professorName) => {
+  await userEvent.click(screen.getByRole('button', { name: /Select Professor/i }));
+  await userEvent.click(screen.getByRole('option', { name: new RegExp(professorName, 'i') }));
+};
+
 describe('AdviseeRequestForm', () => {
   const navigateMock = jest.fn();
 
@@ -41,7 +47,9 @@ describe('AdviseeRequestForm', () => {
     render(<AdviseeRequestForm />);
 
     await waitFor(() => expect(getGroup).toHaveBeenCalledWith('grp_test'));
-    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Select Professor/i })).toBeInTheDocument()
+    );
     expect(screen.getByRole('button', { name: /Submit Request/i })).toBeDisabled();
   });
 
@@ -50,7 +58,9 @@ describe('AdviseeRequestForm', () => {
 
     render(<AdviseeRequestForm />);
 
-    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Select Professor/i })).toBeInTheDocument()
+    );
 
     const form = document.querySelector('form.advisor-form');
     await act(async () => {
@@ -66,9 +76,11 @@ describe('AdviseeRequestForm', () => {
 
     render(<AdviseeRequestForm />);
 
-    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Select Professor/i })).toBeInTheDocument()
+    );
 
-    await userEvent.selectOptions(screen.getByRole('combobox'), 'usr_prof_1');
+    await selectProfessor('Dr. Ada Lovelace');
     await userEvent.type(screen.getByLabelText(/Message \(Optional\)/i), 'We would love your guidance.');
 
     await act(async () => {
@@ -90,8 +102,10 @@ describe('AdviseeRequestForm', () => {
 
     render(<AdviseeRequestForm />);
 
-    await waitFor(() => expect(screen.getByText(/association window is closed/i)).toBeInTheDocument());
-    expect(screen.getByRole('combobox')).toBeDisabled();
+    await waitFor(() =>
+      expect(screen.getByText(/association window is closed/i)).toBeInTheDocument()
+    );
+    expect(screen.getByRole('button', { name: /Select Professor/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /Submit Request/i })).toBeDisabled();
   });
 
@@ -101,8 +115,10 @@ describe('AdviseeRequestForm', () => {
 
     render(<AdviseeRequestForm />);
 
-    await waitFor(() => expect(screen.getByRole('combobox')).toBeInTheDocument());
-    await userEvent.selectOptions(screen.getByRole('combobox'), 'usr_prof_1');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Select Professor/i })).toBeInTheDocument()
+    );
+    await selectProfessor('Dr. Ada Lovelace');
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /Submit Request/i }));
     });
@@ -111,6 +127,59 @@ describe('AdviseeRequestForm', () => {
       expect(screen.getByText(/The advisor request window is currently closed./i)).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: /Submit Request/i })).toBeDisabled();
-    expect(screen.getByRole('combobox')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Select Professor/i })).toBeDisabled();
+  });
+
+  describe('DEV_BYPASS removed', () => {
+    beforeEach(() => {
+      localStorage.setItem('DEV_BYPASS', 'true');
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('never renders a DEV_BYPASS banner regardless of the localStorage flag', async () => {
+      checkAdvisorWindow.mockResolvedValue({ open: true });
+
+      render(<AdviseeRequestForm />);
+
+      await waitFor(() => expect(getGroup).toHaveBeenCalled());
+
+      expect(screen.queryByText(/DEV_BYPASS/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/bypass/i)).not.toBeInTheDocument();
+    });
+
+    it('keeps the closed window locked when DEV_BYPASS is in localStorage', async () => {
+      checkAdvisorWindow.mockResolvedValue({ open: false });
+
+      render(<AdviseeRequestForm />);
+
+      await waitFor(() =>
+        expect(screen.getByText(/association window is closed/i)).toBeInTheDocument()
+      );
+
+      expect(screen.getByRole('button', { name: /Submit Request/i })).toBeDisabled();
+    });
+
+    it('422 response shows the standard closed-window message, not a bypass-mode message', async () => {
+      checkAdvisorWindow.mockResolvedValue({ open: true });
+      submitAdvisorRequest.mockRejectedValue({ response: { status: 422 } });
+
+      render(<AdviseeRequestForm />);
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Select Professor/i })).toBeInTheDocument()
+      );
+      await selectProfessor('Dr. Ada Lovelace');
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /Submit Request/i }));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/The advisor request window is currently closed\./i)).toBeInTheDocument();
+        expect(screen.queryByText(/bypass mode/i)).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/frontend/src/__tests__/OnboardingStore.test.js
+++ b/frontend/src/__tests__/OnboardingStore.test.js
@@ -1,0 +1,79 @@
+import '@testing-library/jest-dom';
+import useOnboardingStore from '../store/onboardingStore';
+
+describe('OnboardingStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useOnboardingStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useOnboardingStore.getState().reset();
+  });
+
+  describe('password never persisted to localStorage', () => {
+    it('does not write password to localStorage when setPassword is called', (done) => {
+      useOnboardingStore.getState().setPassword('s3cr3tP@ss');
+
+      setTimeout(() => {
+        const raw = localStorage.getItem('onboarding-storage');
+        expect(raw).not.toBeNull();
+        const { state } = JSON.parse(raw);
+        expect(state).not.toHaveProperty('password');
+        done();
+      }, 10);
+    });
+
+    it('does not leak the password value into the localStorage string', (done) => {
+      useOnboardingStore.getState().setPassword('should-not-appear-in-storage');
+
+      setTimeout(() => {
+        const raw = localStorage.getItem('onboarding-storage');
+        expect(raw).not.toContain('should-not-appear-in-storage');
+        done();
+      }, 10);
+    });
+
+    it('persists non-sensitive fields (email, validationToken, userId) correctly', (done) => {
+      useOnboardingStore.getState().setEmail('student@example.com');
+      useOnboardingStore.getState().setValidationToken('tok_abc123');
+      useOnboardingStore.getState().setUserId('usr_001');
+
+      setTimeout(() => {
+        const { state } = JSON.parse(localStorage.getItem('onboarding-storage'));
+        expect(state.email).toBe('student@example.com');
+        expect(state.validationToken).toBe('tok_abc123');
+        expect(state.userId).toBe('usr_001');
+        done();
+      }, 10);
+    });
+
+    it('does not persist password even when set alongside other fields', (done) => {
+      useOnboardingStore.getState().setEmail('user@example.com');
+      useOnboardingStore.getState().setPassword('alongside-secret');
+
+      setTimeout(() => {
+        const { state } = JSON.parse(localStorage.getItem('onboarding-storage'));
+        expect(state.email).toBe('user@example.com');
+        expect(state).not.toHaveProperty('password');
+        done();
+      }, 10);
+    });
+  });
+
+  describe('in-memory password state', () => {
+    it('stores and clears password in memory without touching localStorage', () => {
+      useOnboardingStore.getState().setPassword('in-memory-only');
+      expect(useOnboardingStore.getState().password).toBe('in-memory-only');
+
+      useOnboardingStore.getState().setPassword(null);
+      expect(useOnboardingStore.getState().password).toBeNull();
+    });
+
+    it('reset() clears password from in-memory state', () => {
+      useOnboardingStore.getState().setPassword('clear-on-reset');
+      useOnboardingStore.getState().reset();
+      expect(useOnboardingStore.getState().password).toBeNull();
+    });
+  });
+});

--- a/frontend/src/api/profileService.js
+++ b/frontend/src/api/profileService.js
@@ -1,0 +1,3 @@
+import { updateAccount } from './authService';
+
+export const updateProfile = (userId, updates) => updateAccount(userId, updates);

--- a/frontend/src/components/AdviseeRequestForm.js
+++ b/frontend/src/components/AdviseeRequestForm.js
@@ -112,7 +112,6 @@ const AdviseeRequestForm = () => {
   const [scheduleBoundaryLocked, setScheduleBoundaryLocked] = useState(false);
   const [pendingConflict, setPendingConflict] = useState(null);
   const [isCancelling, setIsCancelling] = useState(false);
-  const devBypass = localStorage.getItem('DEV_BYPASS') === 'true';
 
   useEffect(() => {
     if (!groupId || !user?.userId || isReservedGroupRoute) return;
@@ -136,7 +135,7 @@ const AdviseeRequestForm = () => {
         ]);
         
         setProfessors(profList);
-        const effectiveOpen = Boolean(winStatus?.open) || devBypass;
+        const effectiveOpen = Boolean(winStatus?.open);
         setWindowInfo({ ...winStatus, open: effectiveOpen });
 
         if (!effectiveOpen) {
@@ -151,7 +150,7 @@ const AdviseeRequestForm = () => {
     };
 
     fetchData();
-  }, [groupId, user?.userId, navigate, devBypass, isReservedGroupRoute]);
+  }, [groupId, user?.userId, navigate, isReservedGroupRoute]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -186,12 +185,8 @@ const AdviseeRequestForm = () => {
       if (status === 403) {
         setError('You must be the team leader to perform this action.');
       } else if (status === 422) {
-        if (devBypass) {
-          setError('Schedule validation failed on server despite bypass mode. Ask coordinator to open advisor_association window.');
-        } else {
-          setError('The advisor request window is currently closed.');
-          setScheduleBoundaryLocked(true);
-        }
+        setError('The advisor request window is currently closed.');
+        setScheduleBoundaryLocked(true);
       } else if (status === 409) {
         const data = err.response?.data || {};
         const code = data.code;
@@ -319,12 +314,6 @@ const AdviseeRequestForm = () => {
             <span>The association window is closed. Submissions are temporarily disabled.</span>
           </div>
         )}
-        {devBypass && (
-          <div className="warning-banner">
-            <span>DEV_BYPASS is enabled. Frontend schedule lock is bypassed for testing.</span>
-          </div>
-        )}
-
         {error && (
           <div className="error-banner">
             <div>{error}</div>
@@ -355,7 +344,7 @@ const AdviseeRequestForm = () => {
               value={selectedProfessor}
               professors={professors}
               onChange={setSelectedProfessor}
-              disabled={(!windowInfo.open || scheduleBoundaryLocked) && !devBypass ? true : isSubmitting}
+              disabled={!windowInfo.open || scheduleBoundaryLocked || isSubmitting}
             />
           </div>
 
@@ -367,7 +356,7 @@ const AdviseeRequestForm = () => {
               onChange={(e) => setMessage(e.target.value)}
               placeholder="Explain your project goals or why you'd like this professor to advise you..."
               rows="4"
-              disabled={(!windowInfo.open || scheduleBoundaryLocked) && !devBypass ? true : isSubmitting}
+              disabled={!windowInfo.open || scheduleBoundaryLocked || isSubmitting}
             ></textarea>
           </div>
 
@@ -383,7 +372,7 @@ const AdviseeRequestForm = () => {
             <button
               type="submit"
               className="submit-btn"
-              disabled={(!windowInfo.open || scheduleBoundaryLocked) && !devBypass ? true : (!selectedProfessor || isSubmitting)}
+              disabled={!windowInfo.open || scheduleBoundaryLocked || !selectedProfessor || isSubmitting}
             >
               {isSubmitting ? 'Submitting...' : 'Submit Request'}
             </button>

--- a/frontend/src/components/onboarding/OnboardingStepper.js
+++ b/frontend/src/components/onboarding/OnboardingStepper.js
@@ -112,7 +112,7 @@ const Step1 = ({ onNext, onBack }) => {
 // ─────────────────────────────────────────────
 const Step2 = ({ onNext, onBack }) => {
   const navigate = useNavigate();
-  const { validationToken, email, password, userId, setUserId, setStepComplete, setEmailLastSentAt } =
+  const { validationToken, email, password, userId, setUserId, setPassword, setStepComplete, setEmailLastSentAt } =
     useOnboardingStore();
   const { setAuth } = useAuthStore();
   const [loading, setLoading] = useState(false);
@@ -148,6 +148,7 @@ const Step2 = ({ onNext, onBack }) => {
       );
       setUserId(response.userId);
       setStepComplete('accountCreated');
+      setPassword(null);
       // Trigger verification email
       try {
         await sendVerificationEmail(response.userId);
@@ -164,6 +165,7 @@ const Step2 = ({ onNext, onBack }) => {
           // Already registered and still authenticated from a previous run — resume the flow
           setUserId(existingAuth.user.userId);
           setStepComplete('accountCreated');
+          setPassword(null);
           if (!existingAuth.user.emailVerified) {
             try {
               await sendVerificationEmail(existingAuth.user.userId);

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,14 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useAuthStore from '../store/authStore';
+import { updateProfile } from '../api/profileService';
 import './ProfilePage.css';
 
 const ProfilePage = () => {
   const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
   const clearAuth = useAuthStore((state) => state.clearAuth);
+  const setUser = useAuthStore((state) => state.setUser);
   const [isEditing, setIsEditing] = useState(false);
   const [editedUser, setEditedUser] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState(null);
 
   useEffect(() => {
     if (user) {
@@ -28,9 +32,33 @@ const ProfilePage = () => {
     });
   };
 
-  const handleSaveChanges = () => {
-    // TODO: Implement API call to save profile changes
+  const handleSaveChanges = async () => {
+    const updates = {};
+    if (editedUser.githubUsername !== user.githubUsername) {
+      updates.githubUsername = editedUser.githubUsername || '';
+    }
+    if (Object.keys(updates).length === 0) {
+      setIsEditing(false);
+      return;
+    }
+    setIsSaving(true);
+    setSaveMessage(null);
+    try {
+      await updateProfile(user.userId, updates);
+      setUser(updates);
+      setSaveMessage({ type: 'success', text: 'Profile updated successfully.' });
+      setIsEditing(false);
+    } catch (err) {
+      setSaveMessage({ type: 'error', text: err.response?.data?.message || 'Failed to save changes.' });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleCancelEdit = () => {
     setIsEditing(false);
+    setEditedUser({ ...user });
+    setSaveMessage(null);
   };
 
   if (!user) {
@@ -95,7 +123,7 @@ const ProfilePage = () => {
           <div className="profile-actions">
             <button
               className="btn btn-secondary"
-              onClick={() => setIsEditing(!isEditing)}
+              onClick={() => isEditing ? handleCancelEdit() : setIsEditing(true)}
             >
               {isEditing ? 'Cancel' : 'Edit Profile'}
             </button>
@@ -104,6 +132,12 @@ const ProfilePage = () => {
             </button>
           </div>
         </div>
+
+        {saveMessage && (
+          <div className={`profile-save-message profile-save-message--${saveMessage.type}`}>
+            {saveMessage.text}
+          </div>
+        )}
 
         <div className="profile-content">
           {/* Primary Information Section */}
@@ -160,9 +194,17 @@ const ProfilePage = () => {
                 )}
 
                 {/* GitHub Username */}
-                {user.githubUsername && (
-                  <div className="info-field">
-                    <label className="info-label">GitHub Username</label>
+                <div className="info-field">
+                  <label className="info-label">GitHub Username</label>
+                  {isEditing ? (
+                    <input
+                      type="text"
+                      className="info-input"
+                      value={editedUser?.githubUsername || ''}
+                      onChange={(e) => handleEditChange('githubUsername', e.target.value)}
+                      placeholder="your-github-username"
+                    />
+                  ) : user.githubUsername ? (
                     <div className="info-value github-username">
                       <a
                         href={`https://github.com/${user.githubUsername}`}
@@ -172,8 +214,10 @@ const ProfilePage = () => {
                         @{user.githubUsername}
                       </a>
                     </div>
-                  </div>
-                )}
+                  ) : (
+                    <div className="info-value">Not linked</div>
+                  )}
+                </div>
               </div>
             </div>
           </div>
@@ -244,12 +288,14 @@ const ProfilePage = () => {
               <button
                 className="btn btn-primary"
                 onClick={handleSaveChanges}
+                disabled={isSaving}
               >
-                Save Changes
+                {isSaving ? 'Saving...' : 'Save Changes'}
               </button>
               <button
                 className="btn btn-secondary"
-                onClick={() => setIsEditing(false)}
+                onClick={handleCancelEdit}
+                disabled={isSaving}
               >
                 Cancel
               </button>

--- a/frontend/src/pages/__tests__/ProfilePage.test.js
+++ b/frontend/src/pages/__tests__/ProfilePage.test.js
@@ -1,21 +1,24 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router-dom';
 import ProfilePage from '../ProfilePage';
 import useAuthStore from '../../store/authStore';
 
-// Mock the useAuthStore hook
 jest.mock('../../store/authStore', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
 
-// Mock useNavigate from react-router-dom
+jest.mock('../../api/profileService');
+
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
 }));
+
+const { updateProfile } = require('../../api/profileService');
 
 describe('ProfilePage Component', () => {
   const mockUser = {
@@ -210,8 +213,8 @@ describe('ProfilePage Component', () => {
     const editButton = screen.getByRole('button', { name: /edit profile/i });
     fireEvent.click(editButton);
 
-    // Should show Cancel button instead of Edit Profile
-    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    // Should show at least one Cancel button (header toggles to Cancel; edit-actions also adds one)
+    expect(screen.getAllByRole('button', { name: /cancel/i }).length).toBeGreaterThanOrEqual(1);
   });
 
   it('shows error message when user is not available', () => {
@@ -243,13 +246,10 @@ describe('ProfilePage Component', () => {
     ];
 
     testCases.forEach(({ role, display }) => {
-      useAuthStore.mockImplementation((selector) => {
-        const store = {
-          user: { ...mockUser, role },
-          clearAuth: jest.fn(),
-        };
-        return selector(store);
-      });
+      const userWithRole = { ...mockUser, role };
+      useAuthStore.mockImplementation((selector) =>
+        selector({ user: userWithRole, clearAuth: jest.fn(), setUser: jest.fn() })
+      );
 
       const { unmount } = render(
         <BrowserRouter>
@@ -270,13 +270,10 @@ describe('ProfilePage Component', () => {
     ];
 
     testCases.forEach(({ status, display }) => {
-      useAuthStore.mockImplementation((selector) => {
-        const store = {
-          user: { ...mockUser, accountStatus: status },
-          clearAuth: jest.fn(),
-        };
-        return selector(store);
-      });
+      const userWithStatus = { ...mockUser, accountStatus: status };
+      useAuthStore.mockImplementation((selector) =>
+        selector({ user: userWithStatus, clearAuth: jest.fn(), setUser: jest.fn() })
+      );
 
       const { unmount } = render(
         <BrowserRouter>
@@ -289,12 +286,13 @@ describe('ProfilePage Component', () => {
     });
   });
 
-  it('handles users without GitHub username', () => {
+  it('shows "Not linked" when user has no GitHub username', () => {
     const userWithoutGithub = { ...mockUser, githubUsername: null };
     useAuthStore.mockImplementation((selector) => {
       const store = {
         user: userWithoutGithub,
         clearAuth: jest.fn(),
+        setUser: jest.fn(),
       };
       return selector(store);
     });
@@ -305,8 +303,9 @@ describe('ProfilePage Component', () => {
       </BrowserRouter>
     );
 
-    // GitHub section should not be visible
-    expect(screen.queryByText(/GitHub Username/)).not.toBeInTheDocument();
+    expect(screen.getByText('GitHub Username')).toBeInTheDocument();
+    expect(screen.getByText('Not linked')).toBeInTheDocument();
+    expect(screen.queryByText(/^@/)).not.toBeInTheDocument();
   });
 
   it('handles users without studentId', () => {
@@ -315,6 +314,7 @@ describe('ProfilePage Component', () => {
       const store = {
         user: userWithoutStudentId,
         clearAuth: jest.fn(),
+        setUser: jest.fn(),
       };
       return selector(store);
     });
@@ -327,5 +327,87 @@ describe('ProfilePage Component', () => {
 
     // Student ID section should not be visible
     expect(screen.queryByText(/Student ID/)).not.toBeInTheDocument();
+  });
+
+  describe('save profile changes', () => {
+    const mockSetUser = jest.fn();
+
+    beforeEach(() => {
+      updateProfile.mockReset();
+      mockSetUser.mockReset();
+      useAuthStore.mockImplementation((selector) =>
+        selector({ user: mockUser, clearAuth: jest.fn(), setUser: mockSetUser })
+      );
+    });
+
+    it('shows GitHub username input when entering edit mode', () => {
+      render(<BrowserRouter><ProfilePage /></BrowserRouter>);
+
+      fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+
+      expect(screen.getByPlaceholderText('your-github-username')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+    });
+
+    it('calls updateProfile with the changed github username and exits edit mode on success', async () => {
+      updateProfile.mockResolvedValue({});
+      render(<BrowserRouter><ProfilePage /></BrowserRouter>);
+
+      fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+      fireEvent.change(screen.getByPlaceholderText('your-github-username'), {
+        target: { value: 'new-handle' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(updateProfile).toHaveBeenCalledWith(mockUser.userId, { githubUsername: 'new-handle' });
+        expect(mockSetUser).toHaveBeenCalledWith({ githubUsername: 'new-handle' });
+        expect(screen.getByText(/Profile updated successfully/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByPlaceholderText('your-github-username')).not.toBeInTheDocument();
+    });
+
+    it('shows error message and stays in edit mode when updateProfile rejects', async () => {
+      updateProfile.mockRejectedValue({
+        response: { data: { message: 'Username already taken' } },
+      });
+      render(<BrowserRouter><ProfilePage /></BrowserRouter>);
+
+      fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+      fireEvent.change(screen.getByPlaceholderText('your-github-username'), {
+        target: { value: 'taken-name' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Username already taken')).toBeInTheDocument();
+      });
+      expect(screen.getByPlaceholderText('your-github-username')).toBeInTheDocument();
+    });
+
+    it('skips the API call and exits edit mode when no fields changed', async () => {
+      render(<BrowserRouter><ProfilePage /></BrowserRouter>);
+
+      fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+      fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText('your-github-username')).not.toBeInTheDocument();
+      });
+      expect(updateProfile).not.toHaveBeenCalled();
+    });
+
+    it('cancel discards edits without calling the API', () => {
+      render(<BrowserRouter><ProfilePage /></BrowserRouter>);
+
+      fireEvent.click(screen.getByRole('button', { name: /edit profile/i }));
+      fireEvent.change(screen.getByPlaceholderText('your-github-username'), {
+        target: { value: 'discard-me' },
+      });
+      fireEvent.click(screen.getAllByRole('button', { name: /cancel/i })[0]);
+
+      expect(updateProfile).not.toHaveBeenCalled();
+      expect(screen.queryByPlaceholderText('your-github-username')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/store/onboardingStore.js
+++ b/frontend/src/store/onboardingStore.js
@@ -78,6 +78,10 @@ const useOnboardingStore = create(
     }),
     {
       name: 'onboarding-storage',
+      partialize: (state) => {
+        const { password, ...persisted } = state;
+        return persisted;
+      },
       storage: {
         getItem: (name) => {
           const item = localStorage.getItem(name);


### PR DESCRIPTION


## Summary

- **Profile save was a stub** — `handleSaveChanges` discarded edits silently. Now calls `PATCH /onboarding/accounts/:userId` via a new `profileService` wrapper, syncs the store with `setUser`, and shows a success/error banner inline.
- **Password leaked to localStorage** — `onboardingStore` was persisting the raw password via Zustand's `persist` middleware. Added `partialize` to exclude it; also clears the in-memory password immediately after successful registration in `OnboardingStepper`.
- **DEV_BYPASS exposed in production** — `AdviseeRequestForm` honoured a `localStorage.getItem('DEV_BYPASS')` flag that bypassed the advisor-window check. Removed entirely; `effectiveOpen` now derives solely from the server response.

## Test plan

- [ ] `ProfilePage.test.js` — 5 new smoke tests: edit mode toggle, successful save (calls API + updates store), API error stays in edit mode, no-op save skips API, cancel discards without calling API
- [ ] `AdviseeRequestForm.test.js` — 3 new `DEV_BYPASS removed` tests: no banner renders, window stays locked regardless of flag, 422 always shows standard closed-window message
- [ ] `OnboardingStore.test.js` — 6 new tests: password absent from localStorage after `setPassword`, value not present in serialised string, non-sensitive fields persist correctly, in-memory set/clear, `reset()` clears password

All 32 tests pass (`npm test -- --watchAll=false`).