### PR TITLE
fix(auth): require strong JWT/service secrets and add login rate limit

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,9 +13,9 @@ DB_NAME=senior-app
 # In production load this from Vault / Secrets Manager and inject as env var.
 ENCRYPTION_KEY=replace_with_64_hex_characters
 
-# JWT Configuration
-JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
-JWT_REFRESH_SECRET=your-super-secret-refresh-key-change-this-in-production
+# JWT Configuration — both values are REQUIRED. Generate with: openssl rand -hex 64
+JWT_SECRET=replace_with_strong_random_secret
+JWT_REFRESH_SECRET=replace_with_different_strong_random_secret
 JWT_EXPIRATION=1h
 JWT_REFRESH_EXPIRATION=7d
 
@@ -23,6 +23,10 @@ JWT_REFRESH_EXPIRATION=7d
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 GITHUB_REDIRECT_URI=http://localhost:5002/api/v1/auth/github/oauth/callback
+
+# System/M2M service token for cron jobs and internal services — REQUIRED when using system auth
+# Generate with: openssl rand -hex 32
+SYSTEM_SERVICE_TOKEN=replace_with_strong_random_token
 
 # Frontend Configuration
 FRONTEND_URL=http://localhost:3000

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.4.1",
         "express-validator": "^7.0.0",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^7.8.9",
@@ -2551,6 +2552,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express-validator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.4.1",
     "express-validator": "^7.0.0",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^7.8.9",

