### PR TITLE
bugs fixed in advisor panel

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -151,7 +151,7 @@ function App() {
             />
             <Route
               path="/groups/:group_id/advisor"
-              element={<ProtectedRoute component={AdvisorAssociationPanel} requiredRoles={['student']} />}
+              element={<ProtectedRoute component={AdvisorAssociationPanel} requiredRoles={['student', 'coordinator', 'admin']} />}
             />
             <Route
               path="/groups/:group_id/coordinator"

--- a/frontend/src/components/AdviseeRequestForm.css
+++ b/frontend/src/components/AdviseeRequestForm.css
@@ -1,20 +1,17 @@
 .advisee-request-page {
-  min-height: 100vh;
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 40px 20px;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 32px 24px;
+  max-width: 660px;
+  margin: 0 auto;
   color: #333;
 }
 
 .form-container {
   width: 100%;
-  max-width: 600px;
   background: #ffffff;
   border-radius: 12px;
   padding: 40px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 2px 12px rgba(102, 126, 234, 0.1);
+  border: 1px solid #e5e7eb;
   animation: slideUp 0.6s cubic-bezier(0.16, 1, 0.3, 1);
 }
 

--- a/frontend/src/components/AdvisorAssociationPanel.css
+++ b/frontend/src/components/AdvisorAssociationPanel.css
@@ -94,6 +94,12 @@ body:has(.advisor-association-container) {
   color: #166534;
 }
 
+.alert-warning {
+  background-color: #fef9c3;
+  border: 1px solid #fde68a;
+  color: #854d0e;
+}
+
 .alert-icon {
   font-weight: 700;
   display: inline-flex;

--- a/frontend/src/components/AdvisorAssociationPanel.js
+++ b/frontend/src/components/AdvisorAssociationPanel.js
@@ -102,7 +102,8 @@ const AdvisorAssociationPanel = () => {
     }
     try {
       const result = await advisorSanitization();
-      setSuccess(`Sanitization complete! ${result.disbandedGroups.length} groups disbanded.`);
+      const count = result?.disbandedGroups?.length ?? result?.count ?? 0;
+      setSuccess(`Sanitization complete! ${count} groups disbanded.`);
       setSanitizationConfirm(false);
       loadData();
     } catch (err) {
@@ -149,48 +150,121 @@ const AdvisorAssociationPanel = () => {
     return <span className={`badge ${config.class}`}>{config.label}</span>;
   };
 
-  if (loading) return <div className="loading-state">Syncing with D2 database...</div>;
+  if (loading) return <div className="loading-spinner">Syncing advisor data...</div>;
 
   // ═══════════════════════════════════════════
   // RENDER: COORDINATOR VIEW
   // ═══════════════════════════════════════════
   if (isCoordinator && !groupId) {
+    const selectedGroup = allGroups.find((g) => g.groupId === selectedGroupId);
+
     return (
       <div className="advisor-association-container">
         <header className="panel-header">
-          <h1>Coordinator Control: Advisor Association</h1>
-          <p>Global management of advisory relationships (Process 3.6 & 3.7)</p>
+          <div>
+            <h1>Coordinator Control: Advisor Association</h1>
+            <p>Global management of advisory relationships (Process 3.6 &amp; 3.7)</p>
+          </div>
         </header>
 
         {error && <div className="alert alert-error">✕ {error}</div>}
         {success && <div className="alert alert-success">✓ {success}</div>}
 
         <section className="section">
-          <table className="groups-table">
-            <thead>
-              <tr>
-                <th>Group Name</th>
-                <th>Advisor</th>
-                <th>Status</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {allGroups.map((g) => (
-                <tr key={g.groupId}>
-                  <td><strong>{g.groupName}</strong></td>
-                  <td>{g.advisorName || 'Unassigned'}</td>
-                  <td>{renderStatusBadge(g.advisorStatus)}</td>
-                  <td>
-                    <button className="btn-transfer" onClick={() => { setSelectedGroupId(g.groupId); setTransferFormOpen(true); }}>
-                      Transfer
-                    </button>
-                  </td>
+          <div className="groups-table-wrapper">
+            <table className="groups-table">
+              <thead>
+                <tr>
+                  <th>Group Name</th>
+                  <th>Advisor</th>
+                  <th>Status</th>
+                  <th>Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {allGroups.length === 0 && (
+                  <tr><td colSpan={4} className="empty-state">No groups found.</td></tr>
+                )}
+                {allGroups.map((g) => (
+                  <tr key={g.groupId}>
+                    <td className="group-name-cell">{g.groupName}</td>
+                    <td className="advisor-cell">{g.advisorName || '—'}</td>
+                    <td>{renderStatusBadge(g.advisorStatus)}</td>
+                    <td className="actions-cell">
+                      <button
+                        className="btn-transfer"
+                        onClick={() => {
+                          setSelectedGroupId(g.groupId);
+                          setTransferFormOpen(true);
+                          setNewProfessorId('');
+                          setTransferReason('');
+                        }}
+                      >
+                        Transfer
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </section>
+
+        {transferFormOpen && selectedGroupId && (
+          <section className="section transfer-section">
+            <h3 className="section-title">
+              Transfer Advisor — {selectedGroup?.groupName || selectedGroupId}
+            </h3>
+            <form className="transfer-form" onSubmit={handleTransfer}>
+              <div className="form-group">
+                <label>New Professor</label>
+                <select
+                  className="form-control"
+                  value={newProfessorId}
+                  onChange={(e) => setNewProfessorId(e.target.value)}
+                  required
+                >
+                  <option value="">Select a professor</option>
+                  {professors.map((p) => (
+                    <option key={p.userId} value={p.userId}>{p.name || p.email}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label>Reason</label>
+                <textarea
+                  className="form-control"
+                  value={transferReason}
+                  onChange={(e) => setTransferReason(e.target.value)}
+                  placeholder="Reason for transfer..."
+                  rows={3}
+                  required
+                />
+              </div>
+              <div className="form-actions">
+                <button
+                  type="button"
+                  className="btn btn-secondary"
+                  onClick={() => {
+                    setTransferFormOpen(false);
+                    setSelectedGroupId(null);
+                    setTransferReason('');
+                    setNewProfessorId('');
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={!newProfessorId || !transferReason.trim()}
+                >
+                  Confirm Transfer
+                </button>
+              </div>
+            </form>
+          </section>
+        )}
 
         <section className="sanitization-box">
           <h3>Post-Deadline Sanitization</h3>
@@ -198,10 +272,12 @@ const AdvisorAssociationPanel = () => {
           <button className={`btn ${sanitizationConfirm ? 'btn-danger' : 'btn-sanitize'}`} onClick={handleSanitize}>
             {sanitizationConfirm ? 'Confirm: DISBAND ALL UNASSIGNED' : 'Trigger Sanitization'}
           </button>
-          {sanitizationConfirm && <button className="btn-link" onClick={() => setSanitizationConfirm(false)}>Cancel</button>}
+          {sanitizationConfirm && (
+            <button className="btn btn-secondary" style={{ marginLeft: 12 }} onClick={() => setSanitizationConfirm(false)}>
+              Cancel
+            </button>
+          )}
         </section>
-
-        {/* Transfer Modal can be added here using transferFormOpen state */}
       </div>
     );
   }


### PR DESCRIPTION
[AdvisorAssociationPanel.js]

Fixed loading spinner — was loading-state (no CSS), now loading-spinner
Built the missing transfer form — clicking Transfer now shows an inline section with professor selector + reason field + confirm/cancel buttons; was just a comment stub
Wrapped the groups table in groups-table-wrapper for horizontal scroll on mobile
Replaced the missing btn-link on the sanitization cancel with btn btn-secondary
Added group-name-cell / advisor-cell / actions-cell classes and empty state row to table


[AdvisorAssociationPanel.css]

Added .alert-warning (schedule window closed banner was unstyled)
Replaced the full-page purple gradient background with a neutral centered container — the gradient was designed for a standalone page but conflicts with the sidebar layout every other page uses

[App.js]

Added coordinator and admin to the /groups/:group_id/advisor route — coordinators were being redirected to 403