### PR TITLE
added deliverables

### DIFF
--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -768,6 +768,133 @@ const notifyDeliverableHandler = async (req, res) => {
 };
 
 /**
+ * POST /api/deliverables/:stagingId/submit
+ *
+ * Process 5.2–5.5 combined — execute the remaining pipeline steps for an
+ * already-staged deliverable in a single call:
+ *   1. Format validation (if staging.status === 'staging')
+ *   2. Deadline validation (if staging.status === 'format_validated')
+ *   3. Permanent storage (if staging.status === 'requirements_validated')
+ *
+ * Prerequisites:
+ *   1. JWT (student role) — enforced by route middleware
+ *   2. Staging record must exist and not be expired
+ *   3. Student must belong to the group in the staging record
+ *
+ * Returns 201 on success with the final deliverable record.
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ */
+const submitFinalizeHandler = async (req, res) => {
+  const { stagingId } = req.params;
+  const actorId = req.user?.userId;
+
+  let staging;
+  try {
+    staging = await DeliverableStaging.findOne({ stagingId });
+  } catch (err) {
+    console.error('[submitFinalizeHandler] DB lookup error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+  }
+
+  if (!staging) {
+    return res.status(404).json({ code: 'STAGING_NOT_FOUND', message: 'Staging record not found' });
+  }
+
+  if (staging.expiresAt < new Date()) {
+    return res.status(404).json({ code: 'STAGING_EXPIRED', message: 'Staging record has expired' });
+  }
+
+  const ok = await studentBelongsToGroup(actorId, staging.groupId);
+  if (!ok) {
+    return res.status(403).json({ code: 'FORBIDDEN', message: 'You do not belong to this group' });
+  }
+
+  // Run format validation if staging record is still in initial state
+  if (staging.status === 'staging') {
+    const { status, body } = await runFormatValidation(stagingId, actorId);
+    if (status !== 200) return res.status(status).json(body);
+    try {
+      staging = await DeliverableStaging.findOne({ stagingId });
+    } catch (err) {
+      console.error('[submitFinalizeHandler] reload after format validation error:', err);
+      return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+    }
+  }
+
+  // Run deadline validation after format validation passes
+  if (staging.status === 'format_validated') {
+    const { status, body } = await runDeadlineValidation(stagingId, null, actorId);
+    if (status !== 200) return res.status(status).json(body);
+    try {
+      staging = await DeliverableStaging.findOne({ stagingId });
+    } catch (err) {
+      console.error('[submitFinalizeHandler] reload after deadline validation error:', err);
+      return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Database query failed' });
+    }
+  }
+
+  if (staging.status !== 'requirements_validated') {
+    return res.status(400).json({
+      code: 'INVALID_STAGING_STATUS',
+      message: `Cannot finalize: staging record is in '${staging.status}' status`,
+    });
+  }
+
+  let fileInfo;
+  try {
+    fileInfo = persistDeliverableFile(staging);
+  } catch (err) {
+    if (err.statusCode === 507 || err.code === 'DISK_FULL') {
+      return res.status(507).json({ code: 'DISK_FULL', message: 'Insufficient disk space — please retry later' });
+    }
+    if (err.statusCode === 400 && err.code === 'CHECKSUM_MISMATCH') {
+      return res.status(400).json({ code: 'CHECKSUM_MISMATCH', message: err.message });
+    }
+    if (err.statusCode === 404 && err.code === 'FILE_NOT_FOUND') {
+      return res.status(404).json({ code: 'STAGING_FILE_NOT_FOUND', message: err.message });
+    }
+    console.error('[submitFinalizeHandler] File persist error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to store deliverable' });
+  }
+
+  let deliverable;
+  try {
+    deliverable = await createFinalRecord(staging, fileInfo.savedPath);
+    await DeliverableStaging.deleteOne({ stagingId });
+  } catch (err) {
+    console.error('[submitFinalizeHandler] DB error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'Failed to store deliverable' });
+  }
+
+  AuditLog.create({
+    action: 'DELIVERABLE_STORED',
+    actorId,
+    groupId: staging.groupId,
+    payload: { stagingId, deliverableId: deliverable.deliverableId },
+    ipAddress: req.ip || null,
+    userAgent: req.headers['user-agent'] || null,
+  }).catch((err) => {
+    console.error('[submitFinalizeHandler] Audit log error:', err.message);
+  });
+
+  const sizeMb = parseFloat((deliverable.fileSize / (1024 * 1024)).toFixed(2));
+
+  return res.status(201).json({
+    deliverableId: deliverable.deliverableId,
+    groupId: deliverable.groupId,
+    deliverableType: deliverable.deliverableType,
+    status: deliverable.status,
+    fileHash: deliverable.fileHash,
+    sizeMb,
+    format: deliverable.format,
+    version: deliverable.version,
+    submittedAt: deliverable.submittedAt.toISOString(),
+  });
+};
+
+/**
  * GET /api/deliverables/:deliverableId/download
  *
  * Stream the stored file to the requester.
@@ -825,6 +952,7 @@ module.exports = {
   validateFormatHandler,
   validateDeadlineHandler,
   storeDeliverableHandler,
+  submitFinalizeHandler,
   listDeliverablesHandler,
   getDeliverableHandler,
   retractDeliverableHandler,

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -11,6 +11,7 @@ const {
   validateFormatHandler,
   validateDeadlineHandler,
   storeDeliverableHandler,
+  submitFinalizeHandler,
   listDeliverablesHandler,
   getDeliverableHandler,
   retractDeliverableHandler,
@@ -88,17 +89,14 @@ router.post(
 
 /**
  * POST /api/deliverables/:stagingId/submit
+ * Process 5.2–5.5 combined — runs format validation, deadline validation, and
+ * permanent storage in a single call for an already-staged deliverable.
  * Accepted role: student
- * Parses multipart upload (field: "file") before reaching the controller.
- * Kept as a stub for middleware testing (MIME-type filter, role guard).
  */
 router.post(
   '/:stagingId/submit',
   roleMiddleware(['student']),
-  uploadSingle('file'),
-  (_req, res) => {
-    res.status(501).json({ code: 'NOT_IMPLEMENTED', message: 'Submit endpoint not yet implemented' });
-  }
+  submitFinalizeHandler
 );
 
 /**

--- a/backend/src/services/deliverableStorageService.js
+++ b/backend/src/services/deliverableStorageService.js
@@ -5,6 +5,7 @@ const path = require('path');
 const crypto = require('crypto');
 const Deliverable = require('../models/Deliverable');
 const DeliverableStaging = require('../models/DeliverableStaging');
+const Group = require('../models/Group');
 
 /**
  * Custom error class for storage operations
@@ -226,15 +227,15 @@ const deleteStagingRecord = async (stagingId) => {
  *
  * @param {string} stagingId - Staging record ID
  * @param {string} permanentDir - Destination permanent directory
- * @param {string} committeeId - Committee ID (defaults to 'com_test_001' for backward compatibility)
+ * @param {string} [committeeId] - Committee ID; if omitted, resolved from the group record
  * @returns {Promise<object>} Object with deliverable and permanentPath
  * @throws {StorageError} With appropriate status codes
  *   - 404: Staging record not found
- *   - 400: Invalid status, checksum mismatch
+ *   - 400: Invalid status, checksum mismatch, no committee assigned
  *   - 507: Disk full
  *   - 500: Other storage/database errors
  */
-const storeDeliverable = async (stagingId, permanentDir, committeeId = 'com_test_001') => {
+const storeDeliverable = async (stagingId, permanentDir, committeeId) => {
   // Fetch staging record
   let stagingRecord;
   try {
@@ -253,6 +254,28 @@ const storeDeliverable = async (stagingId, permanentDir, committeeId = 'com_test
       404,
       'STAGING_NOT_FOUND'
     );
+  }
+
+  // Resolve committeeId from group if not provided by caller
+  if (!committeeId) {
+    let groupDoc;
+    try {
+      groupDoc = await Group.findOne({ groupId: stagingRecord.groupId }).select('committeeId').lean();
+    } catch (err) {
+      throw new StorageError(
+        `Database query failed looking up committeeId: ${err.message}`,
+        500,
+        'DATABASE_ERROR'
+      );
+    }
+    committeeId = groupDoc?.committeeId;
+    if (!committeeId) {
+      throw new StorageError(
+        `Group ${stagingRecord.groupId} has no committee assigned — coordinator must assign a committee before storing deliverables`,
+        400,
+        'NO_COMMITTEE_ASSIGNED'
+      );
+    }
   }
 
   // Validate staging status

--- a/backend/src/services/storageService.js
+++ b/backend/src/services/storageService.js
@@ -5,6 +5,7 @@ const path = require('path');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
 const Deliverable = require('../models/Deliverable');
+const Group = require('../models/Group');
 
 const PERMANENT_BASE = path.join(process.cwd(), 'uploads', 'deliverables');
 
@@ -124,6 +125,17 @@ const persistDeliverableFile = (stagingRecord) => {
 const createFinalRecord = async (stagingRecord, savedPath, session) => {
   const { groupId, deliverableType, sprintId, sprintIds, submittedBy, description, fileHash, fileSize } = stagingRecord;
 
+  // Resolve committeeId from D2 so the deliverable is linked to the real committee
+  let committeeId = null;
+  try {
+    const committeeQuery = Group.findOne({ groupId }).select('committeeId').lean();
+    if (session) committeeQuery.session(session);
+    const groupDoc = await committeeQuery;
+    committeeId = groupDoc?.committeeId ?? null;
+  } catch (err) {
+    console.warn('[storageService] committeeId lookup failed for group', groupId, ':', err.message);
+  }
+
   const priorCount = await Deliverable.countDocuments({ groupId, deliverableType }).session(session ?? null);
   const version = priorCount + 1;
 
@@ -133,6 +145,7 @@ const createFinalRecord = async (stagingRecord, savedPath, session) => {
   const [deliverable] = await Deliverable.create(
     [
       {
+        committeeId,
         groupId,
         deliverableType,
         sprintId: sprintId || null,


### PR DESCRIPTION
was done:

routes/deliverables.js — Replaced the 501 stub at POST /:stagingId/submit with submitFinalizeHandler. The uploadSingle middleware was removed since no new file upload is needed (the file was already staged in step 1).

controllers/deliverableController.js — Added submitFinalizeHandler: a combined pipeline executor that, given an existing staging record, runs format validation → deadline validation → permanent storage in sequence, returning 201 with the deliverable on success.

services/storageService.js — createFinalRecord now requires Group and looks up the real committeeId from D2 before creating the Deliverable. If the group has no committee, committeeId is stored as null (non-fatal, with a warning) rather than silently using a fake value.

services/deliverableStorageService.js — Removed committeeId = 'com_test_001'. If the caller omits committeeId, the function now looks it up from the group. If the group has no committee assigned, it throws StorageError with code NO_COMMITTEE_ASSIGNED (400) instead of silently proceeding.