### PR TITLE
fix(notifications, webhooks): implement review notification dispatch and webhook execution (#334)

### DIFF
--- a/backend/src/controllers/comments.js
+++ b/backend/src/controllers/comments.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 const Comment = require('../models/Comment');
 const Review = require('../models/Review');
@@ -59,6 +59,20 @@ exports.addComment = async (req, res, next) => {
       status: 'open',
     });
 
+    const commentResponse = {
+      commentId: comment.commentId,
+      deliverableId,
+      authorId: comment.authorId,
+      authorName: comment.authorName,
+      content: comment.content,
+      commentType: comment.commentType,
+      sectionNumber: comment.sectionNumber,
+      needsResponse: comment.needsResponse,
+      status: comment.status,
+      replies: comment.replies,
+      createdAt: comment.createdAt,
+    };
+
     // If this is a clarification_required comment with needsResponse, update Review status
     if (commentType === 'clarification_required' && needsResponse) {
       const review = await Review.findOne({ deliverableId });
@@ -68,6 +82,8 @@ exports.addComment = async (req, res, next) => {
       }
 
       // Dispatch notification
+      let notificationDispatched = false;
+      let notificationError = null;
       try {
         await dispatchClarificationRequiredNotification({
           reviewId: review?.reviewId,
@@ -75,8 +91,14 @@ exports.addComment = async (req, res, next) => {
           commentId: comment.commentId,
           content,
         });
-      } catch (notificationError) {
-        console.error('Notification dispatch error:', notificationError);
+        notificationDispatched = true;
+      } catch (err) {
+        console.error('Notification dispatch error:', err);
+        notificationError = err.message;
+      }
+      commentResponse.notificationDispatched = notificationDispatched;
+      if (notificationError) {
+        commentResponse.notificationError = notificationError;
       }
     }
 
@@ -91,19 +113,7 @@ exports.addComment = async (req, res, next) => {
       },
     });
 
-    res.status(201).json({
-      commentId: comment.commentId,
-      deliverableId,
-      authorId: comment.authorId,
-      authorName: comment.authorName,
-      content: comment.content,
-      commentType: comment.commentType,
-      sectionNumber: comment.sectionNumber,
-      needsResponse: comment.needsResponse,
-      status: comment.status,
-      replies: comment.replies,
-      createdAt: comment.createdAt,
-    });
+    res.status(201).json(commentResponse);
   } catch (error) {
     next(error);
   }
@@ -146,8 +156,8 @@ exports.getComments = async (req, res, next) => {
     const total = await Comment.countDocuments(query);
 
     // Get paginated comments
-    const pageNum = Math.max(1, parseInt(page, 10));
-    const limitNum = Math.max(1, Math.min(100, parseInt(limit, 10)));
+    const pageNum = Math.max(1, Number.parseInt(page, 10));
+    const limitNum = Math.max(1, Math.min(100, Number.parseInt(limit, 10)));
     const skip = (pageNum - 1) * limitNum;
 
     const comments = await Comment.find(query)
@@ -378,3 +388,4 @@ exports.resolveComment = async (req, res, next) => {
     next(error);
   }
 };
+

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -11,6 +11,7 @@ const Group = require('../models/Group');
 const Committee = require('../models/Committee');
 const { getCorrelationId } = require('../middleware/correlationId');
 const { studentBelongsToGroup } = require('../utils/studentGroupMembership');
+const { dispatchReviewAssignmentNotification } = require('../services/notificationService');
 
 const NOTIFICATION_SERVICE_URL = process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000';
 
@@ -659,31 +660,17 @@ const assignReview = async (req, res) => {
     userAgent: req.headers['user-agent'] ?? null,
   }).catch((err) => console.error('[assignReview] audit log error:', err.message));
 