--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -175,7 +175,7 @@ const registerStudent = async (req, res) => {
     // Verify and decode validation token
     let tokenPayload;
     try {
-      tokenPayload = jwt.verify(validationToken, process.env.JWT_SECRET || 'your-secret-key');
+      tokenPayload = jwt.verify(validationToken, process.env.JWT_SECRET);
     } catch (error) {
       return res.status(401).json({
         code: 'INVALID_TOKEN',

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -187,9 +187,9 @@ const systemTokenMiddleware = (req, res, next) => {
   // Issue #67 Fix #4: Check for system/M2M authentication (service token)
   // Read X-Service-Auth header and compare with environment variable
   const serviceAuth = req.headers['x-service-auth'];
-  const expectedToken = process.env.SYSTEM_SERVICE_TOKEN || 'system';
+  const expectedToken = process.env.SYSTEM_SERVICE_TOKEN;
 
-  if (serviceAuth === expectedToken) {
+  if (expectedToken && serviceAuth === expectedToken) {
     // Issue #67 Fix #4: Service token matched - create synthetic user object
     // This allows service/scheduler calls to proceed with system identity
     req.isSystemCall = true; // Mark as system-initiated call
@@ -217,10 +217,10 @@ const systemTokenMiddleware = (req, res, next) => {
  * Allows: (1) SYSTEM_SERVICE_TOKEN via X-Service-Auth, or (2) valid JWT with coordinator/admin.
  */
 const flexibleSystemOrRoleAuth = (req, res, next) => {
-  const expectedToken = process.env.SYSTEM_SERVICE_TOKEN || 'system';
+  const expectedToken = process.env.SYSTEM_SERVICE_TOKEN;
   const serviceAuth = req.headers['x-service-auth'];
 
-  if (serviceAuth === expectedToken) {
+  if (expectedToken && serviceAuth === expectedToken) {
     req.isSystemCall = true;
     req.user = {
       userId: 'system',

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,6 +1,21 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const { authMiddleware, roleMiddleware } = require('../middleware/auth');
+
+const loginRateLimit = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  handler: (req, res) => {
+    res.status(429).json({
+      code: 'RATE_LIMITED',
+      message: 'Too many login attempts from this IP. Please try again in 15 minutes.',
+    });
+  },
+});
+
 const {
   loginWithPassword,
   registerStudent,
@@ -21,7 +36,7 @@ const {
 } = require('../controllers/auth');
 
 // Public routes
-router.post('/login', loginWithPassword);
+router.post('/login', loginRateLimit, loginWithPassword);
 router.post('/register', registerStudent);
 router.post('/refresh', refreshAccessToken);
 router.get('/github/oauth/callback', githubOAuthCallback);

--- a/backend/src/utils/jwt.js
+++ b/backend/src/utils/jwt.js
@@ -1,10 +1,16 @@
 const jwt = require('jsonwebtoken');
 const { v4: uuidv4 } = require('uuid');
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
-const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'your-refresh-secret';
+const JWT_SECRET = process.env.JWT_SECRET;
+const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET;
 const JWT_EXPIRATION = process.env.JWT_EXPIRATION || '1h';
 const JWT_REFRESH_EXPIRATION = process.env.JWT_REFRESH_EXPIRATION || '7d';
+
+if (!JWT_SECRET || !JWT_REFRESH_SECRET) {
+  throw new Error(
+    'JWT_SECRET and JWT_REFRESH_SECRET environment variables are required. Set them in your .env file before starting the server.'
+  );
+}
 
 /**
  * Generate JWT access token

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -12,6 +12,9 @@
  * Run: npm test
  */
 
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'auth-test-jwt-secret';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'auth-test-jwt-refresh-secret';
+
 const crypto = require('crypto');
 
 describe('Password Reset Flow (integration)', () => {
@@ -588,7 +591,7 @@ describe('Auth Middleware', () => {
   });
 
   it('returns 401 for an expired token', () => {
-    const secret = process.env.JWT_SECRET || 'your-secret-key';
+    const secret = process.env.JWT_SECRET;
     const expiredToken = jwt.sign(
       { userId, role, type: 'access' },
       secret,

--- a/backend/tests/jwt-protected-routes-ratelimit.test.js
+++ b/backend/tests/jwt-protected-routes-ratelimit.test.js
@@ -23,6 +23,9 @@
  * Run: npm test -- jwt-protected-routes-ratelimit.test.js
  */
 
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'ratelimit-test-jwt-secret';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'ratelimit-test-jwt-refresh-secret';
+
 const mongoose = require('mongoose');
 const User = require('../src/models/User');
 const RefreshToken = require('../src/models/RefreshToken');
@@ -156,7 +159,7 @@ describe('JWT Protected Endpoints & Rate Limiting (Unit Tests)', () => {
     it('401 INVALID_TOKEN with expired token', () => {
       const expiredToken = jwt.sign(
         { userId: studentUser.userId, role: 'student', type: 'access' },
-        process.env.JWT_SECRET || 'your-secret-key',
+        process.env.JWT_SECRET,
         {
           expiresIn: '-1h',
           issuer: 'senior-app',

--- a/backend/tests/jwt-session-security.test.js
+++ b/backend/tests/jwt-session-security.test.js
@@ -18,6 +18,9 @@
  * Run: npm test -- jwt-session-security.test.js
  */
 
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'jwt-session-test-jwt-secret';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'jwt-session-test-jwt-refresh-secret';
+
 const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 
@@ -32,8 +35,8 @@ describe('JWT Generation & Token Management (Unit Tests)', () => {
   let verifyRefreshToken;
   let decodeToken;
 
-  const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
-  const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'your-refresh-secret';
+  const JWT_SECRET = process.env.JWT_SECRET;
+  const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET;
 
   beforeAll(async () => {
     ({
@@ -519,7 +522,7 @@ describe('Authentication Flow & Protected Routes (Integration Tests)', () => {
     it('returns 401 for expired token', async () => {
       const expiredToken = jwt.sign(
         { userId: 'user123', role: 'student', type: 'access' },
-        process.env.JWT_SECRET || 'your-secret-key',
+        process.env.JWT_SECRET,
         {
           expiresIn: '-1h', // Already expired
           issuer: 'senior-app',

--- a/backend/tests/registration-flow.test.js
+++ b/backend/tests/registration-flow.test.js
@@ -14,6 +14,9 @@
  * Run: npm test -- registration-flow.test.js
  */
 
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'registration-flow-test-jwt-secret';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'registration-flow-test-jwt-refresh-secret';
+
 const mongoose = require('mongoose');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');

--- a/backend/tests/security-validation.test.js
+++ b/backend/tests/security-validation.test.js
@@ -15,6 +15,9 @@
  * Run: npm test -- security-validation.test.js
  */
 
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'security-validation-test-jwt-secret';
+process.env.JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || 'security-validation-test-jwt-refresh-secret';
+
 // Mock email service before imports
 jest.mock('../src/services/emailService', () => ({
   sendPasswordResetEmail: jest.fn().mockResolvedValue({ messageId: 'mock-id', status: 'sent' }),


### PR DESCRIPTION
- Remove 'your-secret-key' and 'your-refresh-secret' fallbacks from jwt.js; throw at startup if JWT_SECRET or JWT_REFRESH_SECRET is unset
- Remove same fallback from controllers/auth.js (registerStudent)
- Remove 'system' default from systemTokenMiddleware and flexibleSystemOrRoleAuth; guard with `expectedToken &&` to prevent undefined === undefined matching when SYSTEM_SERVICE_TOKEN is unset
- Add express-rate-limit to POST /login (30 req / 15 min per IP), returning 429 RATE_LIMITED on breach, layered on top of existing per-account lockout
- Update .env.example: mark JWT secrets as required, add SYSTEM_SERVICE_TOKEN entry with generation instructions
- Set JWT_SECRET/JWT_REFRESH_SECRET in test files that required jwt utilities without going through dotenv (auth, security-validation, jwt-protected-routes-ratelimit, jwt-session-security, registration-flow)