### PR TITLE
Refactor overlay styles in ProfessorOnboardModal for improved responsiveness

### DIFF
--- a/frontend/src/components/ProfessorOnboardModal.js
+++ b/frontend/src/components/ProfessorOnboardModal.js
@@ -179,9 +179,7 @@ const ProfessorOnboardModal = () => {
 
 const styles = {
   overlay: {
-    position: 'fixed',
-    inset: 0,
-    zIndex: 9999,
+    minHeight: '100vh',
     background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
## Summary

- The sidebar was not visible when navigating to /professor/setup (Setup Account page)

- Root cause: ProfessorOnboardModal rendered a position: fixed; inset: 0; z-index: 9999 overlay that painted over the entire viewport, covering the sidebar (z-index 50)

- Fix: Removed position: fixed, inset: 0, and z-index: 9999 from the overlay style; replaced with minHeight: 100vh so the component renders as normal page content within the layout's existing content area, which already accounts for the sidebar via margin-left