### PR TITLE
Fix #360: Publish Wizard UI — step indicators, disabled button, navigation, and test coverage

### DIFF
--- a/frontend/src/__tests__/CoordinatorFinalGradePublishPanel.test.jsx
+++ b/frontend/src/__tests__/CoordinatorFinalGradePublishPanel.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -11,16 +11,15 @@ jest.mock('../api/finalGradeService', () => ({
   publishFinalGrades: jest.fn(),
 }));
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ groupId: 'group-1' }),
-  useNavigate: () => jest.fn(),
-}));
-
-const renderPanel = () =>
+const renderPanel = (initialEntries = ['/groups/group-1/final-grades/publish']) =>
   render(
-    <MemoryRouter>
-      <CoordinatorFinalGradePublishPanel />
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route
+          path="/groups/:groupId/final-grades/publish"
+          element={<CoordinatorFinalGradePublishPanel />}
+        />
+      </Routes>
     </MemoryRouter>
   );
 
@@ -158,5 +157,94 @@ describe('CoordinatorFinalGradePublishPanel', () => {
     expect(secondContainer).toHaveClass('error-message');
     expect(secondContainer).not.toHaveClass('error-message-warning');
     expect(screen.queryByText(/Grades Published/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('Wizard Flow and UI State', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows "Go to Review & Approve" when not published', async () => {
+    getGroupApprovalSummary.mockResolvedValue({
+      summary: [
+        { _id: 'approved', count: 0 },
+        { _id: 'published', count: 0 },
+        { _id: 'pending', count: 3 },
+      ],
+      activePublishCycle: 'Fall2026',
+    });
+
+    renderPanel();
+
+    await screen.findByRole('button', { name: /Publish Final Grades/i });
+    expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Review & Approve/i }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /Go to Review & Approve/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Back to Approval/i })).toBeInTheDocument();
+  });
+
+  it('hides "Go to Review & Approve" when already published', async () => {
+    getGroupApprovalSummary.mockResolvedValue({
+      summary: [
+        { _id: 'approved', count: 0 },
+        { _id: 'published', count: 2 },
+        { _id: 'pending', count: 0 },
+      ],
+      activePublishCycle: 'Fall2026',
+    });
+
+    renderPanel();
+
+    await screen.findByRole('button', { name: /Publish Final Grades/i });
+    expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Go to Review & Approve/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/These grades are already published for this cycle/i)).toBeInTheDocument();
+  });
+
+  it('renders step indicators and completes publish success flow', async () => {
+    getGroupApprovalSummary.mockResolvedValueOnce({
+      summary: [
+        { _id: 'approved', count: 2 },
+        { _id: 'published', count: 0 },
+        { _id: 'pending', count: 1 },
+      ],
+      activePublishCycle: 'Fall2026',
+    });
+    getGroupApprovalSummary.mockResolvedValueOnce({
+      summary: [
+        { _id: 'approved', count: 0 },
+        { _id: 'published', count: 2 },
+        { _id: 'pending', count: 0 },
+      ],
+      activePublishCycle: 'Fall2026',
+    });
+    publishFinalGrades.mockResolvedValue({
+      groupId: 'group-1',
+      publishCycle: 'Fall2026',
+      publishedCount: 2,
+      publishedAt: '2026-05-08T10:00:00.000Z',
+      notificationStatus: {
+        email: true,
+        sms: false,
+        push: true,
+      },
+    });
+
+    renderPanel();
+
+    const publishButton = await screen.findByRole('button', { name: /Publish Final Grades/i });
+    expect(screen.getByText(/Step 2 of 2/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Review & Approve/i })).toBeInTheDocument();
+    expect(screen.getByText(/Publish Grades/i)).toBeInTheDocument();
+
+    await userEvent.click(publishButton);
+    expect(screen.getByRole('dialog', { name: /Confirm Publication/i })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Confirm & Publish/i }));
+    expect(publishFinalGrades).toHaveBeenCalledWith('group-1', expect.any(Object));
+
+    expect(await screen.findByRole('heading', { name: /Grades Published/i })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: /Confirm Publication/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/CoordinatorFinalGradePublishPanel.test.jsx
+++ b/frontend/src/__tests__/CoordinatorFinalGradePublishPanel.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
@@ -15,6 +16,13 @@ jest.mock('react-router-dom', () => ({
   useParams: () => ({ groupId: 'group-1' }),
   useNavigate: () => jest.fn(),
 }));
+
+const renderPanel = () =>
+  render(
+    <MemoryRouter>
+      <CoordinatorFinalGradePublishPanel />
+    </MemoryRouter>
+  );
 
 describe('CoordinatorFinalGradePublishPanel', () => {
   beforeEach(() => {
@@ -40,7 +48,7 @@ describe('CoordinatorFinalGradePublishPanel', () => {
       },
     });
 
-    render(<CoordinatorFinalGradePublishPanel />);
+    renderPanel();
 
     const publishButton = await screen.findByRole('button', { name: /Publish Final Grades/i });
     await userEvent.click(publishButton);
@@ -49,13 +57,14 @@ describe('CoordinatorFinalGradePublishPanel', () => {
     expect(
       await screen.findByText(/The selected cycle does not match the approved records/i)
     ).toBeInTheDocument();
-    expect(screen.getByText(/⚠️/)).toBeInTheDocument();
-    const warningContainer = screen.getByText(/The selected cycle does not match the approved records/i).closest('div');
+    const warningContainer = screen
+      .getByText(/The selected cycle does not match the approved records/i)
+      .closest('div');
     expect(warningContainer).toHaveClass('error-message');
     expect(warningContainer).toHaveClass('error-message-warning');
     expect(screen.getByRole('button', { name: /Confirm & Publish/i })).toBeInTheDocument();
     expect(screen.queryByText(/already been published for this cycle/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Published Summary/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Grades Published/i)).not.toBeInTheDocument();
   });
 
   it('maps ALREADY_PUBLISHED to duplicate publish message', async () => {
@@ -69,7 +78,7 @@ describe('CoordinatorFinalGradePublishPanel', () => {
       },
     });
 
-    render(<CoordinatorFinalGradePublishPanel />);
+    renderPanel();
 
     const publishButton = await screen.findByRole('button', { name: /Publish Final Grades/i });
     await userEvent.click(publishButton);
@@ -79,10 +88,12 @@ describe('CoordinatorFinalGradePublishPanel', () => {
       expect(screen.getByText(/already been published for this cycle/i)).toBeInTheDocument();
     });
 
-    const generalErrorContainer = screen.getByText(/already been published for this cycle/i).closest('div');
+    const generalErrorContainer = screen
+      .getByText(/already been published for this cycle/i)
+      .closest('div');
     expect(generalErrorContainer).toHaveClass('error-message');
     expect(generalErrorContainer).not.toHaveClass('error-message-warning');
-    expect(screen.queryByText(/Published Summary/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Grades Published/i)).not.toBeInTheDocument();
   });
 
   it('uses DEFAULT conflict fallback when 409 code is unrecognized', async () => {
@@ -96,7 +107,7 @@ describe('CoordinatorFinalGradePublishPanel', () => {
       },
     });
 
-    render(<CoordinatorFinalGradePublishPanel />);
+    renderPanel();
 
     const publishButton = await screen.findByRole('button', { name: /Publish Final Grades/i });
     await userEvent.click(publishButton);
@@ -105,7 +116,7 @@ describe('CoordinatorFinalGradePublishPanel', () => {
     await waitFor(() => {
       expect(screen.getByText(/A conflict error occurred/i)).toBeInTheDocument();
     });
-    expect(screen.queryByText(/Published Summary/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Grades Published/i)).not.toBeInTheDocument();
   });
 
   it('resets error type from cycle warning to general error on next attempt', async () => {
@@ -128,7 +139,7 @@ describe('CoordinatorFinalGradePublishPanel', () => {
         },
       });
 
-    render(<CoordinatorFinalGradePublishPanel />);
+    renderPanel();
 
     const publishButton = await screen.findByRole('button', { name: /Publish Final Grades/i });
     await userEvent.click(publishButton);
@@ -139,7 +150,6 @@ describe('CoordinatorFinalGradePublishPanel', () => {
     const firstError = await screen.findByText(/The selected cycle does not match the approved records/i);
     const firstContainer = firstError.closest('div');
     expect(firstContainer).toHaveClass('error-message-warning');
-    expect(screen.getByText(/⚠️/)).toBeInTheDocument();
 
     await userEvent.click(confirmButton);
 
@@ -147,7 +157,6 @@ describe('CoordinatorFinalGradePublishPanel', () => {
     const secondContainer = secondError.closest('div');
     expect(secondContainer).toHaveClass('error-message');
     expect(secondContainer).not.toHaveClass('error-message-warning');
-    expect(screen.getByText(/❌/)).toBeInTheDocument();
-    expect(screen.queryByText(/Published Summary/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Grades Published/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.jsx
+++ b/frontend/src/pages/CoordinatorFinalGradeApprovalPanel.jsx
@@ -234,12 +234,12 @@ const CoordinatorFinalGradeApprovalPanel = () => {
     <div className="approval-page">
       <header className="approval-header">
         <div>
-          <p className="approval-kicker">Coordinator final grade approval</p>
-          <h1>Preview & Approve Grades</h1>
+          <p className="approval-kicker">Step 1 of 2 &mdash; Coordinator final grade approval</p>
+          <h1>Preview &amp; Approve Grades</h1>
           <p>Group {groupId}</p>
         </div>
         <Link className="approval-secondary-link" to={`/groups/${groupId}/final-grades/publish`}>
-          Publish wizard
+          Next: Publish Grades &#8594;
         </Link>
       </header>
 

--- a/frontend/src/pages/CoordinatorFinalGradePublishPanel.css
+++ b/frontend/src/pages/CoordinatorFinalGradePublishPanel.css
@@ -1,3 +1,5 @@
+/* ---- Layout ---- */
+
 .publish-panel-container {
   min-height: 100vh;
   padding: 32px 24px;
@@ -10,7 +12,82 @@ body:has(.publish-panel-container) {
   background: #f8fafc;
 }
 
+/* ---- Wizard step indicator ---- */
+
+.wizard-steps {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 24px;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px 24px;
+  box-shadow: 0 2px 8px rgba(102, 126, 234, 0.06);
+}
+
+.wizard-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  color: #9ca3af;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.wizard-step.completed {
+  color: #667eea;
+  cursor: pointer;
+}
+
+.wizard-step.completed:hover .wizard-step-label {
+  text-decoration: underline;
+}
+
+.wizard-step.active {
+  color: #1a1a2e;
+  cursor: default;
+}
+
+.wizard-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: 700;
+  background: #e5e7eb;
+  color: #9ca3af;
+  flex-shrink: 0;
+}
+
+.wizard-step.completed .wizard-step-num {
+  background: #667eea;
+  color: #ffffff;
+}
+
+.wizard-step.active .wizard-step-num {
+  background: #1a1a2e;
+  color: #ffffff;
+}
+
+.wizard-step-connector {
+  flex: 1;
+  height: 2px;
+  background: #e5e7eb;
+  margin: 0 16px;
+}
+
+/* ---- Header ---- */
+
 .publish-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
   background: #ffffff;
   border-left: 4px solid #667eea;
   border-radius: 12px;
@@ -19,8 +96,17 @@ body:has(.publish-panel-container) {
   padding: 24px 28px;
 }
 
+.publish-kicker {
+  margin: 0 0 6px;
+  color: #667eea;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .publish-header h1 {
-  margin: 0 0 8px 0;
+  margin: 0 0 6px;
   font-size: 26px;
   color: #1a1a2e;
 }
@@ -29,6 +115,70 @@ body:has(.publish-panel-container) {
   margin: 0;
   color: #6b7280;
   font-size: 14px;
+}
+
+.publish-back-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #374151;
+  background: #ffffff;
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.publish-back-link:hover {
+  background: #f3f4f6;
+}
+
+/* ---- Loading / Error states ---- */
+
+.loading-state {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.loading-spinner {
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  border: 2px solid #e5e7eb;
+  border-top-color: #667eea;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.error-state {
+  padding: 14px 18px;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  color: #991b1b;
+  font-size: 14px;
+}
+
+/* ---- Summary dashboard ---- */
+
+.summary-description {
+  margin: 0 0 24px;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
 }
 
 .summary-cards {
@@ -48,8 +198,8 @@ body:has(.publish-panel-container) {
 }
 
 .summary-cards .card h3 {
-  margin: 0 0 12px 0;
-  font-size: 14px;
+  margin: 0 0 12px;
+  font-size: 13px;
   color: #4b5563;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -88,14 +238,19 @@ body:has(.publish-panel-container) {
   color: #1d4ed8;
 }
 
+/* ---- Publish actions ---- */
+
 .publish-actions {
   text-align: center;
-  margin-top: 24px;
   padding: 30px;
   background: #fff;
   border-radius: 12px;
   border: 1px solid #e5e7eb;
   box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
 }
 
 .btn-publish {
@@ -107,7 +262,7 @@ body:has(.publish-panel-container) {
   font-weight: 600;
   border-radius: 8px;
   cursor: pointer;
-  transition: background-color 0.2s, transform 0.1s;
+  transition: opacity 0.2s, transform 0.1s;
 }
 
 .btn-publish:hover:not(.disabled) {
@@ -115,17 +270,39 @@ body:has(.publish-panel-container) {
 }
 
 .btn-publish.disabled {
-  background-color: #9ca3af;
+  background: #9ca3af;
   cursor: not-allowed;
 }
 
 .action-hint {
-  margin-top: 16px;
+  margin: 14px 0 0;
   color: #6b7280;
   font-size: 14px;
 }
 
-/* Modal */
+.btn-secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 14px;
+  min-height: 40px;
+  padding: 0 18px;
+  border: 1px solid #667eea;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  color: #667eea;
+  background: #ffffff;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.btn-secondary-link:hover {
+  background: #f0f0ff;
+}
+
+/* ---- Modal ---- */
+
 .modal-overlay {
   position: fixed;
   top: 0;
@@ -150,29 +327,30 @@ body:has(.publish-panel-container) {
 }
 
 .modal-content h2 {
-  margin: 0 0 16px 0;
-  font-size: 24px;
+  margin: 0 0 12px;
+  font-size: 22px;
+  color: #1a1a2e;
+}
+
+.modal-content > p {
+  margin: 0 0 20px;
+  color: #4b5563;
+  font-size: 14px;
+  line-height: 1.6;
 }
 
 .form-group {
-  margin-top: 24px;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .form-group label {
   display: block;
   font-weight: 600;
   margin-bottom: 8px;
-  font-size: 14px;
-}
-
-.form-group input[type="text"] {
-  width: 100%;
-  padding: 10px;
-  border: 1px solid #d1d5db;
-  border-radius: 8px;
-  font-size: 14px;
-  box-sizing: border-box;
+  font-size: 13px;
+  color: #374151;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .readonly-value {
@@ -184,19 +362,29 @@ body:has(.publish-panel-container) {
   background: #f9fafb;
   color: #374151;
   box-sizing: border-box;
+  font-family: 'Courier New', monospace;
 }
 
 .notification-options {
   background: #f9fafb;
   padding: 16px;
   border-radius: 8px;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
+}
+
+.notification-options-label {
+  margin: 0 0 12px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #374151;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .checkbox-label {
   display: flex;
   align-items: center;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   font-size: 14px;
   color: #374151;
   cursor: pointer;
@@ -207,16 +395,17 @@ body:has(.publish-panel-container) {
 }
 
 .checkbox-label input {
-  margin-right: 12px;
+  margin-right: 10px;
   width: 16px;
   height: 16px;
+  cursor: pointer;
 }
 
 .modal-actions {
   display: flex;
   justify-content: flex-end;
   gap: 12px;
-  margin-top: 32px;
+  margin-top: 28px;
 }
 
 .btn-cancel {
@@ -226,9 +415,10 @@ body:has(.publish-panel-container) {
   border-radius: 8px;
   cursor: pointer;
   font-weight: 500;
+  font-size: 14px;
 }
 
-.btn-cancel:hover {
+.btn-cancel:hover:not(:disabled) {
   background: #f3f4f6;
 }
 
@@ -240,11 +430,20 @@ body:has(.publish-panel-container) {
   border-radius: 8px;
   cursor: pointer;
   font-weight: 600;
+  font-size: 14px;
 }
 
 .btn-confirm:hover:not(:disabled) {
   background: #047857;
 }
+
+.btn-cancel:disabled,
+.btn-confirm:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ---- Error messages ---- */
 
 .error-message {
   color: #dc2626;
@@ -266,10 +465,14 @@ body:has(.publish-panel-container) {
 }
 
 .error-icon {
-  line-height: 1.2;
+  font-weight: 700;
+  font-size: 15px;
+  line-height: 1.3;
+  flex-shrink: 0;
 }
 
-/* Success State */
+/* ---- Success state ---- */
+
 .publish-success-state {
   background: white;
   padding: 40px;
@@ -279,21 +482,61 @@ body:has(.publish-panel-container) {
   box-shadow: 0 2px 8px rgba(102, 126, 234, 0.07);
 }
 
+.publish-success-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  background: #dcfce7;
+  color: #16a34a;
+  border-radius: 50%;
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
 .publish-success-state h2 {
   color: #059669;
-  font-size: 28px;
-  margin-bottom: 16px;
+  font-size: 26px;
+  margin: 0 0 10px;
+}
+
+.publish-success-state > p {
+  color: #4b5563;
+  font-size: 14px;
+  margin: 0 0 24px;
 }
 
 .publish-stats {
   background: #f3f4f6;
   border-radius: 8px;
-  padding: 24px;
-  margin: 24px 0;
+  padding: 20px 24px;
+  margin-bottom: 20px;
   text-align: left;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
+}
+
+.publish-stats div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.publish-stats strong {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #6b7280;
+}
+
+.publish-stats span {
+  font-size: 15px;
+  font-weight: 600;
+  color: #111827;
+  overflow-wrap: anywhere;
 }
 
 .notification-stats {
@@ -301,13 +544,16 @@ body:has(.publish-panel-container) {
   background: #f8fafc;
   padding: 20px;
   border-radius: 8px;
-  margin-bottom: 32px;
+  margin-bottom: 28px;
 }
 
 .notification-stats h3 {
-  margin-top: 0;
-  font-size: 16px;
-  color: #334155;
+  margin: 0 0 12px;
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #374151;
 }
 
 .notification-stats ul {
@@ -317,13 +563,34 @@ body:has(.publish-panel-container) {
 }
 
 .notification-stats li {
-  padding: 8px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 9px 0;
   border-bottom: 1px solid #e2e8f0;
-  color: #475569;
+  color: #374151;
+  font-size: 14px;
 }
 
 .notification-stats li:last-child {
   border-bottom: none;
+}
+
+.notif-badge {
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.notif-badge.sent {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.notif-badge.skipped {
+  background: #f3f4f6;
+  color: #6b7280;
 }
 
 .btn-primary {
@@ -333,6 +600,7 @@ body:has(.publish-panel-container) {
   padding: 12px 24px;
   border-radius: 8px;
   font-weight: 600;
+  font-size: 15px;
   cursor: pointer;
 }
 
@@ -340,9 +608,24 @@ body:has(.publish-panel-container) {
   opacity: 0.9;
 }
 
+/* ---- Responsive ---- */
+
 @media (max-width: 760px) {
   .publish-panel-container {
     padding: 22px 16px 36px;
+  }
+
+  .publish-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .wizard-steps {
+    padding: 14px 16px;
+  }
+
+  .wizard-step-label {
+    display: none;
   }
 
   .summary-cards,

--- a/frontend/src/pages/CoordinatorFinalGradePublishPanel.jsx
+++ b/frontend/src/pages/CoordinatorFinalGradePublishPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { getGroupApprovalSummary, publishFinalGrades } from '../api/finalGradeService';
 import './CoordinatorFinalGradePublishPanel.css';
@@ -21,6 +21,10 @@ const CoordinatorFinalGradePublishPanel = () => {
   const [publishResult, setPublishResult] = useState(null);
   const [publishError, setPublishError] = useState(null);
   const [publishErrorType, setPublishErrorType] = useState('general');
+  const publishButtonRef = useRef(null);
+  const modalContentRef = useRef(null);
+  const publishingRef = useRef(publishing);
+  const prevShowModalRef = useRef(showModal);
 
   useEffect(() => {
     loadSummary();
@@ -47,13 +51,85 @@ const CoordinatorFinalGradePublishPanel = () => {
 
   const canPublish = approvedCount > 0 && publishedCount === 0 && Boolean(publishCycle);
   const publishBlockedReason =
-    approvedCount === 0
-      ? 'No approved grades found yet. First generate a preview and approve grades.'
-      : publishedCount > 0
-        ? 'These grades are already published for this cycle.'
+    publishedCount > 0
+      ? 'These grades are already published for this cycle.'
+      : approvedCount === 0
+        ? 'No approved grades found yet. First generate a preview and approve grades.'
         : !publishCycle
-          ? 'Publish cycle is missing. Refresh the page and re-open from the approval flow.'
+          ? ''
           : 'A valid approval snapshot is required before publishing.';
+
+  useEffect(() => {
+    publishingRef.current = publishing;
+  }, [publishing]);
+
+  useEffect(() => {
+    if (!showModal) return undefined;
+
+    const modalElement = modalContentRef.current;
+    if (!modalElement) return undefined;
+
+    const getFocusable = () =>
+      modalElement.querySelectorAll(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+
+    const focusableElements = getFocusable();
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    } else {
+      modalElement.focus();
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (!publishingRef.current) {
+          setShowModal(false);
+          setPublishError(null);
+        }
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const updatedFocusable = getFocusable();
+      if (updatedFocusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = updatedFocusable[0];
+      const last = updatedFocusable[updatedFocusable.length - 1];
+      const active = document.activeElement;
+
+      if (!modalElement.contains(active)) {
+        event.preventDefault();
+        first.focus();
+        return;
+      }
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [showModal]);
+
+  useEffect(() => {
+    if (prevShowModalRef.current && !showModal) {
+      publishButtonRef.current?.focus();
+    }
+    prevShowModalRef.current = showModal;
+  }, [showModal]);
 
   const handlePublish = async () => {
     setPublishing(true);
@@ -208,6 +284,7 @@ const CoordinatorFinalGradePublishPanel = () => {
 
           <div className="publish-actions">
             <button
+              ref={publishButtonRef}
               className={`btn-publish${!canPublish ? ' disabled' : ''}`}
               onClick={() => setShowModal(true)}
               disabled={!canPublish}
@@ -241,7 +318,7 @@ const CoordinatorFinalGradePublishPanel = () => {
           aria-modal="true"
           aria-labelledby="modal-title"
         >
-          <div className="modal-content">
+          <div className="modal-content" ref={modalContentRef} tabIndex={-1}>
             <h2 id="modal-title">Confirm Publication</h2>
             <p>
               You are about to publish <strong>{approvedCount}</strong> approved grades for group{' '}

--- a/frontend/src/pages/CoordinatorFinalGradePublishPanel.jsx
+++ b/frontend/src/pages/CoordinatorFinalGradePublishPanel.jsx
@@ -11,13 +11,12 @@ const CoordinatorFinalGradePublishPanel = () => {
   const [summaryData, setSummaryData] = useState(null);
   const [error, setError] = useState(null);
 
-  // Publish Modal State
   const [showModal, setShowModal] = useState(false);
   const [publishCycle, setPublishCycle] = useState(null);
   const [notifyEmail, setNotifyEmail] = useState(true);
   const [notifySms, setNotifySms] = useState(false);
   const [notifyPush, setNotifyPush] = useState(false);
-  
+
   const [publishing, setPublishing] = useState(false);
   const [publishResult, setPublishResult] = useState(null);
   const [publishError, setPublishError] = useState(null);
@@ -47,13 +46,14 @@ const CoordinatorFinalGradePublishPanel = () => {
   const pendingCount = summaryData?.find((s) => s._id === 'pending')?.count || 0;
 
   const canPublish = approvedCount > 0 && publishedCount === 0 && Boolean(publishCycle);
-  const publishBlockedReason = approvedCount === 0
-    ? 'No approved grades found yet. First generate preview and approve grades.'
-    : publishedCount > 0
-      ? 'These grades are already published for this cycle.'
-      : !publishCycle
-        ? 'Publish cycle is missing. Refresh the page and re-open from approval flow.'
-        : 'A valid approval snapshot is required before publish.';
+  const publishBlockedReason =
+    approvedCount === 0
+      ? 'No approved grades found yet. First generate a preview and approve grades.'
+      : publishedCount > 0
+        ? 'These grades are already published for this cycle.'
+        : !publishCycle
+          ? 'Publish cycle is missing. Refresh the page and re-open from the approval flow.'
+          : 'A valid approval snapshot is required before publishing.';
 
   const handlePublish = async () => {
     setPublishing(true);
@@ -62,11 +62,7 @@ const CoordinatorFinalGradePublishPanel = () => {
     try {
       const payload = {
         publishCycle,
-        notificationFlags: {
-          email: notifyEmail,
-          sms: notifySms,
-          push: notifyPush
-        }
+        notificationFlags: { email: notifyEmail, sms: notifySms, push: notifyPush },
       };
       const result = await publishFinalGrades(groupId, payload);
       setPublishResult(result);
@@ -81,7 +77,6 @@ const CoordinatorFinalGradePublishPanel = () => {
             'The selected cycle does not match the approved records. Please refresh the page and try again.',
           DEFAULT: 'A conflict error occurred. Please verify the data and try again.',
         };
-
         if (errorCode === 'INCONSISTENT_CYCLE') {
           setPublishErrorType('cycle');
         }
@@ -99,23 +94,53 @@ const CoordinatorFinalGradePublishPanel = () => {
     return (
       <div className="publish-panel-container">
         <div className="publish-success-state">
-          <h2>🎉 Published Summary</h2>
-          <p>The final grades have been successfully published.</p>
+          <div className="publish-success-icon" aria-hidden="true">&#10003;</div>
+          <h2>Grades Published</h2>
+          <p>The final grades have been successfully published and students will be notified.</p>
           <div className="publish-stats">
-            <div><strong>Group:</strong> {publishResult.groupId}</div>
-            <div><strong>Cycle:</strong> {publishResult.publishCycle}</div>
-            <div><strong>Grades Published:</strong> {publishResult.publishedCount}</div>
-            <div><strong>Timestamp:</strong> {new Date(publishResult.publishedAt).toLocaleString()}</div>
+            <div>
+              <strong>Group</strong>
+              <span>{publishResult.groupId}</span>
+            </div>
+            <div>
+              <strong>Cycle</strong>
+              <span>{publishResult.publishCycle}</span>
+            </div>
+            <div>
+              <strong>Grades Published</strong>
+              <span>{publishResult.publishedCount}</span>
+            </div>
+            <div>
+              <strong>Published At</strong>
+              <span>{new Date(publishResult.publishedAt).toLocaleString()}</span>
+            </div>
           </div>
           <div className="notification-stats">
             <h3>Notification Status</h3>
             <ul>
-              <li>Email: {publishResult.notificationStatus?.email ? 'Sent' : 'Skipped'}</li>
-              <li>SMS: {publishResult.notificationStatus?.sms ? 'Sent' : 'Skipped'}</li>
-              <li>Push: {publishResult.notificationStatus?.push ? 'Sent' : 'Skipped'}</li>
+              <li>
+                <span>Email</span>
+                <span className={`notif-badge ${publishResult.notificationStatus?.email ? 'sent' : 'skipped'}`}>
+                  {publishResult.notificationStatus?.email ? 'Sent' : 'Skipped'}
+                </span>
+              </li>
+              <li>
+                <span>SMS</span>
+                <span className={`notif-badge ${publishResult.notificationStatus?.sms ? 'sent' : 'skipped'}`}>
+                  {publishResult.notificationStatus?.sms ? 'Sent' : 'Skipped'}
+                </span>
+              </li>
+              <li>
+                <span>Push</span>
+                <span className={`notif-badge ${publishResult.notificationStatus?.push ? 'sent' : 'skipped'}`}>
+                  {publishResult.notificationStatus?.push ? 'Sent' : 'Skipped'}
+                </span>
+              </li>
             </ul>
           </div>
-          <button className="btn-primary" onClick={() => navigate('/coordinator')}>Return to Dashboard</button>
+          <button className="btn-primary" onClick={() => navigate('/coordinator')}>
+            Return to Dashboard
+          </button>
         </div>
       </div>
     );
@@ -123,17 +148,49 @@ const CoordinatorFinalGradePublishPanel = () => {
 
   return (
     <div className="publish-panel-container">
+      <nav className="wizard-steps" aria-label="Publication steps">
+        <Link className="wizard-step completed" to={`/groups/${groupId}/final-grades/approval`}>
+          <span className="wizard-step-num" aria-hidden="true">1</span>
+          <span className="wizard-step-label">Review &amp; Approve</span>
+        </Link>
+        <div className="wizard-step-connector" aria-hidden="true" />
+        <div className="wizard-step active" aria-current="step">
+          <span className="wizard-step-num" aria-hidden="true">2</span>
+          <span className="wizard-step-label">Publish Grades</span>
+        </div>
+      </nav>
+
       <header className="publish-header">
-        <h1>Publish Final Grades</h1>
-        <p>Group {groupId}</p>
+        <div>
+          <p className="publish-kicker">Step 2 of 2 &mdash; Coordinator grade publication</p>
+          <h1>Publish Final Grades</h1>
+          <p>Group {groupId}</p>
+        </div>
+        <Link className="publish-back-link" to={`/groups/${groupId}/final-grades/approval`}>
+          &#8592; Back to Approval
+        </Link>
       </header>
 
-      {loading && <div className="loading-state">Loading summary...</div>}
-      
-      {!loading && error && <div className="error-state">{error}</div>}
+      {loading && (
+        <div className="loading-state">
+          <span className="loading-spinner" aria-hidden="true" />
+          Loading approval summary...
+        </div>
+      )}
+
+      {!loading && error && (
+        <div className="error-state" role="alert">
+          {error}
+        </div>
+      )}
 
       {!loading && !error && (
         <div className="summary-dashboard">
+          <p className="summary-description">
+            Review the grade counts below. All approved grades for this group will be published in a
+            single batch and students will be notified through the selected channels.
+          </p>
+
           <div className="summary-cards">
             <div className="card">
               <h3>Pending Approval</h3>
@@ -150,64 +207,100 @@ const CoordinatorFinalGradePublishPanel = () => {
           </div>
 
           <div className="publish-actions">
-            <button 
-              className={`btn-publish ${!canPublish ? 'disabled' : ''}`} 
+            <button
+              className={`btn-publish${!canPublish ? ' disabled' : ''}`}
               onClick={() => setShowModal(true)}
               disabled={!canPublish}
+              aria-describedby={!canPublish ? 'publish-blocked-hint' : undefined}
             >
               Publish Final Grades
             </button>
             {!canPublish && (
-              <p className="action-hint">
-                {publishBlockedReason}
-              </p>
-            )}
-            {!canPublish && (
-              <Link className="btn-publish" to={`/groups/${groupId}/final-grades/approval`}>
-                Go to Review & Approve
-              </Link>
+              <>
+                <p id="publish-blocked-hint" className="action-hint">
+                  {publishBlockedReason}
+                </p>
+                {publishedCount === 0 && (
+                  <Link
+                    className="btn-secondary-link"
+                    to={`/groups/${groupId}/final-grades/approval`}
+                  >
+                    Go to Review &amp; Approve
+                  </Link>
+                )}
+              </>
             )}
           </div>
         </div>
       )}
 
       {showModal && (
-        <div className="modal-overlay">
+        <div
+          className="modal-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="modal-title"
+        >
           <div className="modal-content">
-            <h2>Confirm Publication</h2>
-            <p>You are about to publish <strong>{approvedCount}</strong> approved grades for group {groupId}.</p>
-            
+            <h2 id="modal-title">Confirm Publication</h2>
+            <p>
+              You are about to publish <strong>{approvedCount}</strong> approved grades for group{' '}
+              {groupId}. This action cannot be undone.
+            </p>
+
             <div className="form-group">
               <label>Publish Cycle</label>
               <div className="readonly-value">{publishCycle || 'Not available'}</div>
             </div>
 
             <div className="notification-options">
+              <p className="notification-options-label">Notify students via:</p>
               <label className="checkbox-label">
-                <input type="checkbox" checked={notifyEmail} onChange={(e) => setNotifyEmail(e.target.checked)} />
-                Send Email Notifications
+                <input
+                  type="checkbox"
+                  checked={notifyEmail}
+                  onChange={(e) => setNotifyEmail(e.target.checked)}
+                />
+                Email
               </label>
               <label className="checkbox-label">
-                <input type="checkbox" checked={notifySms} onChange={(e) => setNotifySms(e.target.checked)} />
-                Send SMS Notifications
+                <input
+                  type="checkbox"
+                  checked={notifySms}
+                  onChange={(e) => setNotifySms(e.target.checked)}
+                />
+                SMS
               </label>
               <label className="checkbox-label">
-                <input type="checkbox" checked={notifyPush} onChange={(e) => setNotifyPush(e.target.checked)} />
-                Send Push Notifications
+                <input
+                  type="checkbox"
+                  checked={notifyPush}
+                  onChange={(e) => setNotifyPush(e.target.checked)}
+                />
+                Push Notification
               </label>
             </div>
 
             {publishError && (
-              <div className={`error-message ${publishErrorType === 'cycle' ? 'error-message-warning' : ''}`}>
+              <div
+                className={`error-message${publishErrorType === 'cycle' ? ' error-message-warning' : ''}`}
+                role="alert"
+              >
                 <span className="error-icon" aria-hidden="true">
-                  {publishErrorType === 'cycle' ? '⚠️' : '❌'}
+                  {publishErrorType === 'cycle' ? '!' : '×'}
                 </span>
                 <span>{publishError}</span>
               </div>
             )}
 
             <div className="modal-actions">
-              <button className="btn-cancel" onClick={() => setShowModal(false)} disabled={publishing}>Cancel</button>
+              <button
+                className="btn-cancel"
+                onClick={() => setShowModal(false)}
+                disabled={publishing}
+              >
+                Cancel
+              </button>
               <button className="btn-confirm" onClick={handlePublish} disabled={publishing}>
                 {publishing ? 'Publishing...' : 'Confirm & Publish'}
               </button>


### PR DESCRIPTION
## Summary

Closes #360

The Publish Wizard had several UI/UX issues that made its purpose unclear and its visual design inconsistent with the rest of the app. This PR addresses all of them.

## Changes

### CoordinatorFinalGradePublishPanel.jsx
- Added a two-step wizard progress indicator (`Review & Approve → Publish Grades`) so users understand where they are in the flow
- Added a "Step 2 of 2" kicker and "Back to Approval" link in the page header
- Replaced the "Go to Review & Approve" link (which incorrectly shared the `btn-publish` class with the disabled Publish button) with a visually distinct `btn-secondary-link`
- The "Go to Approve" shortcut is now hidden when grades are already published (previously shown in all blocked states, even when it made no sense)
- Improved success state: replaced emoji heading with a CSS checkmark icon and added notification status badges
- Replaced emoji error icons (`⚠️`, `❌`) with plain text characters consistent with the app style
- Added `role="dialog"` and `aria-modal` to the confirmation modal

### CoordinatorFinalGradePublishPanel.css
- **Bug fix:** `.btn-publish.disabled` used `background-color: #9ca3af` which cannot override a `background: linear-gradient(...)` — the disabled button was still showing the purple gradient. Fixed to `background: #9ca3af`
- Added wizard step indicator styles with completed/active states
- Added `.btn-secondary-link` (outlined violet), `.publish-back-link`, `.publish-kicker`, `.loading-spinner` (animated), `.notif-badge` styles
- Improved success stat grid to show label/value column pairs

### CoordinatorFinalGradeApprovalPanel.jsx
- Kicker updated to "Step 1 of 2 — Coordinator final grade approval"
- "Publish wizard" header link renamed to "Next: Publish Grades →" for clarity

### CoordinatorFinalGradePublishPanel.test.jsx
- Wrapped all `render()` calls in `MemoryRouter` (required now that `<Link>` elements render unconditionally in the wizard banner and header)
- Removed stale emoji character assertions; behavioral coverage is preserved through CSS class checks
- Updated `Published Summary` text references to match the new `Grades Published` heading
