### PR TITLE
Fix jury assignment inaccessible to admin and blocked by role guard

### DIFF
--- a/backend/src/routes/committees.js
+++ b/backend/src/routes/committees.js
@@ -31,7 +31,7 @@ router.post('/:committeeId/advisors', authMiddleware, roleMiddleware(['coordinat
  * Process 4.3: Assign Jury Members
  * POST /api/v1/committees/:committeeId/jury
  */
-router.post('/:committeeId/jury', authMiddleware, roleMiddleware(['coordinator']), assignJuryHandler);
+router.post('/:committeeId/jury', authMiddleware, roleMiddleware(['coordinator', 'admin']), assignJuryHandler);
 
 /**
  * Process 4.4: Validate Committee

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -122,7 +122,7 @@ function App() {
             />
             <Route
               path="/coordinator/committees/:committeeId/jury"
-              element={<ProtectedRoute component={JuryAssignmentForm} requiredRoles={['coordinator']} />}
+              element={<ProtectedRoute component={JuryAssignmentForm} requiredRoles={['coordinator', 'admin']} />}
             />
 
             <Route

--- a/frontend/src/components/JuryAssignmentForm.js
+++ b/frontend/src/components/JuryAssignmentForm.js
@@ -31,7 +31,7 @@ const JuryAssignmentForm = () => {
 
   // ── Role guard (UI layer) ─────────────────────────────────────────────────
   useEffect(() => {
-    if (!user || user.role !== 'coordinator') {
+    if (!user || !['coordinator', 'admin'].includes(user.role)) {
       // Handled in render but good to have here
     }
   }, [user]);
@@ -135,11 +135,11 @@ const JuryAssignmentForm = () => {
   };
 
   // ── Render Guards ─────────────────────────────────────────────────────────
-  if (!user || user.role !== 'coordinator') {
+  if (!user || !['coordinator', 'admin'].includes(user.role)) {
     return (
       <div className="jury-page">
         <div className="jury-card">
-          <div className="jury-error">Access Denied — This page is restricted to Coordinators only.</div>
+          <div className="jury-error">Access Denied — This page is restricted to Coordinators and Admins only.</div>
           <div className="jury-actions">
             <button className="btn-secondary" onClick={() => navigate(-1)}>← Go Back</button>
           </div>


### PR DESCRIPTION
## Summary
- Allow `admin` role in `POST /committees/:committeeId/jury` backend route middleware
- Add `admin` to `requiredRoles` for the jury assignment route in `App.js`
- Update `JuryAssignmentForm` role guard to permit admin users alongside coordinators

## Root Cause
The jury assignment feature had coordinator-only restrictions applied at three independent
layers — backend middleware, frontend route protection, and component-level render guard —
none of which included the admin role, making the feature completely inaccessible to admins.