### PR TITLE
fix(dashboard, review): surface invitation errors, fix back navigation context

### DIFF
--- a/frontend/src/components/GroupDashboard.js
+++ b/frontend/src/components/GroupDashboard.js
@@ -31,6 +31,7 @@ const GroupDashboard = () => {
   const [decisionLoading, setDecisionLoading] = useState(false);
   const [decisionMsg, setDecisionMsg] = useState('');
   
+  const [invitationError, setInvitationError] = useState('');
   const [releaseModalOpen, setReleaseModalOpen] = useState(false);
   const [releaseReason, setReleaseReason] = useState('');
   const [releaseLoading, setReleaseLoading] = useState(false);
@@ -69,7 +70,12 @@ const GroupDashboard = () => {
       if (inv && inv.group_id === groupId) {
         setInvitationInfo(inv);
       }
-    }).catch(() => { });
+    }).catch((err) => {
+      const status = err?.response?.status;
+      if (status !== 401 && status !== 403) {
+        setInvitationError('Could not load your pending invitation. Please refresh the page.');
+      }
+    });
   }, [groupId, user]);
 
   const handleDecision = async (decision) => {
@@ -168,6 +174,13 @@ const GroupDashboard = () => {
           )}
         </div>
       </div>
+
+      {invitationError && (
+        <div className="error-container" role="alert">
+          <p className="error-title">Invitation Unavailable</p>
+          <p className="error-message">{invitationError}</p>
+        </div>
+      )}
 
       {invitationInfo && (
         <div className="invitation-banner">

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { getDeliverableDetails, getComments, downloadDeliverable } from '../api/reviewAPI';
 import CommentThread from '../components/reviews/CommentThread';
 import AddCommentForm from '../components/reviews/AddCommentForm';
@@ -13,6 +13,7 @@ import './ReviewPage.css';
  */
 const ReviewPage = () => {
   const { deliverableId } = useParams();
+  const navigate = useNavigate();
   const user = useAuthStore((state) => state.user);
 
   // State management
@@ -153,12 +154,12 @@ const ReviewPage = () => {
           <div className="bg-red-50 border border-red-200 rounded-lg p-6">
             <h2 className="text-lg font-semibold text-red-900 mb-2">Error Loading Deliverable</h2>
             <p className="text-red-800 mb-4">{error}</p>
-            <a
-              href="/dashboard"
-              className="inline-block px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700"
+            <button
+              onClick={() => navigate(-1)}
+              className="inline-block px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 cursor-pointer"
             >
-              ← Back to Dashboard
-            </a>
+              ← Back
+            </button>
           </div>
         </div>
       </div>
@@ -172,12 +173,12 @@ const ReviewPage = () => {
         <div className="max-w-4xl mx-auto p-8">
           <div className="bg-gray-50 border border-gray-200 rounded-lg p-6 text-center">
             <p className="text-gray-600">Deliverable not found</p>
-            <a
-              href="/dashboard"
-              className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+            <button
+              onClick={() => navigate(-1)}
+              className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 cursor-pointer"
             >
-              ← Back to Dashboard
-            </a>
+              ← Back
+            </button>
           </div>
         </div>
       </div>
@@ -189,9 +190,9 @@ const ReviewPage = () => {
       <div className="max-w-7xl mx-auto">
         {/* Page header */}
         <div className="mb-8">
-          <a href="/dashboard" className="text-blue-600 hover:text-blue-800 text-sm font-medium mb-4 inline-block">
-            ← Back to Dashboard
-          </a>
+          <button onClick={() => navigate(-1)} className="text-blue-600 hover:text-blue-800 text-sm font-medium mb-4 inline-block cursor-pointer bg-transparent border-none p-0">
+            ← Back
+          </button>
           <h1 className="text-3xl font-bold text-gray-900">
             Deliverable Review
           </h1>


### PR DESCRIPTION
## Summary

- **Invitation fetch failures now visible**: `GroupDashboard` was swallowing
  all non-404 errors from `getMyPendingInvitation` with an empty catch. Now
  surfaces a visible error banner ("Invitation Unavailable") for unexpected
  failures while still silently ignoring expected 401/403 auth cases.
- **Context-aware back navigation in ReviewPage**: All three "Back to Dashboard"
  links were hardcoded `<a href="/dashboard">`. Replaced with `useNavigate` +
  `navigate(-1)` so users return to their actual previous route (e.g. a
  coordinator review list) instead of always landing on `/dashboard`.
- **Release advisor confirmation**: Already gated behind the existing modal —
  no changes needed.

## Test plan

- [x] Existing `GroupDashboard.test.js` (24 tests) — all pass
- [x] Existing `ReviewPage.test.js` (16 tests) — all pass