### PR TITLE
Implement GitHub account connection in ProfilePage with error handling and UI updates

### DIFF
--- a/frontend/src/components/GitHubCallbackHandler.js
+++ b/frontend/src/components/GitHubCallbackHandler.js
@@ -128,12 +128,19 @@ const GitHubCallbackHandler = () => {
     }
 
     if (status === 'linked' && username) {
-      setGithubUsername(username);
-      // Merge githubUsername into the persisted user object
       if (user) {
         setUser({ ...user, githubUsername: username });
       }
       setStepComplete('githubLinked');
+
+      const returnTo = sessionStorage.getItem('githubReturnTo');
+      if (returnTo) {
+        sessionStorage.removeItem('githubReturnTo');
+        navigate(returnTo, { replace: true, state: { githubLinked: true, githubUsername: username } });
+        return;
+      }
+
+      setGithubUsername(username);
       setPhase('success');
     } else if (errorCode) {
       setErrorInfo(ERROR_MESSAGES[errorCode] || FALLBACK_ERROR);

--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -156,6 +156,12 @@
   color: #991b1b;
 }
 
+.github-connect-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .github-username a {
   color: #667eea;
   text-decoration: none;

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,23 +1,47 @@
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import useAuthStore from '../store/authStore';
 import { updateProfile } from '../api/profileService';
+import { initiateGithubOAuth } from '../api/authService';
 import './ProfilePage.css';
 
 const ProfilePage = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const user = useAuthStore((state) => state.user);
   const setUser = useAuthStore((state) => state.setUser);
   const [isEditing, setIsEditing] = useState(false);
   const [editedUser, setEditedUser] = useState(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveMessage, setSaveMessage] = useState(null);
+  const [isConnectingGithub, setIsConnectingGithub] = useState(false);
+  const [githubError, setGithubError] = useState('');
 
   useEffect(() => {
     if (user) {
       setEditedUser({ ...user });
     }
   }, [user]);
+
+  useEffect(() => {
+    if (location.state?.githubLinked) {
+      setSaveMessage({ type: 'success', text: `GitHub account @${location.state.githubUsername} connected successfully.` });
+      navigate(location.pathname, { replace: true, state: {} });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleConnectGithub = async () => {
+    setIsConnectingGithub(true);
+    setGithubError('');
+    try {
+      sessionStorage.setItem('githubReturnTo', '/profile');
+      const data = await initiateGithubOAuth(window.location.origin + '/auth/github/callback');
+      window.location.href = data.authorizationUrl;
+    } catch (err) {
+      setGithubError(err.response?.data?.message || 'Failed to initiate GitHub connection.');
+      setIsConnectingGithub(false);
+    }
+  };
 
   const handleEditChange = (field, value) => {
     setEditedUser({
@@ -28,9 +52,6 @@ const ProfilePage = () => {
 
   const handleSaveChanges = async () => {
     const updates = {};
-    if (editedUser.githubUsername !== user.githubUsername) {
-      updates.githubUsername = editedUser.githubUsername || '';
-    }
     if (Object.keys(updates).length === 0) {
       setIsEditing(false);
       return;
@@ -184,18 +205,10 @@ const ProfilePage = () => {
                   </div>
                 )}
 
-                {/* GitHub Username */}
+                {/* GitHub Account */}
                 <div className="info-field">
-                  <label className="info-label">GitHub Username</label>
-                  {isEditing ? (
-                    <input
-                      type="text"
-                      className="info-input"
-                      value={editedUser?.githubUsername || ''}
-                      onChange={(e) => handleEditChange('githubUsername', e.target.value)}
-                      placeholder="your-github-username"
-                    />
-                  ) : user.githubUsername ? (
+                  <label className="info-label">GitHub Account</label>
+                  {user.githubUsername ? (
                     <div className="info-value github-username">
                       <a
                         href={`https://github.com/${user.githubUsername}`}
@@ -206,7 +219,20 @@ const ProfilePage = () => {
                       </a>
                     </div>
                   ) : (
-                    <div className="info-value">Not linked</div>
+                    <div className="github-connect-wrapper">
+                      {githubError && (
+                        <div className="profile-save-message profile-save-message--error">
+                          {githubError}
+                        </div>
+                      )}
+                      <button
+                        className="btn btn-primary"
+                        onClick={handleConnectGithub}
+                        disabled={isConnectingGithub}
+                      >
+                        {isConnectingGithub ? 'Redirecting to GitHub...' : 'Connect GitHub Account'}
+                      </button>
+                    </div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- Replace the free-text GitHub username input on the profile page with an OAuth-based "Connect GitHub Account" button, matching the same flow used on the login/onboarding pages
- After a successful OAuth link, the user is redirected back to `/profile` with a success banner instead of being routed to the onboarding success screen
- `GitHubCallbackHandler` now checks `sessionStorage` for a `githubReturnTo` key; if present, it navigates to that path (e.g. `/profile`) with route state instead of showing the onboarding UI

## Changes

**`ProfilePage.jsx`**
- Added `handleConnectGithub` — sets `githubReturnTo` in sessionStorage, then calls `initiateGithubOAuth` to start the OAuth flow
- Added a `useEffect` that reads `location.state.githubLinked` on mount to display a success message after returning from GitHub
- GitHub section now shows a "Connect GitHub Account" button when no account is linked, and a linked `@username` anchor otherwise — independent of edit mode
- Removed the direct `githubUsername` text input and its save logic

**`GitHubCallbackHandler.js`**
- On `status === 'linked'`, checks `sessionStorage` for `githubReturnTo`; if set, clears it and navigates to that route with `{ githubLinked: true, githubUsername }` in state
- Falls through to the existing onboarding success screen when `githubReturnTo` is absent (preserving the onboarding flow)

**`ProfilePage.css`**
- Added `.github-connect-wrapper` for layout of the connect button and inline error message