-  // Dispatch notifications (DFD f14: 6.1 → Notification Service)
+  // Dispatch notifications via service (DFD f14: 6.1 → Notification Service)
   // Awaited so callers can see whether dispatch succeeded or failed.
   let notificationDispatched = false;
   let notificationError = null;
   try {
-    await axios.post(
-      `${NOTIFICATION_SERVICE_URL}/api/notifications`,
-      {
-        type: 'review_assignment',
-        reviewId: review.reviewId,
-        deliverableId,
-        groupId: deliverable.groupId,
-        recipients: membersToAssign,
-        instructions: instructions || null,
-        correlationId,
-        externalRequestId,
-      },
-      {
-        timeout: 5000,
-        headers: {
-          'x-correlation-id': correlationId,
-          ...(externalRequestId ? { 'x-external-request-id': externalRequestId } : {}),
-        },
-      }
-    );
+    await dispatchReviewAssignmentNotification({
+      reviewId: review.reviewId,
+      deliverableId,
+      membersToNotify: membersToAssign,
+      instructions,
+    });
     notificationDispatched = true;
   } catch (err) {
     console.error('[assignReview] notification dispatch error:', err.message);
@@ -696,7 +683,6 @@ const assignReview = async (req, res) => {
     assignedCommitteeMembers: memberDetails,
     assignedCount: memberDetails.length,
     deadline: review.deadline.toISOString(),
-    notificationsSent: membersToAssign.length,
     notificationDispatched,
     ...(notificationError ? { notificationError } : {}),
     instructions: review.instructions,

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -659,34 +659,36 @@ const assignReview = async (req, res) => {
     userAgent: req.headers['user-agent'] ?? null,
   }).catch((err) => console.error('[assignReview] audit log error:', err.message));
 
-  // Dispatch notifications async (DFD f14: 6.1 → Notification Service); does not block response
-  const notificationsSent = membersToAssign.length;
-  setImmediate(async () => {
-    try {
-      await axios.post(
-        `${NOTIFICATION_SERVICE_URL}/api/notifications`,
-        {
-          type: 'review_assignment',
-          reviewId: review.reviewId,
-          deliverableId,
-          groupId: deliverable.groupId,
-          recipients: membersToAssign,
-          instructions: instructions || null,
-          correlationId,
-          externalRequestId
+  // Dispatch notifications (DFD f14: 6.1 → Notification Service)
+  // Awaited so callers can see whether dispatch succeeded or failed.
+  let notificationDispatched = false;
+  let notificationError = null;
+  try {
+    await axios.post(
+      `${NOTIFICATION_SERVICE_URL}/api/notifications`,
+      {
+        type: 'review_assignment',
+        reviewId: review.reviewId,
+        deliverableId,
+        groupId: deliverable.groupId,
+        recipients: membersToAssign,
+        instructions: instructions || null,
+        correlationId,
+        externalRequestId,
+      },
+      {
+        timeout: 5000,
+        headers: {
+          'x-correlation-id': correlationId,
+          ...(externalRequestId ? { 'x-external-request-id': externalRequestId } : {}),
         },
-        {
-          timeout: 5000,
-          headers: {
-            'x-correlation-id': correlationId,
-            ...(externalRequestId ? { 'x-external-request-id': externalRequestId } : {})
-          }
-        }
-      );
-    } catch (err) {
-      console.error('[assignReview] notification dispatch error:', err.message);
-    }
-  });
+      }
+    );
+    notificationDispatched = true;
+  } catch (err) {
+    console.error('[assignReview] notification dispatch error:', err.message);
+    notificationError = err.message;
+  }
 
   return res.status(201).json({
     deliverableId,
@@ -694,7 +696,9 @@ const assignReview = async (req, res) => {
     assignedCommitteeMembers: memberDetails,
     assignedCount: memberDetails.length,
     deadline: review.deadline.toISOString(),
-    notificationsSent,
+    notificationsSent: membersToAssign.length,
+    notificationDispatched,
+    ...(notificationError ? { notificationError } : {}),
     instructions: review.instructions,
   });
 };

--- a/backend/src/controllers/reviews.js
+++ b/backend/src/controllers/reviews.js
@@ -1,4 +1,4 @@
-'use strict';
+﻿'use strict';
 
 const Review = require('../models/Review');
 const Deliverable = require('../models/Deliverable');
@@ -109,6 +109,8 @@ exports.assignReview = async (req, res, next) => {
     });
 
     // Dispatch notifications
+    let notificationDispatched = false;
+    let notificationError = null;
     try {
       await dispatchReviewAssignmentNotification({
         reviewId: review.reviewId,
@@ -116,9 +118,10 @@ exports.assignReview = async (req, res, next) => {
         membersToNotify: assignedMembers.map((m) => m.memberId),
         instructions,
       });
-    } catch (notificationError) {
-      console.error('Notification dispatch error:', notificationError);
-      // Don't fail the request if notification fails
+      notificationDispatched = true;
+    } catch (err) {
+      console.error('Notification dispatch error:', err);
+      notificationError = err.message;
     }
 
     res.status(201).json({
@@ -129,6 +132,8 @@ exports.assignReview = async (req, res, next) => {
       assignedMembers: review.assignedMembers,
       deadline: review.deadline,
       instructions: review.instructions,
+      notificationDispatched,
+      ...(notificationError ? { notificationError } : {}),
     });
   } catch (error) {
     next(error);
@@ -137,7 +142,7 @@ exports.assignReview = async (req, res, next) => {
 
 /**
  * GET /api/v1/reviews/status
- * Process 6.3 — Coordinator dashboard: live overview of all reviews.
+ * Process 6.3 â€” Coordinator dashboard: live overview of all reviews.
  * Query params: status (pending|in_progress|needs_clarification|completed), page (default 1)
  */
 exports.getReviewStatus = async (req, res, next) => {
@@ -152,7 +157,7 @@ exports.getReviewStatus = async (req, res, next) => {
       });
     }
 
-    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const pageNum = Math.max(1, Number.parseInt(page, 10) || 1);
     const PAGE_SIZE = 20;
     const skip = (pageNum - 1) * PAGE_SIZE;
     const filter = status ? { status } : {};
@@ -219,3 +224,4 @@ exports.getReviewStatus = async (req, res, next) => {
     next(error);
   }
 };
+

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -294,22 +294,31 @@ const dispatchReviewAssignmentNotification = async ({
   membersToNotify,
   instructions,
 }) => {
-  try {
-    // TODO: Implement actual notification logic
-    // For now, just return success
-    return {
-      success: true,
-      notificationId: `notif_review_${Date.now()}`,
-    };
-  } catch (error) {
-    logError('Error dispatching review assignment notification', {
-      service_name: 'notification_dispatch',
-      correlationId: null,
-      externalRequestId: null,
-      error: error.message
-    });
-    throw error;
-  }
+  const response = await axios.post(
+    `${NOTIFICATION_SERVICE_URL}/api/notifications`,
+    {
+      type: 'review_assignment',
+      reviewId,
+      deliverableId,
+      recipients: membersToNotify,
+      instructions: instructions || null,
+    },
+    { timeout: 5000 }
+  );
+
+  logInfo('Review assignment notification dispatched', {
+    service_name: 'notification_dispatch',
+    correlationId: null,
+    externalRequestId: null,
+    reviewId,
+    deliverableId,
+    recipientCount: membersToNotify?.length ?? 0,
+  });
+
+  return {
+    success: true,
+    notificationId: response.data?.notification_id || response.data?.notificationId || `notif_review_${Date.now()}`,
+  };
 };
 
 /**
@@ -321,22 +330,31 @@ const dispatchClarificationRequiredNotification = async ({
   commentId,
   content,
 }) => {
-  try {
-    // TODO: Implement actual notification logic
-    // For now, just return success
-    return {
-      success: true,
-      notificationId: `notif_clarif_${Date.now()}`,
-    };
-  } catch (error) {
-    logError('Error dispatching clarification notification', {
-      service_name: 'notification_dispatch',
-      correlationId: null,
-      externalRequestId: null,
-      error: error.message
-    });
-    throw error;
-  }
+  const response = await axios.post(
+    `${NOTIFICATION_SERVICE_URL}/api/notifications`,
+    {
+      type: 'clarification_required',
+      reviewId,
+      deliverableId,
+      commentId,
+      content,
+    },
+    { timeout: 5000 }
+  );
+
+  logInfo('Clarification required notification dispatched', {
+    service_name: 'notification_dispatch',
+    correlationId: null,
+    externalRequestId: null,
+    reviewId,
+    deliverableId,
+    commentId,
+  });
+
+  return {
+    success: true,
+    notificationId: response.data?.notification_id || response.data?.notificationId || `notif_clarif_${Date.now()}`,
+  };
 };
 
 /**

--- a/backend/src/services/webhookDeliveryService.js
+++ b/backend/src/services/webhookDeliveryService.js
@@ -23,6 +23,7 @@
  * ================================================================================
  */
 
+const axios = require('axios');
 const { WebhookDelivery, WEBHOOK_STATUS } = require('../models/WebhookDelivery');
 const { WebhookSignature } = require('../models/WebhookSignature');
 const AuditLog = require('../models/AuditLog');
@@ -421,27 +422,91 @@ async function executeWebhook(webhook, ctx) {
 }
 
 /**
- * ISSUE #241: Execute JIRA webhook (stub)
- * To be implemented with actual JIRA API calls
+ * ISSUE #241: Execute JIRA webhook
+ * POSTs payload to JIRA_WEBHOOK_URL. Requires JIRA_WEBHOOK_URL env var.
  */
 async function executeJiraWebhook(webhook, ctx) {
-  throw new Error('JIRA webhook execution not yet implemented');
+  const url = process.env.JIRA_WEBHOOK_URL;
+  if (!url) {
+    const err = new Error('JIRA_WEBHOOK_URL is not configured');
+    err.code = 'CONFIG_MISSING';
+    throw err;
+  }
+  try {
+    const response = await axios.post(url, webhook.payload, {
+      timeout: RETRY_CONFIG.REQUEST_TIMEOUT_MS,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(webhook.correlationId ? { 'x-correlation-id': webhook.correlationId } : {}),
+      },
+    });
+    return { statusCode: response.status, headers: response.headers, body: response.data };
+  } catch (err) {
+    if (err.response) {
+      const httpErr = new Error(`JIRA webhook failed: HTTP ${err.response.status}`);
+      httpErr.statusCode = err.response.status;
+      httpErr.code = err.code || null;
+      throw httpErr;
+    }
+    throw err;
+  }
 }
 
 /**
- * ISSUE #241: Execute GitHub webhook (stub)
- * To be implemented with actual GitHub API calls
+ * ISSUE #241: Execute GitHub webhook
+ * POSTs payload to GITHUB_WEBHOOK_URL. Requires GITHUB_WEBHOOK_URL env var.
  */
 async function executeGithubWebhook(webhook, ctx) {
-  throw new Error('GitHub webhook execution not yet implemented');
+  const url = process.env.GITHUB_WEBHOOK_URL;
+  if (!url) {
+    const err = new Error('GITHUB_WEBHOOK_URL is not configured');
+    err.code = 'CONFIG_MISSING';
+    throw err;
+  }
+  try {
+    const response = await axios.post(url, webhook.payload, {
+      timeout: RETRY_CONFIG.REQUEST_TIMEOUT_MS,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(webhook.correlationId ? { 'x-correlation-id': webhook.correlationId } : {}),
+      },
+    });
+    return { statusCode: response.status, headers: response.headers, body: response.data };
+  } catch (err) {
+    if (err.response) {
+      const httpErr = new Error(`GitHub webhook failed: HTTP ${err.response.status}`);
+      httpErr.statusCode = err.response.status;
+      httpErr.code = err.code || null;
+      throw httpErr;
+    }
+    throw err;
+  }
 }
 
 /**
- * ISSUE #241: Execute Notification webhook (stub)
- * To be implemented with actual notification dispatch
+ * ISSUE #241: Execute Notification webhook
+ * POSTs payload to the notification service.
  */
 async function executeNotificationWebhook(webhook, ctx) {
-  throw new Error('Notification webhook execution not yet implemented');
+  const url = `${process.env.NOTIFICATION_SERVICE_URL || 'http://localhost:4000'}/api/notifications`;
+  try {
+    const response = await axios.post(url, webhook.payload, {
+      timeout: RETRY_CONFIG.REQUEST_TIMEOUT_MS,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(webhook.correlationId ? { 'x-correlation-id': webhook.correlationId } : {}),
+      },
+    });
+    return { statusCode: response.status, headers: response.headers, body: response.data };
+  } catch (err) {
+    if (err.response) {
+      const httpErr = new Error(`Notification webhook failed: HTTP ${err.response.status}`);
+      httpErr.statusCode = err.response.status;
+      httpErr.code = err.code || null;
+      throw httpErr;
+    }
+    throw err;
+  }
 }
 
 /**

--- a/backend/tests/review-assign.smoke.test.js
+++ b/backend/tests/review-assign.smoke.test.js
@@ -1,5 +1,5 @@
-/**
- * Smoke tests — Process 6.1: POST /api/v1/reviews/assign
+﻿/**
+ * Smoke tests â€” Process 6.1: POST /api/v1/reviews/assign
  *
  * Coverage:
  *   Auth guards
@@ -25,12 +25,12 @@
  *     400  selectedCommitteeMembers contains invalid member IDs
  *
  *   Happy path (201)
- *     201  correct response shape: deliverableId, reviewId, assignedCommitteeMembers, assignedCount, deadline, notificationsSent, instructions
+ *     201  correct response shape: deliverableId, reviewId, assignedCommitteeMembers, assignedCount, deadline, notificationDispatched, instructions
  *     201  assignedCommitteeMembers contains memberId, name, email, status: 'notified'
  *     201  deadline is approximately now + reviewDeadlineDays
  *     201  Review document created in DB with correct fields
  *     201  Deliverable status updated to 'under_review'
- *     201  selectedCommitteeMembers omitted → all committee members assigned automatically
+ *     201  selectedCommitteeMembers omitted â†’ all committee members assigned automatically
  *     201  instructions persisted when provided; null when omitted
  *     201  AuditLog record created with action REVIEW_ASSIGNED
  *
@@ -164,13 +164,13 @@ afterEach(async () => {
 // Auth guards
 // ===========================================================================
 describe('auth guards', () => {
-  it('401 — no Authorization header', async () => {
+  it('401 â€” no Authorization header', async () => {
     const res = await request(app).post(ENDPOINT).send({});
     expect(res.status).toBe(401);
     expect(res.body.code).toBe('UNAUTHORIZED');
   });
 
-  it('401 — malformed JWT', async () => {
+  it('401 â€” malformed JWT', async () => {
     const res = await request(app)
       .post(ENDPOINT)
       .set('Authorization', 'Bearer not.a.real.token')
@@ -179,7 +179,7 @@ describe('auth guards', () => {
     expect(res.body.code).toBe('INVALID_TOKEN');
   });
 
-  it('403 — student cannot assign review', async () => {
+  it('403 â€” student cannot assign review', async () => {
     const res = await request(app)
       .post(ENDPOINT)
       .set('Authorization', `Bearer ${token(unique('stu'), 'student')}`)
@@ -187,7 +187,7 @@ describe('auth guards', () => {
     expect(res.status).toBe(403);
   });
 
-  it('403 — committee_member cannot assign review', async () => {
+  it('403 â€” committee_member cannot assign review', async () => {
     const res = await request(app)
       .post(ENDPOINT)
       .set('Authorization', `Bearer ${token(unique('cm'), 'committee_member')}`)
@@ -195,7 +195,7 @@ describe('auth guards', () => {
     expect(res.status).toBe(403);
   });
 
-  it('403 — professor cannot assign review', async () => {
+  it('403 â€” professor cannot assign review', async () => {
     const res = await request(app)
       .post(ENDPOINT)
       .set('Authorization', `Bearer ${token(unique('prof'), 'professor')}`)
@@ -208,7 +208,7 @@ describe('auth guards', () => {
 // Body validation
 // ===========================================================================
 describe('body validation', () => {
-  it('400 — missing deliverableId', async () => {
+  it('400 â€” missing deliverableId', async () => {
     const { token: t } = coordToken();
     const res = await request(app)
       .post(ENDPOINT)
@@ -219,7 +219,7 @@ describe('body validation', () => {
     expect(res.body.message).toMatch(/deliverableId/i);
   });
 
-  it('400 — missing reviewDeadlineDays', async () => {
+  it('400 â€” missing reviewDeadlineDays', async () => {
     const { token: t } = coordToken();
     const res = await request(app)
       .post(ENDPOINT)
@@ -230,7 +230,7 @@ describe('body validation', () => {
     expect(res.body.message).toMatch(/reviewDeadlineDays/i);
   });
 
-  it('400 — reviewDeadlineDays = 0 (minimum is 1)', async () => {
+  it('400 â€” reviewDeadlineDays = 0 (minimum is 1)', async () => {
     const { token: t } = coordToken();
     const res = await request(app)
       .post(ENDPOINT)
@@ -240,7 +240,7 @@ describe('body validation', () => {
     expect(res.body.code).toBe('INVALID_REQUEST');
   });
 
-  it('400 — reviewDeadlineDays = 31 (maximum is 30)', async () => {
+  it('400 â€” reviewDeadlineDays = 31 (maximum is 30)', async () => {
     const { token: t } = coordToken();
     const res = await request(app)
       .post(ENDPOINT)
@@ -250,7 +250,7 @@ describe('body validation', () => {
     expect(res.body.code).toBe('INVALID_REQUEST');
   });
 
-  it('400 — reviewDeadlineDays is a float (not an integer)', async () => {
+  it('400 â€” reviewDeadlineDays is a float (not an integer)', async () => {
     const { token: t } = coordToken();
     const res = await request(app)
       .post(ENDPOINT)
@@ -265,7 +265,7 @@ describe('body validation', () => {
 // Resource checks
 // ===========================================================================
 describe('resource checks', () => {
-  it('404 — deliverable not found', async () => {
+  it('404 â€” deliverable not found', async () => {
     const { token: t } = coordToken();
     const res = await request(app)
       .post(ENDPOINT)
@@ -275,7 +275,7 @@ describe('resource checks', () => {
     expect(res.body.code).toBe('DELIVERABLE_NOT_FOUND');
   });
 
-  it('409 — review already exists for this deliverable', async () => {
+  it('409 â€” review already exists for this deliverable', async () => {
     const { committee, memberIds } = await seedCommittee(2);
     const { deliverableId, groupId } = await seedDeliverable(committee.committeeId);
     const { token: t } = coordToken();
@@ -296,7 +296,7 @@ describe('resource checks', () => {
     expect(res.body.code).toBe('REVIEW_ALREADY_EXISTS');
   });
 
-  it('400 — deliverable status is not accepted (under_review)', async () => {
+  it('400 â€” deliverable status is not accepted (under_review)', async () => {
     const { committee, memberIds } = await seedCommittee(1);
     const { deliverableId } = await seedDeliverable(committee.committeeId, 'under_review');
     const { token: t } = coordToken();
@@ -311,7 +311,7 @@ describe('resource checks', () => {
     expect(res.body.message).toMatch(/accepted/i);
   });
 
-  it('400 — deliverable status is awaiting_resubmission', async () => {
+  it('400 â€” deliverable status is awaiting_resubmission', async () => {
     const { committee, memberIds } = await seedCommittee(1);
     const { deliverableId } = await seedDeliverable(committee.committeeId, 'awaiting_resubmission');
     const { token: t } = coordToken();
@@ -330,7 +330,7 @@ describe('resource checks', () => {
 // Member validation
 // ===========================================================================
 describe('member validation', () => {
-  it('400 — selectedCommitteeMembers contains IDs not in committee', async () => {
+  it('400 â€” selectedCommitteeMembers contains IDs not in committee', async () => {
     const { committee, memberIds } = await seedCommittee(2);
     const { deliverableId } = await seedDeliverable(committee.committeeId);
     const { token: t } = coordToken();
@@ -351,7 +351,7 @@ describe('member validation', () => {
     expect(res.body.invalidMemberIds).not.toContain(memberIds[0]);
   });
 
-  it('400 — all selected member IDs are invalid', async () => {
+  it('400 â€” all selected member IDs are invalid', async () => {
     const { committee } = await seedCommittee(1);
     const { deliverableId } = await seedDeliverable(committee.committeeId);
     const { token: t } = coordToken();
@@ -374,7 +374,7 @@ describe('member validation', () => {
 // ===========================================================================
 // Happy path
 // ===========================================================================
-describe('happy path — 201', () => {
+describe('happy path â€” 201', () => {
   it('returns correct top-level response shape', async () => {
     const { committee, memberIds } = await seedCommittee(3);
     const { deliverableId } = await seedDeliverable(committee.committeeId);
@@ -398,7 +398,7 @@ describe('happy path — 201', () => {
     expect(res.body.assignedCount).toBe(selected.length);
     expect(typeof res.body.deadline).toBe('string');
     expect(new Date(res.body.deadline).toString()).not.toBe('Invalid Date');
-    expect(res.body.notificationsSent).toBe(selected.length);
+    expect(typeof res.body.notificationDispatched).toBe('boolean');
     expect(res.body.instructions).toBe('Focus on architecture section.');
   });
 
@@ -550,7 +550,7 @@ describe('happy path — 201', () => {
     expect(audit.payload.assignedMemberCount).toBe(memberIds.length);
   });
 
-  it('notificationsSent equals the number of assigned members', async () => {
+  it('notificationDispatched is a boolean in the response', async () => {
     const { committee, memberIds } = await seedCommittee(3);
     const { deliverableId } = await seedDeliverable(committee.committeeId);
     const { token: t } = coordToken();
@@ -562,6 +562,7 @@ describe('happy path — 201', () => {
       .send({ deliverableId, reviewDeadlineDays: 7, selectedCommitteeMembers: selected });
 
     expect(res.status).toBe(201);
-    expect(res.body.notificationsSent).toBe(selected.length);
+    expect(typeof res.body.notificationDispatched).toBe('boolean');
   });
 });
+

--- a/backend/tests/review-notifications.test.js
+++ b/backend/tests/review-notifications.test.js
@@ -55,6 +55,13 @@ beforeEach(async () => {
     await collections[key].deleteMany({});
   }
   jest.clearAllMocks();
+  // dispatchReviewAssignmentNotification and dispatchClarificationRequiredNotification
+  // now make real axios calls — provide a default resolved value so unit tests don't crash.
+  // Use a counter so successive calls within one test get distinct notification IDs.
+  let callCount = 0;
+  axios.post.mockImplementation(() =>
+    Promise.resolve({ data: { notification_id: `notif_test_mock_${++callCount}` } })
+  );
 });
 
 describe('NotificationService - Dispatch Functions', () => {


### PR DESCRIPTION
Replace no-op notification stubs and placeholder webhook executors with real implementations so review assignment and clarification-required notifications are actually sent, and webhook delivery has a live execution path.

- notificationService: replace TODO stubs in dispatchReviewAssignment- Notification and dispatchClarificationRequiredNotification with real axios.post calls matching the pattern used by all other dispatch functions in the module; guard membersToNotify?.length against undefined callers
- webhookDeliveryService: add axios import; implement all three executor stubs (executeNotificationWebhook, executeJiraWebhook, executeGithubWebhook) with real HTTP POSTs; normalize axios HTTP errors to carry statusCode so the existing isTransientError/retry logic works correctly; JIRA and GitHub handlers fail fast with CONFIG_MISSING (non-retryable) when env vars are absent
- reviewController: replace fire-and-forget setImmediate dispatch with an awaited call so the outcome is known before the response is sent; expose notificationDispatched (bool) and notificationError (string) in the 201 body so callers can see failures instead of always receiving notificationsSent: N
- comments: track dispatch outcome and include notificationDispatched / notificationError in the addComment 201 response
- tests: add default axios.post.mockImplementation in the global beforeEach of review-notifications.test.js so the now-real dispatch functions don't crash on an unmocked axios; use a per-test call counter to produce distinct notification IDs across multiple calls