### PR TITLE
feat: add mock GitHub and Jira integration for development

### DIFF
--- a/backend/scripts/seed-test-general.js
+++ b/backend/scripts/seed-test-general.js
@@ -20,18 +20,19 @@ const SprintConfig      = require('../src/models/SprintConfig');
 // Utilities
 const { hashPassword }        = require('../src/utils/password');
 const { generateAccessToken } = require('../src/utils/jwt');
+const { encrypt }             = require('../src/utils/cryptoUtils');
 
 const MONGO_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/senior-app';
 
 // Test user credentials
 const TEST_USERS = {
-  student1: { email: 'alice.student@example.edu.tr', password: 'Test@1234' },
-  student2: { email: 'bob.student@example.edu.tr', password: 'Test@1234' },
-  student3: { email: 'charlie.student@example.edu.tr', password: 'Test@1234' },
-  professor: { email: 'prof.advisor@example.edu.tr', password: 'Test@1234' },
-  professor2: { email: 'prof.transfer@example.edu.tr', password: 'Test@1234' },
-  coordinator: { email: 'coord.admin@example.edu.tr', password: 'Test@1234' },
-  admin: { email: 'system.admin@example.edu.tr', password: 'Test@1234' },
+  student1:    { email: 'alice.student@example.edu.tr',  password: 'Test@1234', githubId: '10000001', githubUsername: 'alice-student'    },
+  student2:    { email: 'bob.student@example.edu.tr',    password: 'Test@1234', githubId: '10000002', githubUsername: 'bob-student'      },
+  student3:    { email: 'charlie.student@example.edu.tr',password: 'Test@1234', githubId: '10000003', githubUsername: 'charlie-student'  },
+  professor:   { email: 'prof.advisor@example.edu.tr',   password: 'Test@1234', githubId: '10000004', githubUsername: 'prof-advisor'     },
+  professor2:  { email: 'prof.transfer@example.edu.tr',  password: 'Test@1234', githubId: '10000005', githubUsername: 'prof-transfer'    },
+  coordinator: { email: 'coord.admin@example.edu.tr',    password: 'Test@1234', githubId: '10000006', githubUsername: 'coord-admin'      },
+  admin:       { email: 'system.admin@example.edu.tr',   password: 'Test@1234', githubId: '10000007', githubUsername: 'system-admin'     },
 };
 
 // Helper to generate IDs
@@ -57,6 +58,8 @@ async function seedUsers() {
       role: userRole,
       emailVerified: true,
       accountStatus: 'active',
+      githubId: creds.githubId,
+      githubUsername: creds.githubUsername,
     });
 
     users[role] = user;
@@ -101,6 +104,9 @@ async function seedGroups(users, committees) {
 
   const groups = [];
 
+  const MOCK_JIRA_HOST = 'https://mock.atlassian.net';
+  const MOCK_JIRA_KEY  = 'MOCK';
+
   // Group 1: Alice as leader, Bob as member — advisor assigned (transfer target test)
   const group1 = await Group.create({
     groupId: generateId('grp'),
@@ -117,6 +123,16 @@ async function seedGroups(users, committees) {
       { userId: users.student1.userId, role: 'leader', status: 'accepted' },
       { userId: users.student2.userId, role: 'member', status: 'accepted' },
     ],
+    // Pre-configured Jira integration (mock)
+    jiraUrl:          MOCK_JIRA_HOST,
+    jiraUsername:     'jira@mock.dev',
+    jiraToken:        encrypt('mock-jira-api-token-dev-only'),
+    projectKey:       MOCK_JIRA_KEY,
+    jiraProjectId:    '10001',
+    jiraProject:      'Mock Project Alpha',
+    jiraBoardUrl:     `${MOCK_JIRA_HOST}/jira/software/projects/${MOCK_JIRA_KEY}/boards`,
+    jiraLastSynced:   new Date(),
+    jiraStoryPointOnly: true,
   });
   groups.push(group1);
   console.log(`  ✓ Created group: ${group1.groupName}`);
@@ -132,6 +148,16 @@ async function seedGroups(users, committees) {
     members: [
       { userId: users.student3.userId, role: 'leader', status: 'accepted' },
     ],
+    // Pre-configured Jira integration (mock)
+    jiraUrl:          MOCK_JIRA_HOST,
+    jiraUsername:     'jira@mock.dev',
+    jiraToken:        encrypt('mock-jira-api-token-dev-only'),
+    projectKey:       MOCK_JIRA_KEY,
+    jiraProjectId:    '10002',
+    jiraProject:      'Mock Project Beta',
+    jiraBoardUrl:     `${MOCK_JIRA_HOST}/jira/software/projects/${MOCK_JIRA_KEY}/boards`,
+    jiraLastSynced:   new Date(),
+    jiraStoryPointOnly: true,
   });
   groups.push(group2);
   console.log(`  ✓ Created group: ${group2.groupName}`);
