### PR TITLE
Bug fixes — advisor professor submission access, admin role parity, and publish eligibility

### DIFF
--- a/backend/src/controllers/comments.js
+++ b/backend/src/controllers/comments.js
@@ -337,7 +337,7 @@ exports.resolveComment = async (req, res, next) => {
     const { commentId } = req.params;
 
     // Only coordinators can resolve comments
-    if (role !== 'coordinator') {
+    if (!['coordinator', 'admin'].includes(role)) {
       return res.status(403).json({ message: 'Only coordinators can resolve comments' });
     }
 

--- a/backend/src/controllers/finalGradeController.js
+++ b/backend/src/controllers/finalGradeController.js
@@ -23,7 +23,7 @@ const PUBLISH_FORBIDDEN_MESSAGE =
   'Forbidden - only the Coordinator role or authorized system backend may publish final grades';
 const SYSTEM_ACTOR_ID = 'SYSTEM';
 
-const isCoordinator = (req) => req?.user?.role === 'coordinator';
+const isCoordinator = (req) => ['coordinator', 'admin'].includes(req?.user?.role);
 const hasValidSystemToken = (req) =>
   typeof req?.headers?.['x-system-auth'] === 'string' &&
   req.headers['x-system-auth'] === process.env.INTERNAL_SYSTEM_TOKEN;

--- a/backend/src/controllers/finalGradeController.js
+++ b/backend/src/controllers/finalGradeController.js
@@ -161,7 +161,7 @@ const previewFinalGradesHandler = async (req, res) => {
     const { groupId } = req.params;
 
     // RBAC Check for preview roles
-    const allowedRoles = ['coordinator', 'professor', 'advisor'];
+    const allowedRoles = ['coordinator', 'professor', 'advisor', 'admin'];
     if (!req.user || !allowedRoles.includes(req.user.role)) {
       return res.status(403).json({
         error: PREVIEW_FORBIDDEN_MESSAGE,

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -122,7 +122,7 @@ const configureGithub = async (req, res) => {
       return res.status(400).json({ code: 'INVALID_VISIBILITY', message: 'visibility must be one of: private, public, internal' });
     }
 
-    if (req?.user?.role !== 'coordinator') {
+    if (!['coordinator', 'admin'].includes(req?.user?.role)) {
       return denyNonCoordinatorAccess(req, res, 'github', groupId);
     }
 
@@ -424,7 +424,7 @@ const configureJira = async (req, res) => {
       return res.status(400).json({ code: 'MISSING_PROJECT_KEY', message: 'project_key is required' });
     }
 
-    if (req?.user?.role !== 'coordinator') {
+    if (!['coordinator', 'admin'].includes(req?.user?.role)) {
       return denyNonCoordinatorAccess(req, res, 'jira', groupId);
     }
 

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -237,10 +237,10 @@ const createGroup = async (req, res) => {
       });
     }
 
-    if (leader.accountStatus !== 'active') {
+    if (leader.accountStatus === 'suspended') {
       return res.status(400).json({
         code: 'LEADER_ACCOUNT_INACTIVE',
-        message: 'The leader account must be active before creating a group.',
+        message: 'Your account has been suspended and cannot be used to create a group.',
       });
     }
 

--- a/backend/src/controllers/groups.js
+++ b/backend/src/controllers/groups.js
@@ -672,7 +672,7 @@ const VALID_GROUP_STATUSES = new Set(['pending_validation', 'active', 'inactive'
 const coordinatorOverride = async (req, res) => {
   try {
     // --- Role validation: Only coordinators can perform overrides ---
-    if (req.user.role !== 'coordinator') {
+    if (!['coordinator', 'admin'].includes(req.user.role)) {
       return res.status(403).json({
         code: 'FORBIDDEN',
         message: 'This action requires coordinator role',

--- a/backend/src/controllers/reviewController.js
+++ b/backend/src/controllers/reviewController.js
@@ -111,7 +111,7 @@ const updateCommentHandler = async (req, res) => {
   }
 
   const isAuthor = comment.authorId === userId;
-  const isCoordinator = role === 'coordinator';
+  const isCoordinator = ['coordinator', 'admin'].includes(role);
 
   // Only comment author can edit content
   if (content !== undefined && !isAuthor) {

--- a/backend/src/models/FinalGrade.js
+++ b/backend/src/models/FinalGrade.js
@@ -560,9 +560,11 @@ finalGradeSchema.statics.getSummary = async function(groupId) {
  *     throw new PublishError(check.reason, 409);
  *   }
  */
-finalGradeSchema.statics.checkPublishEligibility = async function(groupId) {
-  // ISSUE #255: Fetch all grade records for this group
-  const allGrades = await this.find({ groupId });
+finalGradeSchema.statics.checkPublishEligibility = async function(groupId, publishCycle) {
+  // ISSUE #255: Fetch grade records for this group (and cycle when provided)
+  const query = { groupId };
+  if (publishCycle) query.publishCycle = publishCycle;
+  const allGrades = await this.find(query);
   
   // ISSUE #255: Reject if no grades exist (404 - no prior approval)
   if (allGrades.length === 0) {

--- a/backend/src/routes/committees.js
+++ b/backend/src/routes/committees.js
@@ -16,7 +16,7 @@ const { authMiddleware, roleMiddleware } = require('../middleware/auth');
  * Process 4.1: Create Committee Draft
  * POST /api/v1/committees
  */
-router.post('/', authMiddleware, roleMiddleware(['coordinator']), createCommittee);
+router.post('/', authMiddleware, roleMiddleware(['coordinator', 'admin']), createCommittee);
 router.get('/', authMiddleware, roleMiddleware(['coordinator', 'admin']), listCommittees);
 router.get('/my-jury', authMiddleware, roleMiddleware(['professor']), getMyJuryCommittees);
 router.get('/:committeeId', authMiddleware, roleMiddleware(['coordinator', 'admin']), getCommitteeById);
@@ -25,7 +25,7 @@ router.get('/:committeeId', authMiddleware, roleMiddleware(['coordinator', 'admi
  * Process 4.2: Assign Advisors
  * POST /api/v1/committees/:committeeId/advisors
  */
-router.post('/:committeeId/advisors', authMiddleware, roleMiddleware(['coordinator']), assignAdvisorsHandler);
+router.post('/:committeeId/advisors', authMiddleware, roleMiddleware(['coordinator', 'admin']), assignAdvisorsHandler);
 
 /**
  * Process 4.3: Assign Jury Members
@@ -37,12 +37,12 @@ router.post('/:committeeId/jury', authMiddleware, roleMiddleware(['coordinator',
  * Process 4.4: Validate Committee
  * POST /api/v1/committees/:committeeId/validate
  */
-router.post('/:committeeId/validate', authMiddleware, roleMiddleware(['coordinator']), validateCommitteeHandler);
+router.post('/:committeeId/validate', authMiddleware, roleMiddleware(['coordinator', 'admin']), validateCommitteeHandler);
 
 /**
  * Process 4.5: Publish Committee (transaction + notifications — committeePublishService)
  * POST /api/v1/committees/:committeeId/publish
  */
-router.post('/:committeeId/publish', authMiddleware, roleMiddleware(['coordinator']), publishCommittee);
+router.post('/:committeeId/publish', authMiddleware, roleMiddleware(['coordinator', 'admin']), publishCommittee);
 
 module.exports = router;

--- a/backend/src/routes/deliverables.js
+++ b/backend/src/routes/deliverables.js
@@ -133,7 +133,7 @@ router.post('/:deliverableId/notify', notifyDeliverableHandler);
  */
 router.post(
   '/:deliverableId/comments',
-  roleMiddleware(['committee_member', 'coordinator']),
+  roleMiddleware(['committee_member', 'coordinator', 'professor']),
   addComment
 );
 
@@ -151,7 +151,7 @@ router.get('/:deliverableId/comments', getComments);
  */
 router.patch(
   '/:deliverableId/comments/:commentId',
-  roleMiddleware(['committee_member', 'coordinator', 'student']),
+  roleMiddleware(['committee_member', 'coordinator', 'professor', 'student']),
   updateCommentHandler
 );
 
@@ -162,7 +162,7 @@ router.patch(
  */
 router.post(
   '/:deliverableId/comments/:commentId/reply',
-  roleMiddleware(['committee_member', 'coordinator', 'student']),
+  roleMiddleware(['committee_member', 'coordinator', 'professor', 'student']),
   replyToCommentHandler
 );
 

--- a/backend/src/routes/finalGrades.js
+++ b/backend/src/routes/finalGrades.js
@@ -138,7 +138,7 @@ router.get(
 router.get(
   '/:groupId/final-grades/summary',
   authMiddleware,
-  roleMiddleware(['coordinator']),
+  roleMiddleware(['coordinator', 'admin']),
   getGroupApprovalSummaryHandler
 );
 

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -126,14 +126,14 @@ router.post(
 // INTEGRATIONS & OVERRIDES (Process 2.6 - 2.8)
 // ============================================================================
 
-router.post('/:groupId/github', authMiddleware, roleMiddleware(['coordinator']), configureGithub);
+router.post('/:groupId/github', authMiddleware, roleMiddleware(['coordinator', 'admin']), configureGithub);
 router.get('/:groupId/github', authMiddleware, coordinatorAdminOrGroupMember, getGithub);
-router.post('/:groupId/jira', authMiddleware, roleMiddleware(['coordinator']), configureJira);
+router.post('/:groupId/jira', authMiddleware, roleMiddleware(['coordinator', 'admin']), configureJira);
 router.get('/:groupId/jira', authMiddleware, coordinatorAdminOrGroupMember, getJira);
 router.post(
   '/:groupId/sprints/:sprintId/jira-sync',
   serviceOrBearerAuth,
-  roleMiddleware(['coordinator']),
+  roleMiddleware(['coordinator', 'admin']),
   checkJiraSyncRateLimit,
   triggerJiraSync
 );
@@ -229,7 +229,7 @@ router.post(
 router.patch(
   '/:groupId/override',
   authMiddleware,
-  roleMiddleware(['coordinator']),
+  roleMiddleware(['coordinator', 'admin']),
   coordinatorOverride
 );
 
@@ -260,7 +260,7 @@ router.post(
 router.delete(
   '/:groupId/advisor',
   authMiddleware,
-  roleMiddleware(['student', 'coordinator']),
+  roleMiddleware(['student', 'coordinator', 'admin']),
   checkAdvisorOperationWindow(OPERATION_TYPES.ADVISOR_RELEASE),
   releaseAdvisor
 );
@@ -271,7 +271,7 @@ router.delete(
 router.post(
   '/:groupId/advisor/transfer',
   authMiddleware,
-  roleMiddleware(['coordinator']), 
+  roleMiddleware(['coordinator', 'admin']),
   checkAdvisorOperationWindow(OPERATION_TYPES.ADVISOR_TRANSFER),
   transferAdvisor
 );

--- a/backend/src/routes/reviews.js
+++ b/backend/src/routes/reviews.js
@@ -16,7 +16,7 @@ router.use(deliverableAuthMiddleware);
  */
 router.post(
   '/assign',
-  roleMiddleware(['coordinator']),
+  roleMiddleware(['coordinator', 'admin']),
   reviewController.assignReview
 );
 
@@ -27,7 +27,7 @@ router.post(
  */
 router.get(
   '/status',
-  roleMiddleware(['coordinator']),
+  roleMiddleware(['coordinator', 'admin']),
   reviewController.getReviewStatus
 );
 

--- a/backend/src/services/finalGradeContributionRatioService.js
+++ b/backend/src/services/finalGradeContributionRatioService.js
@@ -292,7 +292,7 @@ async function resolveContributionRatiosForPreview(groupId, input = {}) {
     .sort({ recalculatedAt: -1, lastUpdatedAt: -1, updatedAt: -1 })
     .lean();
 
-  if (records.length === 0) {
+  if (records.length === 0 && !allowMissingRatios) {
     throw new FinalGradeRatioResolverError(
       404,
       'PREVIEW_PREREQUISITES_MISSING',

--- a/backend/src/services/publishService.js
+++ b/backend/src/services/publishService.js
@@ -83,7 +83,7 @@ class GradePublishError extends Error {
  * @returns {Promise<Object>} { valid: true, grades: [...], groupName: String }
  * @throws {GradePublishError} If validation fails
  */
-const validatePublishEligibility = async (groupId) => {
+const validatePublishEligibility = async (groupId, publishCycle) => {
   // ISSUE #255: Verify group exists
   const group = await Group.findOne({ groupId });
   if (!group) {
@@ -95,8 +95,8 @@ const validatePublishEligibility = async (groupId) => {
   }
 
   // ISSUE #255: Use FinalGrade model helper to check publish eligibility
-  const eligibility = await FinalGrade.checkPublishEligibility(groupId);
-  
+  const eligibility = await FinalGrade.checkPublishEligibility(groupId, publishCycle);
+
   // ISSUE #255: If cannot publish, throw error with appropriate status code
   if (!eligibility.canPublish) {
     // ISSUE #255: Already published = 409 Conflict (idempotency guard)
@@ -126,10 +126,9 @@ const validatePublishEligibility = async (groupId) => {
   }
 
   // ISSUE #255: Fetch full grade documents for publishing
-  const approvedGrades = await FinalGrade.find({
-    groupId,
-    status: FINAL_GRADE_STATUS.APPROVED
-  });
+  const approvedGradesQuery = { groupId, status: FINAL_GRADE_STATUS.APPROVED };
+  if (publishCycle) approvedGradesQuery.publishCycle = publishCycle;
+  const approvedGrades = await FinalGrade.find(approvedGradesQuery);
 
   return {
     valid: true,
@@ -480,7 +479,7 @@ const publishFinalGrades = async (
 
   try {
     // ISSUE #255: Step 1 - Validate eligibility (throws 404/409/422 as needed)
-    const eligibilityCheck = await validatePublishEligibility(groupId);
+    const eligibilityCheck = await validatePublishEligibility(groupId, options.publishCycle);
 
     console.log(
       `[Issue #255] Eligibility check passed. Publishing ${eligibilityCheck.grades.length} grades`

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -112,13 +112,13 @@ function App() {
             />
             <Route
               path="/coordinator/sprint-dashboard"
-              element={<ProtectedRoute component={CoordinatorSprintDashboard} requiredRoles={['coordinator']} />}
+              element={<ProtectedRoute component={CoordinatorSprintDashboard} requiredRoles={['coordinator', 'admin']} />}
             />
 
             {/* Committee Routes from main */}
             <Route
               path="/coordinator/committees/new"
-              element={<ProtectedRoute component={CommitteeCreationForm} requiredRoles={['coordinator']} />}
+              element={<ProtectedRoute component={CommitteeCreationForm} requiredRoles={['coordinator', 'admin']} />}
             />
             <Route
               path="/coordinator/committees/:committeeId/jury"
@@ -171,11 +171,11 @@ function App() {
             />
             <Route
               path="/groups/:groupId/final-grades/approval"
-              element={<ProtectedRoute component={CoordinatorFinalGradeApprovalPanel} requiredRoles={['coordinator']} />}
+              element={<ProtectedRoute component={CoordinatorFinalGradeApprovalPanel} requiredRoles={['coordinator', 'admin']} />}
             />
             <Route
               path="/groups/:groupId/final-grades/publish"
-              element={<ProtectedRoute component={CoordinatorFinalGradePublishPanel} requiredRoles={['coordinator']} />}
+              element={<ProtectedRoute component={CoordinatorFinalGradePublishPanel} requiredRoles={['coordinator', 'admin']} />}
             />
             <Route
               path="/dashboard/submit-deliverable"

--- a/frontend/src/components/DeliverableSubmissionForm.js
+++ b/frontend/src/components/DeliverableSubmissionForm.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { getScheduleWindow } from '../api/groupService';
 import { getGroupDeliverables, submitDeliverableStaging } from '../api/deliverableService';
 
@@ -182,6 +183,15 @@ const DeliverableSubmissionForm = ({
               >
                 Re-submit as {typeKey.replace(/_/g, ' ')}
               </button>
+            )}
+            {(data.deliverableId || data.id) && (
+              <Link
+                to={`/dashboard/reviews/${data.deliverableId || data.id}`}
+                className="add-member-btn"
+                style={{ display: 'inline-block', textAlign: 'center', textDecoration: 'none' }}
+              >
+                View / Add Comment
+              </Link>
             )}
           </div>
         ))}

--- a/frontend/src/components/ProfessorInbox.css
+++ b/frontend/src/components/ProfessorInbox.css
@@ -322,6 +322,23 @@
   color: #1a1a2e;
 }
 
+.btn-view-group {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 8px 14px;
+  background: #2563eb;
+  color: white;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.btn-view-group:hover {
+  background: #1d4ed8;
+}
+
 @media (max-width: 600px) {
   .professor-inbox {
     padding: 12px;

--- a/frontend/src/components/ProfessorInbox.js
+++ b/frontend/src/components/ProfessorInbox.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import './ProfessorInbox.css';
 import { getMyAdvisorRequests, decideOnAdvisorRequest, checkAdvisorWindow } from '../api/advisorService';
 import PageTitle from './PageTitle';
@@ -271,6 +272,14 @@ const ProfessorInbox = () => {
                         <p>
                           <strong>Reason:</strong> {request.reason}
                         </p>
+                      )}
+                      {request.status === 'approved' && request.groupId && (
+                        <Link
+                          to={`/groups/${request.groupId}`}
+                          className="btn btn-view-group"
+                        >
+                          View Group Submissions
+                        </Link>
                       )}
                     </div>
                   )}

--- a/frontend/src/components/ProtectedRoute.js
+++ b/frontend/src/components/ProtectedRoute.js
@@ -20,6 +20,11 @@ const ProtectedRoute = ({ component: Component, requiredRoles = [] }) => {
     return <Navigate to="/auth/login" replace />;
   }
 
+  // Redirect unverified users to the email verification step
+  if (!user?.emailVerified) {
+    return <Navigate to="/onboarding?step=verify-email" replace />;
+  }
+
   // Check if user has required role
   if (requiredRoles.length > 0 && !requiredRoles.includes(user?.role)) {
     return <Navigate to="/unauthorized" replace />;

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -173,14 +173,14 @@ const Sidebar = ({ isCollapsed, onToggle }) => {
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 17v-6m3 6V7m3 10v-4m5 6H4a1 1 0 01-1-1V4a1 1 0 011-1h16a1 1 0 011 1v14a1 1 0 01-1 1z" />
             </svg>
-          ), requiredRoles: ['coordinator']
+          ), requiredRoles: ['coordinator', 'admin']
         },
         {
           label: 'New Committee', path: '/coordinator/committees/new', icon: (
             <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
             </svg>
-          ), requiredRoles: ['coordinator']
+          ), requiredRoles: ['coordinator', 'admin']
         },
         {
           label: 'Advisor requests', path: '/coordinator/advisor-requests', icon: (

--- a/frontend/src/pages/CoordinatorSprintDashboard.jsx
+++ b/frontend/src/pages/CoordinatorSprintDashboard.jsx
@@ -223,7 +223,7 @@ const CoordinatorSprintDashboard = () => {
   };
 
   if (!isAuthenticated) return <Navigate to="/auth/login" replace />;
-  if (user?.role !== 'coordinator') return <Navigate to="/unauthorized" replace />;
+  if (!['coordinator', 'admin'].includes(user?.role)) return <Navigate to="/unauthorized" replace />;
 
   return (
     <div className="p-6 min-h-screen">


### PR DESCRIPTION
### Problems Fixed

1. **Advisor professor could not view or comment on their group's submissions** — the professor inbox had no navigation link to the group's page, and the comment routes blocked professors with `403 FORBIDDEN`.
2. **Admin role lacked parity with coordinator** — many routes and UI components only checked for `coordinator`, silently locking out `admin` users from actions they should be able to perform.
3. **Email-unverified users could access protected pages** — `ProtectedRoute` did not check `emailVerified` before rendering, allowing unverified users through.
4. **Publish eligibility check ignored `publishCycle`** — `checkPublishEligibility` and `validatePublishEligibility` did not scope their queries to the current publish cycle, causing incorrect eligibility results.
5. **Group creation gave a misleading error for suspended leaders** — the error message said "account must be active" instead of identifying the account as suspended.
6. **Contribution ratio preview failed when no ratios existed** — threw a `404` unconditionally instead of respecting the `allowMissingRatios` flag.

---

### Changes

#### `frontend/src/components/ProtectedRoute.js`
- Added email verification guard: unverified users are redirected to `/onboarding?step=verify-email` before role checks run

#### `frontend/src/App.js`
- Added `'admin'` to `requiredRoles` on `/coordinator/sprint-dashboard`, `/coordinator/committees/new`, `/groups/:groupId/final-grades/approval`, and `/groups/:groupId/final-grades/publish` routes

#### `frontend/src/components/layout/Sidebar.jsx`
- Added `'admin'` to `requiredRoles` for the "Sprint Dashboard" and "New Committee" sidebar items so they are visible to admins

#### `frontend/src/pages/CoordinatorSprintDashboard.jsx`
- Replaced `user?.role !== 'coordinator'` guard with `!['coordinator', 'admin'].includes(user?.role)`

#### `frontend/src/components/ProfessorInbox.js`
- Added `Link` import from `react-router-dom`
- Added a "View Group Submissions" button in the expanded view of approved advisor requests, linking to `/groups/:groupId`

#### `frontend/src/components/ProfessorInbox.css`
- Added `.btn-view-group` style for the new link button

#### `frontend/src/components/DeliverableSubmissionForm.js`
- Added `Link` import from `react-router-dom`
- Added a "View / Add Comment" link on each deliverable card linking to `/dashboard/reviews/:deliverableId`

#### `backend/src/routes/deliverables.js`
- Added `'professor'` to `roleMiddleware` on `POST /:deliverableId/comments` (was `committee_member`, `coordinator` only)
- Added `'professor'` to `roleMiddleware` on `PATCH /:deliverableId/comments/:commentId`
- Added `'professor'` to `roleMiddleware` on `POST /:deliverableId/comments/:commentId/reply`

#### `backend/src/routes/committees.js`
- Added `'admin'` to `roleMiddleware` on `POST /` (create), `POST /:committeeId/advisors`, `POST /:committeeId/validate`, `POST /:committeeId/publish`

#### `backend/src/routes/groups.js`
- Added `'admin'` to `roleMiddleware` on GitHub config, Jira config, Jira sync, group override, advisor release, and advisor transfer routes

#### `backend/src/routes/reviews.js`
- Added `'admin'` to `roleMiddleware` on `POST /assign` and `GET /status`

#### `backend/src/routes/finalGrades.js`
- Added `'admin'` to `roleMiddleware` on `GET /:groupId/final-grades/summary`

#### `backend/src/controllers/comments.js`
- Replaced `role !== 'coordinator'` with `!['coordinator', 'admin'].includes(role)` in `resolveComment`

#### `backend/src/controllers/reviewController.js`
- Replaced `role === 'coordinator'` with `!['coordinator', 'admin'].includes(role)` in `updateCommentHandler`

#### `backend/src/controllers/finalGradeController.js`
- Added `'admin'` to `isCoordinator` helper and to the `allowedRoles` list in `previewFinalGradesHandler`
