### PR TITLE
Fix jury committees page by implementing GET /committees/my-jury endpoint

### DIFF
--- a/backend/src/controllers/committees.js
+++ b/backend/src/controllers/committees.js
@@ -472,6 +472,48 @@ const getCommitteeById = async (req, res) => {
   }
 };
 
+/**
+ * Get published committees where the authenticated user is a jury member.
+ * GET /api/v1/committees/my-jury
+ */
+const getMyJuryCommittees = async (req, res) => {
+  try {
+    const userId = req.user?.userId;
+
+    if (!userId) {
+      return res.status(403).json({
+        error: 'Forbidden',
+        message: 'Authentication required',
+      });
+    }
+
+    const committees = await Committee.find({ juryIds: userId, status: 'published' })
+      .sort({ publishedAt: -1 })
+      .lean();
+
+    return res.status(200).json({
+      committees: committees.map((committee) => ({
+        committeeId: committee.committeeId,
+        committeeName: committee.committeeName,
+        description: committee.description || null,
+        status: committee.status,
+        advisorIds: Array.isArray(committee.advisorIds) ? committee.advisorIds : [],
+        juryIds: Array.isArray(committee.juryIds) ? committee.juryIds : [],
+        publishedAt: committee.publishedAt,
+        createdAt: committee.createdAt,
+        updatedAt: committee.updatedAt,
+      })),
+      total: committees.length,
+    });
+  } catch (err) {
+    console.error('getMyJuryCommittees error:', err);
+    return res.status(500).json({
+      code: 'INTERNAL_ERROR',
+      message: 'Failed to load jury committees',
+    });
+  }
+};
+
 module.exports = {
   createCommittee,
   publishCommittee,
@@ -479,5 +521,6 @@ module.exports = {
   assignAdvisorsHandler,
   assignJuryHandler,
   listCommittees,
-  getCommitteeById
+  getCommitteeById,
+  getMyJuryCommittees,
 };

--- a/backend/src/routes/committees.js
+++ b/backend/src/routes/committees.js
@@ -8,6 +8,7 @@ const {
   assignJuryHandler,
   validateCommitteeHandler,
   publishCommittee,
+  getMyJuryCommittees,
 } = require('../controllers/committees');
 const { authMiddleware, roleMiddleware } = require('../middleware/auth');
 
@@ -17,6 +18,7 @@ const { authMiddleware, roleMiddleware } = require('../middleware/auth');
  */
 router.post('/', authMiddleware, roleMiddleware(['coordinator']), createCommittee);
 router.get('/', authMiddleware, roleMiddleware(['coordinator', 'admin']), listCommittees);
+router.get('/my-jury', authMiddleware, roleMiddleware(['professor']), getMyJuryCommittees);
 router.get('/:committeeId', authMiddleware, roleMiddleware(['coordinator', 'admin']), getCommitteeById);
 
 /**

--- a/backend/tests/committee-integration.test.js
+++ b/backend/tests/committee-integration.test.js
@@ -69,6 +69,10 @@ function tokenStudent(userId = unique('stu')) {
   return { userId, token: generateAccessToken(userId, 'student') };
 }
 
+function tokenProfessor(userId = unique('prof')) {
+  return { userId, token: generateAccessToken(userId, 'professor') };
+}
+
 async function seedActiveDeliverableWindow() {
   const now = Date.now();
   return ScheduleWindow.create({
@@ -637,6 +641,116 @@ describe('Committee & deliverable integration (Process 4.0)', () => {
       expect(gDoc.committeePublishedAt).toBeFalsy();
 
       AuditLog.prototype.save.mockRestore();
+    });
+  });
+
+  describe('GET /api/v1/committees/my-jury', () => {
+    it('returns 200 with published committees where the user is a jury member', async () => {
+      const coord = tokenCoordinator();
+      const prof = tokenProfessor();
+
+      const created = await request(app)
+        .post(`${API}/committees`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ committeeName: unique('JuryView'), description: 'jury test' });
+      const committeeId = created.body.committeeId;
+
+      await request(app)
+        .post(`${API}/committees/${committeeId}/advisors`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ advisorIds: [unique('adv')] });
+
+      await request(app)
+        .post(`${API}/committees/${committeeId}/jury`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ juryIds: [prof.userId] });
+
+      await request(app)
+        .post(`${API}/committees/${committeeId}/validate`)
+        .set('Authorization', `Bearer ${coord.token}`);
+
+      await request(app)
+        .post(`${API}/committees/${committeeId}/publish`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ assignedGroupIds: [] });
+
+      const res = await request(app)
+        .get(`${API}/committees/my-jury`)
+        .set('Authorization', `Bearer ${prof.token}`);
+
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body.committees)).toBe(true);
+      expect(res.body.committees).toHaveLength(1);
+      expect(res.body.committees[0].committeeId).toBe(committeeId);
+      expect(res.body.committees[0].status).toBe('published');
+      expect(res.body.committees[0].juryIds).toContain(prof.userId);
+      expect(res.body.total).toBe(1);
+    });
+
+    it('returns 200 with empty list when user is not assigned to any jury', async () => {
+      const prof = tokenProfessor();
+
+      const res = await request(app)
+        .get(`${API}/committees/my-jury`)
+        .set('Authorization', `Bearer ${prof.token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.committees).toEqual([]);
+      expect(res.body.total).toBe(0);
+    });
+
+    it('does not return draft or validated committees', async () => {
+      const coord = tokenCoordinator();
+      const prof = tokenProfessor();
+
+      const created = await request(app)
+        .post(`${API}/committees`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ committeeName: unique('JuryDraft') });
+      const committeeId = created.body.committeeId;
+
+      await request(app)
+        .post(`${API}/committees/${committeeId}/advisors`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ advisorIds: [unique('adv')] });
+
+      await request(app)
+        .post(`${API}/committees/${committeeId}/jury`)
+        .set('Authorization', `Bearer ${coord.token}`)
+        .send({ juryIds: [prof.userId] });
+
+      // Validate but do NOT publish — committee stays in validated state
+      await request(app)
+        .post(`${API}/committees/${committeeId}/validate`)
+        .set('Authorization', `Bearer ${coord.token}`);
+
+      const res = await request(app)
+        .get(`${API}/committees/my-jury`)
+        .set('Authorization', `Bearer ${prof.token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.committees).toEqual([]);
+      expect(res.body.total).toBe(0);
+    });
+
+    it('returns 403 when caller is a coordinator or student', async () => {
+      const coord = tokenCoordinator();
+      const student = tokenStudent();
+
+      const resCoord = await request(app)
+        .get(`${API}/committees/my-jury`)
+        .set('Authorization', `Bearer ${coord.token}`);
+      expect(resCoord.status).toBe(403);
+
+      const resStudent = await request(app)
+        .get(`${API}/committees/my-jury`)
+        .set('Authorization', `Bearer ${student.token}`);
+      expect(resStudent.status).toBe(403);
+    });
+
+    it('returns 401 when token is missing', async () => {
+      const res = await request(app).get(`${API}/committees/my-jury`);
+      expect(res.status).toBe(401);
     });
   });
 

--- a/frontend/src/api/groupService.js
+++ b/frontend/src/api/groupService.js
@@ -196,22 +196,12 @@ export const getGroupCommitteeStatus = async (groupId) => {
 };
 
 /**
- * Get jury-assigned committees for the authenticated user
- * @returns {Promise<{committees: object[]}>}
- *
- * NOTE: Backend GET endpoint for jury committees is planned in Level 2.4.
- * TODO: Once backend implements committee retrieval endpoints, replace with:
- *   GET /committees?role=jury (or dedicated GET /jury/committees endpoint)
- *   Filter response to only published committees for non-coordinator users
+ * Get published committees where the authenticated user is assigned as a jury member.
+ * @returns {Promise<{committees: object[], total: number}>}
  */
 export const getJuryCommittees = async () => {
-  // TODO: Backend implementation required (Level 2.4 Issue #75 or related)
-  // Once backend provides endpoint for jury committee retrieval, uncomment:
-  // const response = await apiClient.get('/committees?role=jury&status=published');
-  // return response.data;
-  return {
-    committees: [], // Awaiting backend GET endpoint for jury committee retrieval
-  };
+  const response = await apiClient.get('/committees/my-jury');
+  return response.data;
 };
 
 /**


### PR DESCRIPTION
The getJuryCommittees() frontend function was hardcoded to return an empty array, leaving the Jury Committees page permanently non-functional.

- Add getMyJuryCommittees controller: queries published committees where the authenticated user appears in juryIds
- Add GET /committees/my-jury route restricted to professor role, placed before /:committeeId to avoid Express param collision
- Wire up frontend getJuryCommittees() to call the new endpoint
- Add 5 integration test cases covering happy path, empty state, status filtering, role guard, and auth guard