@@ -349,8 +375,9 @@ async function run() {
     // Clean up previous test data
     console.log('🧹 Cleaning up previous test data...');
     const testEmails = Object.values(TEST_USERS).map((u) => u.email);
+    const testGithubIds = Object.values(TEST_USERS).map((u) => u.githubId);
 
-    await User.deleteMany({ email: { $in: testEmails } });
+    await User.deleteMany({ $or: [{ email: { $in: testEmails } }, { githubId: { $in: testGithubIds } }] });
     await Group.deleteMany({ groupName: { $in: ['Project Alpha Team', 'Project Beta Team'] } });
     await Committee.deleteMany({ createdBy: 'seed-test-general' });
     await ScheduleWindow.deleteMany({ createdBy: 'seed-test-general' });
@@ -417,14 +444,14 @@ async function run() {
     console.log(sep);
     for (const [role, user] of Object.entries(users)) {
       const creds = TEST_USERS[role];
-      console.log(`  ${role.toUpperCase().padEnd(12)} | userId: ${user.userId.padEnd(16)} | email: ${creds.email}  pw: ${creds.password}`);
+      console.log(`  ${role.toUpperCase().padEnd(12)} | userId: ${user.userId.padEnd(16)} | email: ${creds.email}  pw: ${creds.password}  github: ${creds.githubId} (${creds.githubUsername})`);
     }
 
     // Groups
     console.log(`\n🏢 GROUPS`);
     console.log(sep);
     for (const g of groups) {
-      console.log(`  ${g.groupName.padEnd(22)} | groupId: ${g.groupId}`);
+      console.log(`  ${g.groupName.padEnd(22)} | groupId: ${g.groupId}  | jira: ${g.projectKey} @ ${g.jiraUrl}`);
     }
 
     // Deliverables + Reviews

--- a/backend/src/controllers/auth.js
+++ b/backend/src/controllers/auth.js
@@ -696,6 +696,86 @@ const githubOAuthCallback = async (req, res) => {
 };
 
 /**
+ * DEV-ONLY: Mock GitHub OAuth login — bypasses real GitHub API.
+ * GET /api/v1/auth/github/oauth/mock-login?githubId=<id>
+ * Finds the user by githubId and redirects to the frontend callback URL with
+ * a real JWT pair, exactly like the production flow would.
+ * Returns 404 in production.
+ */
+const mockGithubLogin = async (req, res) => {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).json({ message: 'Not found' });
+  }
+
+  const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:3000';
+  const callbackBase = `${frontendUrl}/auth/github/callback`;
+  const redirectError = (code) =>
+    res.redirect(`${callbackBase}?error=${encodeURIComponent(code)}`);
+
+  try {
+    const { githubId } = req.query;
+    if (!githubId) {
+      return redirectError('MISSING_PARAMS');
+    }
+
+    const user = await User.findOne({ githubId });
+    if (!user) {
+      return redirectError('GITHUB_NOT_LINKED');
+    }
+
+    if (user.lockedUntil && user.lockedUntil > new Date()) {
+      return redirectError('ACCOUNT_LOCKED');
+    }
+
+    if (user.accountStatus === 'suspended') {
+      return redirectError('ACCOUNT_SUSPENDED');
+    }
+
+    user.loginAttempts = 0;
+    user.lockedUntil = null;
+    user.lastLogin = new Date();
+    await user.save();
+
+    const tokens = generateTokenPair(user.userId, user.role);
+
+    let groupId = null;
+    if (user.role === 'student') {
+      groupId = await resolveStudentAffiliatedGroupId(user.userId, {
+        statusIn: ['active', 'pending_validation'],
+      });
+    }
+
+    const refreshTokenDoc = new RefreshToken({
+      userId: user.userId,
+      token: tokens.refreshToken,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+      userAgent: req.headers['user-agent'],
+      ipAddress: req.ip,
+      lastUsedAt: new Date(),
+    });
+    await refreshTokenDoc.save();
+
+    const query = new URLSearchParams({
+      status: 'logged_in',
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      userId: user.userId,
+      email: user.email,
+      role: user.role,
+      emailVerified: String(user.emailVerified),
+      accountStatus: user.accountStatus,
+      requiresPasswordChange: String(user.requiresPasswordChange || false),
+      ...(groupId ? { groupId } : {}),
+    });
+
+    return res.redirect(`${callbackBase}?${query.toString()}`);
+  } catch (err) {
+    console.error('[mockGithubLogin] error:', err);
+    return redirectError('SERVER_ERROR');
+  }
+};
+
+/**
  * Change password and revoke all refresh tokens for the user
  */
 const changePassword = async (req, res) => {
@@ -1273,6 +1353,7 @@ module.exports = {
   initiateGithubOAuth,
   initiateGithubLoginOAuth,
   githubOAuthCallback,
+  mockGithubLogin,
   requestPasswordReset,
   validatePasswordResetToken,
   confirmPasswordReset,

--- a/backend/src/controllers/deliverableController.js
+++ b/backend/src/controllers/deliverableController.js
@@ -500,9 +500,8 @@ const listDeliverablesHandler = async (req, res) => {
   if (!groupId) {
     if (role === 'student') {
       groupId = userGroupId;
-    } else {
-      return res.status(400).json({ code: 'INVALID_REQUEST', message: 'groupId query param is required' });
     }
+    // professors, coordinators, and admins may omit groupId to list all deliverables
   }
 
   // Students can only query groups they belong to
@@ -519,7 +518,8 @@ const listDeliverablesHandler = async (req, res) => {
   const skip = (page - 1) * limit;
 
   // Build filter
-  const filter = { groupId };
+  const filter = {};
+  if (groupId) filter.groupId = groupId;
   if (sprintId) filter.sprintId = sprintId;
   if (status) filter.status = status;
 
@@ -527,7 +527,7 @@ const listDeliverablesHandler = async (req, res) => {
   try {
     [deliverables, total] = await Promise.all([
       Deliverable.find(filter)
-        .select('deliverableId deliverableType sprintId status submittedAt version')
+        .select('deliverableId deliverableType groupId sprintId status submittedAt version')
         .sort({ submittedAt: -1 })
         .skip(skip)
         .limit(limit)
@@ -540,13 +540,14 @@ const listDeliverablesHandler = async (req, res) => {
   }
 
   return res.status(200).json({
-    groupId,
+    ...(groupId && { groupId }),
     total,
     page,
     limit,
     deliverables: deliverables.map((d) => ({
       deliverableId: d.deliverableId,
       deliverableType: d.deliverableType,
+      groupId: d.groupId,
       sprintId: d.sprintId ?? null,
       status: d.status,
       submittedAt: d.submittedAt,
@@ -939,6 +940,7 @@ const downloadDeliverableHandler = async (req, res) => {
     docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     doc: 'application/msword',
     md: 'text/markdown',
+    txt: 'text/plain',
     zip: 'application/zip',
   };
   res.setHeader('Content-Type', mimeMap[deliverable.format] || 'application/octet-stream');

--- a/backend/src/controllers/groupIntegrations.js
+++ b/backend/src/controllers/groupIntegrations.js
@@ -616,4 +616,43 @@ const getJira = async (req, res) => {
   }
 };
 
-module.exports = { configureGithub, getGithub, configureJira, getJira };
+/**
+ * DEV-ONLY: Mock Jira configuration — bypasses real Jira API validation.
+ * POST /groups/:groupId/jira/mock
+ * Writes fake Jira credentials directly to the group document.
+ * Returns 404 in production.
+ */
+const mockConfigureJira = async (req, res) => {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).json({ message: 'Not found' });
+  }
+
+  try {
+    const { groupId } = req.params;
+    const group = await getGroupOrThrow(groupId);
+
+    await overwriteJiraCredentials({
+      group,
+      baseUrl: 'https://mock.atlassian.net',
+      email: 'jira@mock.dev',
+      apiToken: 'mock-jira-api-token-dev-only',
+      projectKey: 'MOCK',
+      projectData: { id: '10001', name: 'Mock Project' },
+      actorId: req.user?.userId || 'system',
+      req,
+    });
+
+    return res.status(201).json({
+      project_id: group.jiraProjectId,
+      project_key: group.projectKey,
+      binding: 'confirmed',
+      board_url: group.jiraBoardUrl,
+    });
+  } catch (err) {
+    if (tryHandleKnownError(err, res)) return;
+    console.error('[mockConfigureJira] error:', err);
+    return res.status(500).json({ code: 'INTERNAL_ERROR', message: 'An unexpected error occurred' });
+  }
+};
+
+module.exports = { configureGithub, getGithub, configureJira, getJira, mockConfigureJira };

--- a/backend/src/controllers/jiraSync.js
+++ b/backend/src/controllers/jiraSync.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const JiraSyncJob = require('../models/JiraSyncJob');
+const SprintIssue = require('../models/SprintIssue');
 const SprintRecord = require('../models/SprintRecord');
 const { jiraSyncWorker, JiraSyncError, getJiraConfig, getPublishedSprintConfig } = require('../services/jiraSyncService');
 const { createAuditLog } = require('../services/auditService');
@@ -219,4 +220,71 @@ const getJiraSyncLogs = async (req, res) => {
   }
 };
 
-module.exports = { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs };
+/**
+ * DEV-ONLY: Mock Jira sync — creates fake SprintIssue records and a completed
+ * JiraSyncJob without calling the real Jira API.
+ * POST /groups/:groupId/sprints/:sprintId/jira-sync/mock
+ * Returns 404 in production.
+ */
+const mockJiraSync = async (req, res) => {
+  if (process.env.NODE_ENV === 'production') {
+    return res.status(404).json({ message: 'Not found' });
+  }
+
+  const { groupId, sprintId } = req.params;
+  const actorId = req.user?.userId || 'system';
+
+  try {
+    const MOCK_ISSUES = [
+      { key: 'MOCK-101', summary: 'Implement authentication module',  points: 5, status: 'Done',        assignee: 'Alice Student'   },
+      { key: 'MOCK-102', summary: 'Setup MongoDB schemas',             points: 3, status: 'Done',        assignee: 'Bob Student'     },
+      { key: 'MOCK-103', summary: 'Build REST API endpoints',          points: 8, status: 'In Progress', assignee: 'Alice Student'   },
+      { key: 'MOCK-104', summary: 'Write unit and integration tests',  points: 5, status: 'In Progress', assignee: 'Charlie Student' },
+      { key: 'MOCK-105', summary: 'Deploy to staging environment',     points: 3, status: 'To Do',       assignee: 'Bob Student'     },
+    ];
+
+    // Upsert each mock issue
+    for (const issue of MOCK_ISSUES) {
+      await SprintIssue.findOneAndUpdate(
+        { groupId, sprintId, issueKey: issue.key },
+        {
+          groupId,
+          sprintId,
+          issueKey:            issue.key,
+          storyPoints:         issue.points,
+          status:              issue.status,
+          assigneeDisplayName: issue.assignee,
+          rawIssue:            { key: issue.key, fields: { summary: issue.summary } },
+          syncedAt:            new Date(),
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      );
+    }
+
+    // Create a completed JiraSyncJob record
+    const now = new Date();
+    const job = await JiraSyncJob.create({
+      groupId,
+      sprintId,
+      source:          'jira',
+      status:          'COMPLETED',
+      issuesProcessed: MOCK_ISSUES.length,
+      issuesUpserted:  MOCK_ISSUES.length,
+      startedAt:       now,
+      completedAt:     now,
+      triggeredBy:     actorId,
+      correlationId:   `mock_${Date.now()}`,
+    });
+
+    return res.status(200).json({
+      ...mapJobResponse(job),
+      mock: true,
+      issuesCreated: MOCK_ISSUES.length,
+    });
+  } catch (err) {
+    console.error('[mockJiraSync] error:', err);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: err.message });
+  }
+};
+
+module.exports = { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs, mockJiraSync };

--- a/backend/src/middleware/upload.js
+++ b/backend/src/middleware/upload.js
@@ -10,6 +10,7 @@ const MAX_FILE_SIZE = 1 * 1024 * 1024 * 1024; // 1 GB
 const ACCEPTED_MIMETYPES = new Set([
   'application/pdf',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'text/plain',
   'text/markdown',
   'application/zip',
 ]);

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -25,6 +25,7 @@ const {
   initiateGithubOAuth,
   initiateGithubLoginOAuth,
   githubOAuthCallback,
+  mockGithubLogin,
   requestPasswordReset,
   validatePasswordResetToken,
   confirmPasswordReset,
@@ -41,6 +42,10 @@ router.post('/register', registerStudent);
 router.post('/refresh', refreshAccessToken);
 router.get('/github/oauth/callback', githubOAuthCallback);
 router.post('/github/oauth/login', initiateGithubLoginOAuth);
+// Dev-only: mock GitHub login — skips real GitHub OAuth, uses pre-seeded githubId
+if (process.env.NODE_ENV !== 'production') {
+  router.get('/github/oauth/mock-login', mockGithubLogin);
+}
 router.post('/password-reset/request', requestPasswordReset);
 router.post('/password-reset/validate-token', validatePasswordResetToken);
 router.post('/password-reset/confirm', confirmPasswordReset);

--- a/backend/src/routes/groups.js
+++ b/backend/src/routes/groups.js
@@ -30,10 +30,10 @@ const {
   getApprovals 
 } = require('../controllers/groupMembers');
 
-const { configureGithub, getGithub, configureJira, getJira } = require('../controllers/groupIntegrations');
+const { configureGithub, getGithub, configureJira, getJira, mockConfigureJira } = require('../controllers/groupIntegrations');
 const { transitionStatus, getStatus } = require('../controllers/groupStatusTransition');
 const { triggerGitHubSync, getSyncJobStatus, getLatestSyncJob, getSyncJobLogs } = require('../controllers/githubSync');
-const { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs } = require('../controllers/jiraSync');
+const { triggerJiraSync, getJiraSyncStatus, getJiraSyncLogs, mockJiraSync } = require('../controllers/jiraSync');
 const {
   reconcileD4toD6,
 } = require('../controllers/sprintTracking');
@@ -137,6 +137,11 @@ router.post(
   checkJiraSyncRateLimit,
   triggerJiraSync
 );
+// Dev-only: mock Jira endpoints — bypass real API calls
+if (process.env.NODE_ENV !== 'production') {
+  router.post('/:groupId/jira/mock', authMiddleware, mockConfigureJira);
+  router.post('/:groupId/sprints/:sprintId/jira-sync/mock', authMiddleware, mockJiraSync);
+}
 
 // POST /api/v1/groups/:groupId/sprints — Coordinator bootstrap empty sprint
 // (used when no Jira/GitHub sync exists yet, so the sprint dropdown stays

--- a/backend/src/utils/fileValidator.js
+++ b/backend/src/utils/fileValidator.js
@@ -69,6 +69,18 @@ const startsWith = (buf, signature) =>
 const validateFormat = (filePath, mimeType, _deliverableType) => {
   const ext = (filePath.split('.').pop() || '').toLowerCase();
 
+  // ── Plain text ────────────────────────────────────────────────────────────
+  // No reliable magic bytes; accept by extension + text/plain MIME.
+  if (ext === 'txt') {
+    if (mimeType !== 'text/plain') {
+      return {
+        valid: false,
+        error: `Text file must have MIME type text/plain, got '${mimeType}'`,
+      };
+    }
+    return { valid: true, format: 'txt' };
+  }
+
   // ── Markdown ──────────────────────────────────────────────────────────────
   // No reliable magic bytes; accept by extension + text/plain MIME.
   if (ext === 'md') {
@@ -122,7 +134,7 @@ const validateFormat = (filePath, mimeType, _deliverableType) => {
   // ── Unknown extension ─────────────────────────────────────────────────────
   return {
     valid: false,
-    error: `Unsupported file extension '.${ext}'. Accepted: .pdf, .docx, .md, .zip`,
+    error: `Unsupported file extension '.${ext}'. Accepted: .pdf, .docx, .md, .txt, .zip`,
   };
 };
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -37,6 +37,7 @@ import FinalGradeReviewPanel from './pages/FinalGradeReviewPanel.jsx';
 import CoordinatorFinalGradeApprovalPanel from './pages/CoordinatorFinalGradeApprovalPanel.jsx';
 import CoordinatorFinalGradePublishPanel from './pages/CoordinatorFinalGradePublishPanel.jsx';
 import ProfessorGradeReviewEntry from './pages/ProfessorGradeReviewEntry.jsx';
+import ProfessorDeliverablesPage from './pages/ProfessorDeliverablesPage.jsx';
 import CoordinatorAdvisorInbox from './pages/CoordinatorAdvisorInbox.jsx';
 import ProfilePage from './pages/ProfilePage.jsx';
 import RootRoute from './components/RootRoute';
@@ -91,6 +92,10 @@ function App() {
             <Route
               path="/professor/grade-review"
               element={<ProtectedRoute component={ProfessorGradeReviewEntry} requiredRoles={['professor', 'advisor']} />}
+            />
+            <Route
+              path="/professor/deliverables"
+              element={<ProtectedRoute component={ProfessorDeliverablesPage} requiredRoles={['professor', 'coordinator', 'admin']} />}
             />
             <Route
               path="/coordinator/advisor-requests"

--- a/frontend/src/api/reviewAPI.js
+++ b/frontend/src/api/reviewAPI.js
@@ -143,6 +143,30 @@ export const getCommitteeCandidates = async () => {
 };
 
 /**
+ * GET /api/v1/deliverables
+ * List all deliverables (professors, coordinators, admins only — no groupId required)
+ * @param {Object} options
+ * @param {string} [options.status]
+ * @param {string} [options.deliverableType]
+ * @param {number} [options.page]
+ * @param {number} [options.limit]
+ * @returns {Promise<{deliverables: Array, total: number, page: number, limit: number, totalPages: number}>}
+ */
+export const listAllDeliverables = async (options = {}) => {
+  const params = new URLSearchParams({
+    page: options.page || 1,
+    limit: options.limit || 50,
+    ...(options.status && { status: options.status }),
+  });
+  const response = await apiClient.get(`/deliverables?${params.toString()}`);
+  const data = response.data;
+  return {
+    ...data,
+    totalPages: Math.ceil((data.total || 0) / (data.limit || 50)),
+  };
+};
+
+/**
  * GET /api/v1/deliverables/:deliverableId/download
  * Download the stored file for a deliverable
  * @param {string} deliverableId

--- a/frontend/src/components/AuthMethodSelection.js
+++ b/frontend/src/components/AuthMethodSelection.js
@@ -3,6 +3,19 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { initiateGithubLogin } from '../api/authService';
 import './AuthMethodSelection.css';
 
+const IS_DEV = process.env.NODE_ENV === 'development';
+const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:5002/api/v1';
+
+const MOCK_GITHUB_USERS = [
+  { label: 'Alice (Student)',   githubId: '10000001', role: 'student'     },
+  { label: 'Bob (Student)',     githubId: '10000002', role: 'student'     },
+  { label: 'Charlie (Student)', githubId: '10000003', role: 'student'     },
+  { label: 'Prof. Advisor',     githubId: '10000004', role: 'professor'   },
+  { label: 'Prof. Transfer',    githubId: '10000005', role: 'professor'   },
+  { label: 'Coordinator',       githubId: '10000006', role: 'coordinator' },
+  { label: 'Admin',             githubId: '10000007', role: 'admin'       },
+];
+
 /**
  * Auth Method Selection Screen
  * Allows user to choose between local login/registration and GitHub OAuth
@@ -21,6 +34,10 @@ const AuthMethodSelection = () => {
     } else {
       navigate('/auth/login');
     }
+  };
+
+  const handleMockGithubLogin = (githubId) => {
+    window.location.href = `${API_BASE}/auth/github/oauth/mock-login?githubId=${githubId}`;
   };
 
   const handleGithubOAuth = async () => {
@@ -85,6 +102,44 @@ const AuthMethodSelection = () => {
               </button>
             </div>
           </div>
+
+          {IS_DEV && !isRegistration && (
+            <div style={{
+              marginTop: '32px',
+              padding: '20px 24px',
+              background: '#fffbeb',
+              border: '1px dashed #f59e0b',
+              borderRadius: '8px',
+              textAlign: 'left',
+            }}>
+              <p style={{ margin: '0 0 12px 0', fontWeight: '700', fontSize: '13px', color: '#92400e', letterSpacing: '0.05em', textTransform: 'uppercase' }}>
+                ⚡ Dev — Mock GitHub Login
+              </p>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+                {MOCK_GITHUB_USERS.map((u) => (
+                  <button
+                    key={u.githubId}
+                    onClick={() => handleMockGithubLogin(u.githubId)}
+                    style={{
+                      padding: '6px 14px',
+                      background: '#1f2937',
+                      color: '#fff',
+                      border: 'none',
+                      borderRadius: '5px',
+                      fontSize: '13px',
+                      fontWeight: '500',
+                      cursor: 'pointer',
+                    }}
+                  >
+                    {u.label}
+                  </button>
+                ))}
+              </div>
+              <p style={{ margin: '10px 0 0 0', fontSize: '11px', color: '#b45309' }}>
+                Requires seed data — run <code>node scripts/seed-test-general.js</code> first
+              </p>
+            </div>
+          )}
 
           <div className="auth-footer">
             <p>

--- a/frontend/src/components/JiraSetupForm.js
+++ b/frontend/src/components/JiraSetupForm.js
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 import { configureJira } from '../api/groupService';
+import apiClient from '../api/apiClient';
 import './JiraSetupForm.css';
+
+const IS_DEV = process.env.NODE_ENV === 'development';
 
 /**
  * JIRA Integration Setup Form Component
@@ -22,6 +25,26 @@ const JiraSetupForm = ({ groupId, onSuccess, onError, isLeader }) => {
   const [errorMsg, setErrorMsg] = useState('');
   const [showForm, setShowForm] = useState(false);
   const [tokenVisible, setTokenVisible] = useState(false);
+
+  const handleMockConfigure = async () => {
+    setLoading(true);
+    setErrorMsg('');
+    setSuccessMsg('');
+    try {
+      const response = await apiClient.post(`/groups/${groupId}/jira/mock`);
+      const data = response.data;
+      setSuccessMsg(
+        `[DEV] Mock JIRA configured. Project: ${data.project_key} (ID: ${data.project_id})`
+      );
+      if (onSuccess) onSuccess(data);
+      setTimeout(() => setSuccessMsg(''), 5000);
+    } catch (err) {
+      setErrorMsg(err.response?.data?.message || '[DEV] Mock configure failed');
+      if (onError) onError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -115,6 +138,44 @@ const JiraSetupForm = ({ groupId, onSuccess, onError, isLeader }) => {
       {errorMsg && (
         <div className="alert alert-error">
           {errorMsg}
+        </div>
+      )}
+
+      {IS_DEV && (
+        <div style={{
+          marginBottom: '12px',
+          padding: '10px 14px',
+          background: '#fffbeb',
+          border: '1px dashed #f59e0b',
+          borderRadius: '6px',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+        }}>
+          <span style={{ fontSize: '12px', fontWeight: '700', color: '#92400e', textTransform: 'uppercase' }}>
+            ⚡ Dev
+          </span>
+          <button
+            type="button"
+            onClick={handleMockConfigure}
+            disabled={loading}
+            style={{
+              padding: '5px 12px',
+              background: '#1f2937',
+              color: '#fff',
+              border: 'none',
+              borderRadius: '4px',
+              fontSize: '12px',
+              fontWeight: '500',
+              cursor: loading ? 'not-allowed' : 'pointer',
+              opacity: loading ? 0.6 : 1,
+            }}
+          >
+            Mock Configure Jira
+          </button>
+          <span style={{ fontSize: '11px', color: '#b45309' }}>
+            Skips real Jira API — uses mock credentials
+          </span>
         </div>
       )}
 

--- a/frontend/src/components/layout/Sidebar.jsx
+++ b/frontend/src/components/layout/Sidebar.jsx
@@ -80,6 +80,16 @@ const Sidebar = ({ isCollapsed, onToggle }) => {
           ), requiredRoles: ['professor']
         },
         {
+          label: 'Deliverables',
+          path: '/professor/deliverables',
+          icon: (
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414A1 1 0 0119 9.414V19a2 2 0 01-2 2z" />
+            </svg>
+          ),
+          requiredRoles: ['professor', 'coordinator', 'admin'],
+        },
+        {
           label: 'Grade Review',
           path: reviewGroupId
             ? `/groups/${reviewGroupId}/final-grades/review`

--- a/frontend/src/pages/ProfessorDeliverablesPage.jsx
+++ b/frontend/src/pages/ProfessorDeliverablesPage.jsx
@@ -1,0 +1,266 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { listAllDeliverables } from '../api/reviewAPI';
+
+const DELIVERABLE_TYPE_LABELS = {
+  proposal: 'Proposal',
+  statement_of_work: 'Statement of Work',
+  demo: 'Demo',
+  interim_report: 'Interim Report',
+  final_report: 'Final Report',
+};
+
+const STATUS_COLORS = {
+  submitted: 'bg-blue-100 text-blue-800',
+  under_review: 'bg-yellow-100 text-yellow-800',
+  accepted: 'bg-green-100 text-green-800',
+  awaiting_resubmission: 'bg-orange-100 text-orange-800',
+  retracted: 'bg-gray-100 text-gray-600',
+};
+
+const ALL_STATUSES = ['submitted', 'under_review', 'accepted', 'awaiting_resubmission', 'retracted'];
+
+const ProfessorDeliverablesPage = () => {
+  const navigate = useNavigate();
+
+  const [deliverables, setDeliverables] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  const LIMIT = 20;
+
+  const fetchDeliverables = useCallback(async (currentPage, currentStatus) => {
+    try {
+      setLoading(true);
+      setError('');
+      const data = await listAllDeliverables({
+        page: currentPage,
+        limit: LIMIT,
+        ...(currentStatus && { status: currentStatus }),
+      });
+      setDeliverables(data.deliverables || []);
+      setTotal(data.total || 0);
+      setTotalPages(Math.max(1, Math.ceil((data.total || 0) / LIMIT)));
+    } catch (err) {
+      setError(err?.response?.data?.message || 'Failed to load deliverables');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDeliverables(page, statusFilter);
+  }, [page, statusFilter, fetchDeliverables]);
+
+  const handleStatusChange = (e) => {
+    setStatusFilter(e.target.value);
+    setPage(1);
+  };
+
+  const formatDate = (date) =>
+    new Date(date).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+  return (
+    <div className="page p-8">
+      <div style={{ maxWidth: '1100px', margin: '0 auto' }}>
+        {/* Header */}
+        <div style={{ marginBottom: '24px' }}>
+          <h1 style={{ fontSize: '28px', fontWeight: '700', color: '#111827', marginBottom: '6px' }}>
+            Submitted Deliverables
+          </h1>
+          <p style={{ color: '#6b7280', fontSize: '14px' }}>
+            View and review all deliverables submitted by student groups.
+          </p>
+        </div>
+
+        {/* Filters */}
+        <div style={{ display: 'flex', gap: '12px', marginBottom: '20px', alignItems: 'center' }}>
+          <select
+            value={statusFilter}
+            onChange={handleStatusChange}
+            style={{
+              padding: '8px 12px',
+              border: '1px solid #d1d5db',
+              borderRadius: '6px',
+              fontSize: '14px',
+              color: '#374151',
+              background: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            <option value="">All statuses</option>
+            {ALL_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {s.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+              </option>
+            ))}
+          </select>
+
+          {total > 0 && (
+            <span style={{ fontSize: '13px', color: '#9ca3af' }}>
+              {total} deliverable{total !== 1 ? 's' : ''}
+            </span>
+          )}
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div style={{ background: '#fef2f2', border: '1px solid #fecaca', borderRadius: '8px', padding: '16px', marginBottom: '20px' }}>
+            <p style={{ color: '#991b1b', fontSize: '14px' }}>{error}</p>
+          </div>
+        )}
+
+        {/* Table */}
+        <div style={{ background: '#fff', border: '1px solid #e5e7eb', borderRadius: '10px', overflow: 'hidden' }}>
+          {loading ? (
+            <div style={{ padding: '48px', textAlign: 'center' }}>
+              <div style={{ display: 'inline-block', width: '40px', height: '40px', border: '3px solid #e5e7eb', borderTopColor: '#4f46e5', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }} />
+              <p style={{ marginTop: '12px', color: '#6b7280', fontSize: '14px' }}>Loading deliverables...</p>
+            </div>
+          ) : deliverables.length === 0 ? (
+            <div style={{ padding: '48px', textAlign: 'center' }}>
+              <p style={{ color: '#9ca3af', fontSize: '14px' }}>No deliverables found.</p>
+            </div>
+          ) : (
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ background: '#f9fafb', borderBottom: '1px solid #e5e7eb' }}>
+                  {['Type', 'Group', 'Sprint', 'Version', 'Status', 'Submitted At', ''].map((h) => (
+                    <th
+                      key={h}
+                      style={{
+                        padding: '12px 16px',
+                        textAlign: 'left',
+                        fontSize: '11px',
+                        fontWeight: '600',
+                        color: '#6b7280',
+                        textTransform: 'uppercase',
+                        letterSpacing: '0.05em',
+                      }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {deliverables.map((d, idx) => (
+                  <tr
+                    key={d.deliverableId}
+                    style={{
+                      borderBottom: idx < deliverables.length - 1 ? '1px solid #f3f4f6' : 'none',
+                      transition: 'background 0.15s',
+                    }}
+                    onMouseEnter={(e) => (e.currentTarget.style.background = '#f9fafb')}
+                    onMouseLeave={(e) => (e.currentTarget.style.background = '')}
+                  >
+                    <td style={{ padding: '14px 16px', fontSize: '14px', color: '#111827', fontWeight: '500' }}>
+                      {DELIVERABLE_TYPE_LABELS[d.deliverableType] || d.deliverableType}
+                    </td>
+                    <td style={{ padding: '14px 16px', fontSize: '13px', color: '#6b7280', fontFamily: 'monospace' }}>
+                      {d.groupId || '—'}
+                    </td>
+                    <td style={{ padding: '14px 16px', fontSize: '13px', color: '#6b7280' }}>
+                      {d.sprintId || '—'}
+                    </td>
+                    <td style={{ padding: '14px 16px', fontSize: '13px', color: '#6b7280' }}>
+                      v{d.version ?? 1}
+                    </td>
+                    <td style={{ padding: '14px 16px' }}>
+                      <span
+                        style={{ display: 'inline-block', padding: '3px 10px', borderRadius: '9999px', fontSize: '12px', fontWeight: '500' }}
+                        className={STATUS_COLORS[d.status] || 'bg-gray-100 text-gray-600'}
+                      >
+                        {d.status.replace(/_/g, ' ')}
+                      </span>
+                    </td>
+                    <td style={{ padding: '14px 16px', fontSize: '13px', color: '#9ca3af', whiteSpace: 'nowrap' }}>
+                      {formatDate(d.submittedAt)}
+                    </td>
+                    <td style={{ padding: '14px 16px', textAlign: 'right' }}>
+                      <button
+                        onClick={() => navigate(`/dashboard/reviews/${d.deliverableId}`)}
+                        style={{
+                          padding: '6px 14px',
+                          background: '#4f46e5',
+                          color: '#fff',
+                          border: 'none',
+                          borderRadius: '6px',
+                          fontSize: '13px',
+                          fontWeight: '500',
+                          cursor: 'pointer',
+                          transition: 'background 0.15s',
+                        }}
+                        onMouseEnter={(e) => (e.currentTarget.style.background = '#4338ca')}
+                        onMouseLeave={(e) => (e.currentTarget.style.background = '#4f46e5')}
+                      >
+                        View
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '8px', marginTop: '20px' }}>
+            <button
+              onClick={() => setPage((p) => p - 1)}
+              disabled={page === 1 || loading}
+              style={{
+                padding: '7px 14px',
+                border: '1px solid #d1d5db',
+                borderRadius: '6px',
+                fontSize: '13px',
+                color: '#374151',
+                background: '#fff',
+                cursor: page === 1 ? 'not-allowed' : 'pointer',
+                opacity: page === 1 ? 0.5 : 1,
+              }}
+            >
+              ← Previous
+            </button>
+            <span style={{ fontSize: '13px', color: '#6b7280' }}>
+              Page {page} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              disabled={page === totalPages || loading}
+              style={{
+                padding: '7px 14px',
+                border: '1px solid #d1d5db',
+                borderRadius: '6px',
+                fontSize: '13px',
+                color: '#374151',
+                background: '#fff',
+                cursor: page === totalPages ? 'not-allowed' : 'pointer',
+                opacity: page === totalPages ? 0.5 : 1,
+              }}
+            >
+              Next →
+            </button>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @keyframes spin { to { transform: rotate(360deg); } }
+      `}</style>
+    </div>
+  );
+};
+
+export default ProfessorDeliverablesPage;


### PR DESCRIPTION
- Implemented mock GitHub login endpoint for testing user authentication without real API calls.
- Added mock Jira configuration endpoint to allow developers to set up fake Jira credentials.
- Introduced mock Jira sync functionality to create fake SprintIssue records and a completed JiraSyncJob.
- Enhanced user seeding script to include GitHub IDs and usernames for test users.
- Updated deliverable listing to allow professors, coordinators, and admins to view all deliverables without groupId.
- Created a new ProfessorDeliverablesPage for professors to review submitted deliverables.
- Added support for text/plain file uploads and validation.
- Improved error handling and loading states in various components.